### PR TITLE
Configure: Add commit template for git commit cmd

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,43 @@
+# [Title Module]
+# Write a title summarizing what this commit does.
+# Please don't end title with a sentence period.
+# Write your title by the following name formats:
+# 	Fix ... is for bug, typo, issue fix
+# 	Feature: ... is used for Feature request
+# 	Enhancement: ... is for code optimization
+#	Doc: ... is for the documentation changes
+# For more, start with imperative uppercase verbs.
+# Use 50 char maximum, which is this line's width.
+#################################################
+Add your title here
+
+# Remember blank line between title and body.
+
+########################################################################
+# [Body Module]
+# Explain *what*, *why* and *how*. 
+# If your commit has noted compatibility issues, describe them also.
+# For every line, use 72 char maximum width, which is this line's width.
+########################################################################
+Add your commit body here
+
+
+########################################################################
+# [Trailers Module]
+# This part is optional, enable them as you need. One trailer per line.
+# If the bug is reported by someone else, welcome to add reporter info:
+# Reported-by: NAME
+# You can attribute a commit to more than one author by adding:
+#Co-authored-by: NAME <NAME@EXAMPLE.COM>
+# If you create this commit on behalf an organization, then use:
+#on-behalf-of: @ORG NAME@ORGANIZATION.COM
+# If your commit have clear context included in GitHub Issues or GitHub
+# Discussions, please list them as a reference:
+#See: Issue#id <https://github.com/cloudberrydb/cloudberrydb/issues/?>?
+#See: Discussion#id <http://github.com/orgs/cloudberrydb/discussions/>?
+########################################################################
+#
+#
+# Note: Usage - use this config for your own git
+# Run the configure cmd in the terminal
+# `git config --global commit.template .gitmessage`


### PR DESCRIPTION
<!--
Thank you for contributing! 
***If you're the first time contributor, please sign the Contributor License Agreement(CLA).***
-->

### Change logs

The new file .gitmessage is for `git commit` cmd template. When you run `git commit` cmd under Cloudberry Database dir, it guides you how to write the commit message title, body and its trailer.

### Why are the changes needed?

Unify the git commit message log.

### Does this PR introduce any user-facing change?

It is not for users, but for developers. Developers can run cmd `git config --global commit.template .gitmessage` to use the lastest template.

### How was this patch tested?

Don't need test, the change is not related to Cloudberry Database core.

### Contributor's Checklist
Here are some reminders before you submit the pull request:
* Document changes
* Communicate in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (list them if needed)
* Add tests for the change
* Pass `make installcheck`
* Pass `make -C src/test installcheck-cbdb-parallel`

<!--Who can review & approve your PR?
Feel free to @dev team for the approve! -->
