### PR TITLE
ORCA: allow not enforce distribution key in 3-stage aggregate

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -290,7 +290,11 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT(
 		 "Explore a nested loop join even if a hash join is possible")},
-
+	{EopttraceEnableUseDistributionInDQA,
+	 &optimizer_enable_use_distribution_in_dqa,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT(
+		 "Enable use the distribution key in DQA")},
 };
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -115,12 +115,17 @@ CPhysicalAgg::CPhysicalAgg(
 		ulDistrReqs = 2;
 	}
 
-	// Split DQA generates a 2-stage aggregate to handle the case where
-	// hash aggregate has a distinct agg func. Here we need to be careful
-	// not to prohibit distribution property enforcement.
-	m_should_enforce_distribution &= !(
-		isAggFromSplitDQA && aggStage == CLogicalGbAgg::EasTwoStageScalarDQA &&
-		colref_array->Size() > 0);
+	// Force enable distribution property in DQA
+	if (GPOS_FTRACE(EopttraceEnableUseDistributionInDQA)) {
+		m_should_enforce_distribution = false;
+	} else {
+		// Split DQA generates a 2-stage aggregate to handle the case where
+		// hash aggregate has a distinct agg func. Here we need to be careful
+		// not to prohibit distribution property enforcement.
+		m_should_enforce_distribution &= !(
+			isAggFromSplitDQA && aggStage == CLogicalGbAgg::EasTwoStageScalarDQA &&
+			colref_array->Size() > 0);
+	}
 
 	SetDistrRequests(ulDistrReqs);
 }

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -210,10 +210,13 @@ enum EOptTraceFlag
 	// Use legacy (cdbhash) opfamilies for compatibility
 	EopttraceUseLegacyOpfamilies = 103039,
 
-	// enable NL Left Join plan alternatives where inner child is redistributed if possible
+	// Enable NL Left Join plan alternatives where inner child is redistributed if possible
 	EopttraceEnableRedistributeNLLOJInnerChild = 103040,
 
 	EopttraceForceComprehensiveJoinImplementation = 103041,
+
+	// Enable use the distribution key in DQA
+	EopttraceEnableUseDistributionInDQA = 103042,
 
 	///////////////////////////////////////////////////////
 	///////////////////// statistics flags ////////////////

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -405,6 +405,7 @@ bool		optimizer_enable_space_pruning;
 bool		optimizer_enable_associativity;
 bool		optimizer_enable_eageragg;
 bool		optimizer_enable_range_predicate_dpe;
+bool		optimizer_enable_use_distribution_in_dqa;
 
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
@@ -2948,6 +2949,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_range_predicate_dpe,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_use_distribution_in_dqa", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enable use the distribution key in DQA"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_use_distribution_in_dqa,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -584,6 +584,7 @@ extern bool optimizer_cte_inlining;
 extern bool optimizer_enable_space_pruning;
 extern bool optimizer_enable_associativity;
 extern bool optimizer_enable_range_predicate_dpe;
+extern bool optimizer_enable_use_distribution_in_dqa;
 
 /* Analyze related GUCs for Optimizer */
 extern bool optimizer_analyze_root_partition;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -423,6 +423,7 @@
 		"optimizer_enable_partition_propagation",
 		"optimizer_enable_partition_selection",
 		"optimizer_enable_range_predicate_dpe",
+		"optimizer_enable_use_distribution_in_dqa",
 		"optimizer_enable_redistribute_nestloop_loj_inner_child",
 		"optimizer_enable_replicated_table",
 		"optimizer_enable_sort",

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2377,6 +2377,10 @@ select count(distinct a) from t_issue_659;
 (1 row)
 
 set gp_eager_distinct_dedup = on;
+-- for ORCA
+set optimizer_force_three_stage_scalar_dqa to on;
+set optimizer_force_multistage_agg to on;
+set optimizer_enable_use_distribution_in_dqa to on;
 explain(costs off)
 select count(distinct a) from t_issue_659;
                    QUERY PLAN                    
@@ -2397,4 +2401,7 @@ select count(distinct a) from t_issue_659;
 (1 row)
 
 reset gp_eager_distinct_dedup;
+reset optimizer_force_three_stage_scalar_dqa;
+reset optimizer_force_multistage_agg;
+reset optimizer_enable_use_distribution_in_dqa;
 drop table t_issue_659;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2524,16 +2524,23 @@ select count(distinct a) from t_issue_659;
 (1 row)
 
 set gp_eager_distinct_dedup = on;
+-- for ORCA
+set optimizer_force_three_stage_scalar_dqa to on;
+set optimizer_force_multistage_agg to on;
+set optimizer_enable_use_distribution_in_dqa to on;
 explain(costs off)
 select count(distinct a) from t_issue_659;
-                   QUERY PLAN                   
-------------------------------------------------
- Finalize Aggregate
+                   QUERY PLAN                    
+-------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on t_issue_659
+         ->  HashAggregate
+               Group Key: a
+               ->  Streaming HashAggregate
+                     Group Key: a
+                     ->  Seq Scan on t_issue_659
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(8 rows)
 
 select count(distinct a) from t_issue_659;
  count 
@@ -2542,4 +2549,7 @@ select count(distinct a) from t_issue_659;
 (1 row)
 
 reset gp_eager_distinct_dedup;
+reset optimizer_force_three_stage_scalar_dqa;
+reset optimizer_force_multistage_agg;
+reset optimizer_enable_use_distribution_in_dqa;
 drop table t_issue_659;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -419,8 +419,15 @@ explain(costs off)
 select count(distinct a) from t_issue_659;
 select count(distinct a) from t_issue_659;
 set gp_eager_distinct_dedup = on;
+-- for ORCA
+set optimizer_force_three_stage_scalar_dqa to on;
+set optimizer_force_multistage_agg to on;
+set optimizer_enable_use_distribution_in_dqa to on;
 explain(costs off)
 select count(distinct a) from t_issue_659;
 select count(distinct a) from t_issue_659;
 reset gp_eager_distinct_dedup;
+reset optimizer_force_three_stage_scalar_dqa;
+reset optimizer_force_multistage_agg;
+reset optimizer_enable_use_distribution_in_dqa;
 drop table t_issue_659;


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #659

### Change log

In the case where the group-by key is a distribution key, ORCA disables 3-stage aggregate by default.

Add a new GUC(optimizer_enable_use_distribution_in_dqa) to allow not enforce distribution key in 3-stage aggregate in ORCA. which enables local deduplication before the 2-stage agg.


### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
