### PR TITLE
Add test case with ORCA query optimizer enabled

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -87,6 +87,7 @@ github:
         - Build Apache Cloudberry
         - RPM Install Test Apache Cloudberry
         - ic-good-opt-off
+        - ic-good-opt-on
         - ic-expandshrink
         - ic-singlenode
         - ic-resgroup-v2

--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -684,6 +684,15 @@ jobs:
             pg_settings:
               optimizer: "off"
 
+          - test: ic-good-opt-on
+            make_configs:
+              - src/test/regress:installcheck-good
+            num_primary_mirror_pairs: 3
+            enable_cgroups: false
+            enable_core_check: true
+            pg_settings:
+              optimizer: "on"
+
           - test: ic-expandshrink
             make_configs:
               - src/test/isolation2:installcheck-expandshrink


### PR DESCRIPTION
Adds test configuration for running regression tests with ORCA enabled:
- test: ic-good-opt-on
- make_configs: src/test/regress:installcheck-good
- pg_settings.optimizer: "on"

The ORCA query optimizer provides cost-based query optimization and offers additional query optimization capabilities. This configuration allows regression testing with ORCA enabled to verify optimizer functionality.