### PR TITLE
Enhance Dynamic Table auto-refresh task.

### DIFF
--- a/src/backend/commands/taskcmds.c
+++ b/src/backend/commands/taskcmds.c
@@ -251,7 +251,14 @@ AlterTask(ParseState *pstate, AlterTaskStmt * stmt)
 	}
 
 	if (d_sql != NULL && d_sql->arg)
-		sql = defGetString(d_sql);
+	{
+		if (strncmp(stmt->taskname, DYNAMIC_TASK_PREFIX, 25) == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("can not alter REFRESH SQL of dynamic tables")));
+		else
+			sql = defGetString(d_sql);
+	}
 
 	AlterCronJob(jobid, schedule, sql, dbname, username, d_active != NULL ? &active : NULL);
 

--- a/src/test/regress/expected/dynamic_table.out
+++ b/src/test/regress/expected/dynamic_table.out
@@ -156,14 +156,14 @@ SELECT * FROM t1 WHERE a = 2;
 (2 rows)
 
 -- test DROP DYNAMIC TABLE
-SELECT schedule, command FROM pg_task WHERE jobname LIKE 'gp_dynamic_table_refresh%' AND command LIKE '%dt0';
+SELECT schedule, command FROM pg_task WHERE jobname LIKE 'gp_dynamic_table_refresh%' AND command LIKE '%dt0%';
  schedule  |                    command                     
 -----------+------------------------------------------------
  5 * * * * | REFRESH DYNAMIC TABLE dynamic_table_schema.dt0
 (1 row)
 
 DROP DYNAMIC TABLE dt0;
-SELECT schedule, command FROM pg_task WHERE jobname LIKE 'gp_dynamic_table_refresh%' AND command LIKE '%dt0';
+SELECT schedule, command FROM pg_task WHERE jobname LIKE 'gp_dynamic_table_refresh%' AND command LIKE '%dt0%';
  schedule | command 
 ----------+---------
 (0 rows)
@@ -291,6 +291,11 @@ SELECT 'dt5'::regclass::oid AS dtoid \gset
 CREATE TASK gp_dynamic_table_refresh_xxx SCHEDULE '1 second' AS 'REFRESH DYNAMIC TABLE dt5';
 ERROR:  unacceptable task name "gp_dynamic_table_refresh_xxx"
 DETAIL:  The prefix "gp_dynamic_table_refresh_" is reserved for system tasks.
+-- can not alter the REFRESH SQL of Dynamic Tables.
+ALTER TASK gp_dynamic_table_refresh_:dtoid AS '* * * * *';
+ERROR:  can not alter REFRESH SQL of dynamic tables
+ALTER TASK gp_dynamic_table_refresh_:dtoid AS '';
+ERROR:  can not alter REFRESH SQL of dynamic tables
 -- should fail
 DROP TASK gp_dynamic_table_refresh_:dtoid;
 ERROR:  can not drop a internal task "gp_dynamic_table_refresh_17387" paried with dynamic table
@@ -337,6 +342,26 @@ SELECT * FROM pg_dynamic_tables;
                       |                  |                   |            |            |             |     t2.c                         +
                       |                  |                   |            |            |             |    FROM t2;
 (4 rows)
+
+CREATE TABLE t3(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE DYNAMIC TABLE dt_1_min SCHEDULE '* * * * *' AS SELECT * FROM t3 WITH NO DATA;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO T3 VALUES(1);
+-- wait for backgroud refresh
+SELECT pg_sleep(80);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM dt_1_min;
+ a 
+---
+ 1
+(1 row)
 
 RESET enable_answer_query_using_materialized_views;
 RESET optimizer;


### PR DESCRIPTION
This commit implements changes to the auto-refresh task for Dynamic Tables, specifically:

1. Forbid users from altering the "AS" part of the ALTER TASK command. The SQL must always be a REFRESH command to maintain the integrity of the Dynamic Table design (an auto-refreshing materialized view). Other ALTER TASK subcommands remain allowed, enabling users to control other aspects as needed.
2. Modify the SQL from "REFRESH DYNAMIC TABLE xxx" to "REFRESH DYNAMIC TABLE xxx CONCURRENTLY" to allow refreshing the materialized view without locking out concurrent selects.

These changes aim to improve the usability and performance of Dynamic Tables in our system.

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
