### PR TITLE
Allow using table access method when creating partition table

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -836,11 +836,20 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	{
 		accessMethod = stmt->accessMethod;
 
+	/*
+	 * CBDB: Allow specifying table access method to be compatible with
+	 * gp-style partition table.
+	 * Please KEEP the macro switch to reduce upgrade conflict.
+	 * NOTE: The upstream also supports table access method for partition
+	 *       tables in higher(17) version
+	 */
+#if 0
 		/* Only to allow access method when the partition is gp style partition */
-		if (partitioned && Gp_role != GP_ROLE_EXECUTE && !stmt->partspec->gpPartDef)
+		if (partitioned && Gp_role != GP_ROLE_EXECUTE)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("specifying a table access method is not supported on a partitioned table")));
+#endif
 
 	}
 	else if (relkind == RELKIND_DIRECTORY_TABLE)

--- a/src/test/regress/expected/create_am.out
+++ b/src/test/regress/expected/create_am.out
@@ -188,8 +188,8 @@ SELECT f1 FROM tableam_tblmv_heap2 ORDER BY f1;
 (1 row)
 
 -- CREATE TABLE ..  PARTITION BY doesn't not support USING
-CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
-ERROR:  specifying a table access method is not supported on a partitioned table
+-- CBDB ignore: allow table access method
+-- CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
 CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a);
 -- new partitions will inherit from the current default, rather the partition root
 SET default_table_access_method = 'heap';

--- a/src/test/regress/expected/create_am_optimizer.out
+++ b/src/test/regress/expected/create_am_optimizer.out
@@ -189,8 +189,8 @@ SELECT f1 FROM tableam_tblmv_heap2 ORDER BY f1;
 (1 row)
 
 -- CREATE TABLE ..  PARTITION BY doesn't not support USING
-CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
-ERROR:  specifying a table access method is not supported on a partitioned table
+-- CBDB ignore: allow table access method
+-- CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
 CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a);
 -- new partitions will inherit from the current default, rather the partition root
 SET default_table_access_method = 'heap';

--- a/src/test/regress/sql/create_am.sql
+++ b/src/test/regress/sql/create_am.sql
@@ -125,7 +125,8 @@ CREATE MATERIALIZED VIEW tableam_tblmv_heap2 USING heap2 AS SELECT * FROM tablea
 SELECT f1 FROM tableam_tblmv_heap2 ORDER BY f1;
 
 -- CREATE TABLE ..  PARTITION BY doesn't not support USING
-CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
+-- CBDB ignore: allow table access method
+-- CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
 
 CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a);
 -- new partitions will inherit from the current default, rather the partition root

--- a/src/test/singlenode_regress/expected/create_am.out
+++ b/src/test/singlenode_regress/expected/create_am.out
@@ -179,8 +179,8 @@ SELECT f1 FROM tableam_tblmv_heap2 ORDER BY f1;
 (1 row)
 
 -- CREATE TABLE ..  PARTITION BY doesn't not support USING
-CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
-ERROR:  specifying a table access method is not supported on a partitioned table
+-- CBDB ignore: allow table access method
+-- CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
 CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a);
 -- new partitions will inherit from the current default, rather the partition root
 SET default_table_access_method = 'heap';

--- a/src/test/singlenode_regress/sql/create_am.sql
+++ b/src/test/singlenode_regress/sql/create_am.sql
@@ -125,7 +125,8 @@ CREATE MATERIALIZED VIEW tableam_tblmv_heap2 USING heap2 AS SELECT * FROM tablea
 SELECT f1 FROM tableam_tblmv_heap2 ORDER BY f1;
 
 -- CREATE TABLE ..  PARTITION BY doesn't not support USING
-CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
+-- CBDB ignore: allow table access method
+-- CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a) USING heap2;
 
 CREATE TABLE tableam_parted_heap2 (a text, b int) PARTITION BY list (a);
 -- new partitions will inherit from the current default, rather the partition root


### PR DESCRIPTION
The pg upstream doesn't support specifying table access method on partition table until version 17. While the GPDB still supports specifying table access method on partition table. The current behavior is supporting table access method on gp-style partition table, not supporting it on pg-style partition table.

It might be confusing. For some external tools, it still requires the capability of specifying table access method on both partition types.

This commit relaxes the constraint to allow specifying table access method on both parition types.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
Allow using table access method when creating partition table

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
