### PR TITLE
ci: Re-enable tests with increased shared memory

### DIFF
--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -643,6 +643,7 @@ jobs:
       options: >-
         --user root
         -h cdw
+        --shm-size=2gb
 
     steps:
 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -258,7 +258,7 @@ test: ao_locks
 test: freeze_aux_tables
 
 # cbdb parallel test
-ignore: cbdb_parallel
+test: cbdb_parallel
 
 # These cannot run in parallel, because they check that VACUUM FULL shrinks table size.
 # A concurrent session could hold back the xid horizon and prevent old tuples from being
@@ -269,7 +269,7 @@ test: vacuum_full_heap
 test: vacuum_full_heap_bitmapindex
 test: vacuum_ao_aux_only
 # Check for shmem leak for instrumentation slots
-ignore: instr_in_shmem_verify
+test: instr_in_shmem_verify
 # check autostats
 test: autostats
 test: enable_autovacuum


### PR DESCRIPTION
The cbdb_parallel and instr_in_shmem_verify test suites were previously disabled due to insufficient shared memory in the GitHub Actions CI environment. By adding --shm-size=2gb to the container configuration, these tests now pass consistently.

Changes:
- Add --shm-size=2gb to GitHub Actions container configuration
- Re-enable cbdb_parallel test suite
- Re-enable instr_in_shmem_verify test suite
