### PR TITLE
Maintain Data Status of Materialized Views for Partitioned Tables.

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2424,6 +2424,14 @@ heap_drop_with_catalog(Oid relid)
 		LockRelationOid(parentOid, AccessExclusiveLock);
 
 		/*
+		 * Now we could update view status of parent.
+		 * Drop a partiton means delete data from parent.
+		 */
+		SetRelativeMatviewAuxStatus(parentOid,
+									MV_DATA_STATUS_EXPIRED,
+									MV_DATA_STATUS_TRANSFER_DIRECTION_UP);
+
+		/*
 		 * If this is not the default partition, dropping it will change the
 		 * default partition's partition constraint, so we must lock it.
 		 */
@@ -3992,7 +4000,9 @@ heap_truncate_one_rel(Relation rel)
 
 	/* update view info */
 	if (IS_QD_OR_SINGLENODE())
-		SetRelativeMatviewAuxStatus(RelationGetRelid(rel), MV_DATA_STATUS_EXPIRED);
+		SetRelativeMatviewAuxStatus(RelationGetRelid(rel),
+									MV_DATA_STATUS_EXPIRED,
+									MV_DATA_STATUS_TRANSFER_DIRECTION_ALL);
 
 	/* If there is a toast table, truncate that too */
 	toastrelid = rel->rd_rel->reltoastrelid;

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -232,7 +232,9 @@ cluster(ParseState *pstate, ClusterStmt *stmt, bool isTopLevel)
 			 * to distint the pages instead, since latest relative materialized
 			 * view REFRESH.
 			 */
-			SetRelativeMatviewAuxStatus(tableOid, MV_DATA_STATUS_UP_REORGANIZED);
+			SetRelativeMatviewAuxStatus(tableOid,
+										MV_DATA_STATUS_UP_REORGANIZED,
+										MV_DATA_STATUS_TRANSFER_DIRECTION_ALL);
 
 		}
 	}
@@ -302,7 +304,9 @@ cluster(ParseState *pstate, ClusterStmt *stmt, bool isTopLevel)
 			}
 			/* See comments above. */
 			if (IS_QD_OR_SINGLENODE())
-				SetRelativeMatviewAuxStatus(rvtc->tableOid, MV_DATA_STATUS_UP_REORGANIZED);
+				SetRelativeMatviewAuxStatus(rvtc->tableOid,
+											MV_DATA_STATUS_UP_REORGANIZED,
+											MV_DATA_STATUS_TRANSFER_DIRECTION_ALL);
 
 			PopActiveSnapshot();
 			CommitTransactionCommand();

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -453,7 +453,9 @@ DoCopy(ParseState *pstate, const CopyStmt *stmt,
 			 */
 			if (IS_QD_OR_SINGLENODE() && *processed > 0)
 			{
-				SetRelativeMatviewAuxStatus(relid, MV_DATA_STATUS_EXPIRED_INSERT_ONLY);
+				SetRelativeMatviewAuxStatus(relid,
+											MV_DATA_STATUS_EXPIRED_INSERT_ONLY,
+											MV_DATA_STATUS_TRANSFER_DIRECTION_ALL);
 			}
 		}
 		PG_CATCH();

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1437,6 +1437,24 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	/* Store inheritance information for new rel. */
 	StoreCatalogInheritance(relationId, inheritOids, stmt->partbound != NULL);
 
+	if (IS_QD_OR_SINGLENODE() && stmt->partbound != NULL)
+	{
+		/*
+		 * Update parent relation's view status.
+		 * We just want to tranasfer status up to the top.
+		 */
+		Assert(list_length(inheritOids) == 1);
+		Oid parent = linitial_oid(inheritOids);
+		/*
+		 * FIXME: A new partition means data insertion for parent.
+		 * But DeltaScan can't handle it yet, so mark it as expired
+		 * to disable Append Agg for now.
+		 */
+		SetRelativeMatviewAuxStatus(parent,
+									MV_DATA_STATUS_EXPIRED,
+									MV_DATA_STATUS_TRANSFER_DIRECTION_UP);
+	}
+	
 	/*
 	 * Process the partitioning specification (if any) and store the partition
 	 * key information into the catalog.
@@ -2572,7 +2590,9 @@ ExecuteTruncateGuts(List *explicit_rels,
 
 			/* update view info */
 			if (IS_QD_OR_SINGLENODE())
-				SetRelativeMatviewAuxStatus(RelationGetRelid(rel), MV_DATA_STATUS_EXPIRED);
+				SetRelativeMatviewAuxStatus(RelationGetRelid(rel),
+											MV_DATA_STATUS_EXPIRED,
+											MV_DATA_STATUS_TRANSFER_DIRECTION_ALL);
 
 			heap_relid = RelationGetRelid(rel);
 
