### PR TITLE
Add EXTERNAL TABLE to autocomplete

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1124,6 +1124,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"DYNAMIC TABLE", NULL, NULL, &Query_for_list_of_matviews, THING_NO_ALTER},
 	{"EVENT TRIGGER", NULL, NULL, NULL},
 	{"EXTENSION", Query_for_list_of_extensions},
+	{"EXTERNAL TABLE", NULL, NULL, NULL},
 	{"FOREIGN DATA WRAPPER", NULL, NULL, NULL},
 	{"FOREIGN TABLE", NULL, NULL, NULL},
 	{"FUNCTION", NULL, NULL, Query_for_list_of_functions},


### PR DESCRIPTION
Cherry pick from https://github.com/greenplum-db/gpdb-archive/commit/df114f0d3d22098ecd9450f4c5dd9d83c3a5047e

Long log:
Add EXTERNAL TABLE to autocomplete (#15350)
Extends the psql console utility. 
It's autocompletion capabilities with the "CREATE EXTERNAL TABLE" syntax. 
Now, when you type "CREATE EXT" and press Tab, 
both options will be offered: 
"CREATE EXTENSION" and "CREATE EXTERNAL TABLE".

Author-by: @nameless-tree
