### PR TITLE
Update branch check with current test job names [skip ci]

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -88,10 +88,11 @@ github:
         - RPM Install Test Apache Cloudberry
         - ic-good-opt-off
         - ic-expandshrink
-        - ic-singlenode_regress
-        - ic-singlenode_isolation
-        - ic-singlenode_isolation2
+        - ic-singlenode
         - ic-resgroup-v2
+        - ic-contrib
+        - ic-gpcontrib
+        - ic-fixme
         - Generate Apache Cloudberry Build Report
 
       # Pull request review requirements


### PR DESCRIPTION
Updates required status checks to match the current test matrix jobs:
- Removes: ic-singlenode_regress, ic-singlenode_isolation, ic-singlenode_isolation2
- Adds: ic-singlenode (combines previous singlenode checks)
- Adds: ic-contrib, ic-gpcontrib, ic-fixme

Aligns branch protection status checks with the consolidated test matrix configurations to ensure proper merge validation.