@@ -21411,6 +21431,20 @@ ATExecAttachPartition(List **wqueue, Relation rel, PartitionCmd *cmd,
 
 	/* OK to create inheritance.  Rest of the checks performed there */
 	CreateInheritance(attachrel, rel);
+	/*
+	 * Update status of parent relative views.
+	 * FIXME: Attach a partition means insert data into parent.
+	 * But DeltaScan can't handle it yet, so mark it as expired
+	 * to disable Append Agg for now.
+	 */
+	if (IS_QD_OR_SINGLENODE())
+	{
+		/* to see its parent */
+		CommandCounterIncrement();
+		SetRelativeMatviewAuxStatus(RelationGetRelid(rel),
+									MV_DATA_STATUS_EXPIRED,
+									MV_DATA_STATUS_TRANSFER_DIRECTION_UP);
+	}
 
 	/* Update the pg_class entry. */
 	StorePartitionBound(attachrel, rel, cmd->bound);
@@ -21939,7 +21973,19 @@ ATExecDetachPartition(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	 * non-concurrent mode) or just set the inhdetachpending flag.
 	 */
 	if (!concurrent)
+	{
+		/*
+		 * Update status of parent relative views.
+		 * We must do this before RemoveInheritance.
+		 * Detach a partition means delete data from parent.
+		 */
+		if (IS_QD_OR_SINGLENODE())
+			SetRelativeMatviewAuxStatus(RelationGetRelid(rel),
+										MV_DATA_STATUS_EXPIRED,
+										MV_DATA_STATUS_TRANSFER_DIRECTION_UP);
+
 		RemoveInheritance(partRel, rel, false);
+	}
 	else
 		MarkInheritDetached(partRel, rel);
 
@@ -22075,6 +22121,16 @@ DetachPartitionFinalize(Relation rel, Relation partRel, bool concurrent,
 
 	if (concurrent)
 	{
+		/*
+		 * Update status of parent relative views.
+		 * We must do this before RemoveInheritance.
+		 * Detach a partition means delete data from parent.
+		 */
+		if (IS_QD_OR_SINGLENODE())
+			SetRelativeMatviewAuxStatus(RelationGetRelid(rel),
+										MV_DATA_STATUS_EXPIRED,
+										MV_DATA_STATUS_TRANSFER_DIRECTION_UP);
+
 		/*
 		 * We can remove the pg_inherits row now. (In the non-concurrent case,
 		 * this was already done).

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2688,7 +2688,9 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 		 * FIXME: for auto vacuum process on segments, it's in utility mode,
 		 * we can't handle it yet. But it's not a problem for SERVERLESS.
 		 */
-		SetRelativeMatviewAuxStatus(relid, MV_DATA_STATUS_UP_REORGANIZED);
+		SetRelativeMatviewAuxStatus(relid,
+									MV_DATA_STATUS_UP_REORGANIZED,
+									MV_DATA_STATUS_TRANSFER_DIRECTION_ALL);
 	}
 
 	/* Roll back any GUC changes executed by index functions */

--- a/src/include/catalog/gp_matview_aux.h
+++ b/src/include/catalog/gp_matview_aux.h
@@ -54,13 +54,17 @@ DECLARE_INDEX(gp_matview_aux_datastatus_index, 7149, on gp_matview_aux using btr
 #define		MV_DATA_STATUS_EXPIRED					'e'	/* data is expired */
 #define		MV_DATA_STATUS_EXPIRED_INSERT_ONLY		'i'	/* expired but has only INSERT operation since latest REFRESH */
 
+#define		MV_DATA_STATUS_TRANSFER_DIRECTION_UP	'u'	/* set status recursivly up to the top. */
+#define		MV_DATA_STATUS_TRANSFER_DIRECTION_DOWN	'd'	/* set status recursivly down to the leaf. */
+#define		MV_DATA_STATUS_TRANSFER_DIRECTION_ALL	'a'	/* set status recursivly up and down */
+
 extern void InsertMatviewAuxEntry(Oid mvoid, const Query *viewQuery, bool skipdata);
 
 extern void RemoveMatviewAuxEntry(Oid mvoid);
 
 extern List* GetViewBaseRelids(const Query *viewQuery, bool *has_foreign);
 
-extern void SetRelativeMatviewAuxStatus(Oid relid, char status);
+extern void SetRelativeMatviewAuxStatus(Oid relid, char status, char direction);
 
 extern void SetMatviewAuxStatus(Oid mvoid, char status);
 

--- a/src/test/regress/expected/matview_data.out
+++ b/src/test/regress/expected/matview_data.out
@@ -432,10 +432,231 @@ select mvname, datastatus from gp_matview_aux where mvname = 'mv_t_cte_issue_582
 (1 row)
 
 abort;
+-- test partitioned tables
+create table par(a int, b int, c int) partition by range(b)
+    subpartition by range(c) subpartition template (start (1) end (3) every (1))
+    (start(1) end(3) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into par values(1, 1, 1), (1, 1, 2), (2, 2, 1), (2, 2, 2);
+create materialized view mv_par as select * from par;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par1 as select * from  par_1_prt_1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par1_1 as select * from par_1_prt_1_2_prt_1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par1_2 as select * from par_1_prt_1_2_prt_2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par2 as select * from  par_1_prt_2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par2_2 as select * from  par_1_prt_2_2_prt_1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_2 | u
+(6 rows)
+
+insert into par_1_prt_1 values (1, 1, 1);
+-- mv_par1* shoud be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_2 | u
+ mv_par1   | i
+ mv_par1_1 | i
+ mv_par1_2 | i
+ mv_par    | i
+(6 rows)
+
+insert into par values (1, 2, 2);
+-- mv_par* should be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | i
+ mv_par1_1 | i
+ mv_par1_2 | i
+ mv_par    | i
+ mv_par2   | i
+ mv_par2_2 | i
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_2;
+begin;
+insert into par_1_prt_2_2_prt_1 values (1, 2, 1);
+-- mv_par1* should not be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_2 | i
+ mv_par2   | i
+ mv_par    | i
+(6 rows)
+
+abort;
+begin;
+truncate par_1_prt_2;
+-- mv_par1* should not be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_2 | e
+ mv_par2   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+truncate par_1_prt_2;
+-- mv_par1* should not be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_2 | e
+ mv_par2   | e
+ mv_par    | e
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_2;
+vacuum full par_1_prt_1_2_prt_1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_2 | u
+ mv_par1_1 | r
+ mv_par1   | r
+ mv_par    | r
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_2;
+vacuum full par;
+-- all should be updated.
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | r
+ mv_par    | r
+ mv_par2_2 | r
+ mv_par1_2 | r
+ mv_par1   | r
+ mv_par1_1 | r
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_2;
+begin;
+create table par_1_prt_1_2_prt_3  partition of par_1_prt_1 for values from  (3) to (4);
+NOTICE:  table has parent, setting distribution columns to match parent table
+-- update status when partition of
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_2 | u
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+begin;
+drop table par_1_prt_1 cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to materialized view mv_par1_1
+drop cascades to materialized view mv_par1_2
+drop cascades to materialized view mv_par1
+-- update status when drop table 
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_2 | u
+ mv_par    | e
+(3 rows)
+
+abort;
+begin;
+alter table par_1_prt_1 detach partition par_1_prt_1_2_prt_1;
+-- update status when detach
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_2 | u
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+begin;
+create table new_par(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Cloudberry Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- update status when attach
+alter table par_1_prt_1 attach partition new_par for values from (4) to (5);
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_2 | u
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+--start_ignore
 drop schema matview_data_schema cascade;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table t2
 drop cascades to table t3
 drop cascades to materialized view mv3
+--end_ignore
 reset enable_answer_query_using_materialized_views;
 reset optimizer;


### PR DESCRIPTION
### Handle of data status changes for materialized views associated with partitioned tables.

Writable operations (**INSERT, UPDATE, DELETE, COPY, TRUNCATE, CLUSTER and etc**) on a base table lead to changes in the data status of linked materialized views. For partitioned tables, changes in child partitions can impact parent and ancestor tables, necessitating updates to the relevant materialized views.
  
For example, consider a root partitioned table P0 with two child partitioned tables: P1 and P2. Each child table further has 
two sub-partitions: P1 has P1_1 and P1_2, while P2 has P2_1 and P2_2.   
![q_dynamic_table drawio](https://github.com/user-attachments/assets/c9c5e187-9030-4b52-95ec-663cf9d8912f)
If we insert rows into P1_1, the data status of both mv0 (based on P0) and mv1 (based on P1) will change, as P1_1's parent table P1 and the root table P0 now contain more rows. 
![q_dynamic_table drawio2](https://github.com/user-attachments/assets/6b0d6f01-4803-448d-a69f-d880f206307d)
Conversely, if we insert rows into P2_1, only the data status of mv2_1 (based on P2_1) and mv0 will be affected, while mv1 remains unchanged because the data in P1 has not changed.
![q_dynamic_table drawio3](https://github.com/user-attachments/assets/ed674dee-ed7f-4ce7-b5be-baccb1e55bd2)

### Propagation Direction: 
  Data status changes propagate both UP and DOWN the partition tree, except for specific DDL operations:
  * **Create Table XXX Partition Of**:
	  Indicates an insert operation on the parent table.
  * **Drop Table**:
	   Indicates a delete operation on the parent table.
  * **Alter Table ATTACH/DETACH** :
	  Attaching implies an insert, while detaching implies a delete.

Handling **TRUNCATE** and **CLUSTER**: A TRUNCATE operation on a parent table is treated as a DELETE on its child tables, affecting both the parent and its descendants. Similarly, a CLUSTER operation will transform the data status in both UP and DOWN directions. However, CLUSTER has a recognized status to indicate that the changes have been applied to the pages of the tables.

The **COPY** command indicates that data has been inserted into the table and its ancestor tables.

The **VACUUM** command indicates that data has been recognized on the table and its ancestor tables.

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
