### PR TITLE
Fix confused print of gp_connections test case.

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2409,8 +2409,7 @@ run_schedule(const char *schedule, test_start_function startfunc,
 				status(_("ok    "));	/* align with FAILED */
 				success_count++;
 			}
-
-			if (statuses[i] != 0)
+			if (statuses[i] != 0 && (strcmp(test, "gp_connections") != 0))
 				log_child_failure(statuses[i]);
 
 			INSTR_TIME_SUBTRACT(stoptimes[i], starttimes[i]);
@@ -2502,7 +2501,7 @@ run_single_test(const char *test, test_start_function startfunc,
 		success_count++;
 	}
 
-	if (exit_status != 0)
+	if (exit_status != 0 && (strcmp(test, "gp_connections") != 0))
 		log_child_failure(exit_status);
 
 	INSTR_TIME_SUBTRACT(stoptime, starttime);


### PR DESCRIPTION
I, along with other developers I’ve heard from, occasionally find ourselves puzzled: the test `gp_connections` clearly succeeded, but the printed results seem somewhat incorrect 

When regression succeeds to run gp_connections case, some printed info are confused:
```shell
============== running regression test queries  ============== test 
gp_connections ... ok (test process exited with exit code 2)
```
While the test passed, but the message seems to tell us that the process exit unexpectedly.

I dig into this and found: the case is designed to exit with code 2 which is expected: failed to connect a primary db.

However the message may make developers confused and try to find something wrong but actually not.
And after a failed connect, the script will exit, there is no chance to do something to make amends.

Hacked in pg_regress to ignore gp_connections exit code info.
```shell
============== running regression test queries  ==============
test gp_connections               ... ok         2500 ms
```
**This fix doesn't have an impact on test case behavior: if there is diffs between sql and expected files, the case failed as expected.**

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
