### PR TITLE
ci: add PR edit trigger and improve CI skip instructions [skip ci]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,7 +41,14 @@ Fixes #ISSUE_Number
 ### Additional Context
 <!-- Any other information that would help reviewers? Remove if none -->
 
-⚠️ **To skip CI:** Add `[skip ci]` to your PR title. Only use when necessary! ⚠️
+### CI Skip Instructions
+<!--
+To skip CI builds, add the appropriate CI skip identifier to your PR title.
+The identifier must:
+- Be in square brackets []
+- Include the word "ci" and either "skip" or "no"
+- Only use for documentation-only changes or when absolutely necessary
+-->
 
 ---
 <!-- Join our community:

--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -99,6 +99,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- Update CI skip instructions to describe format without including patterns
- Add explicit warning about CI skip usage
- Add 'edited' type to PR workflow triggers to detect when skip identifiers are added or removed from PR title/body
