### PR TITLE
Enhance the code style of IVM

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -2641,8 +2641,8 @@ apply_delta(char *old_enr, char *new_enr, MV_TriggerTable *table, Oid matviewOid
 		/* apply new delta */
 		if (use_count)
 			apply_new_delta_with_count(matviewname, enr->md.name,
-										keys, aggs_set_new,
-										&target_list_buf, count_colname);
+										keys, &target_list_buf,
+										aggs_set_new, count_colname);
 		else
 			apply_new_delta(matviewname, enr->md.name, &target_list_buf);
 	}
@@ -3080,7 +3080,7 @@ apply_old_delta(const char *matviewname, const char *deltaname_old,
  */
 static void
 apply_new_delta_with_count(const char *matviewname, const char* deltaname_new,
-				List *keys, StringInfo aggs_set, StringInfo target_list,
+				List *keys, StringInfo target_list, StringInfo aggs_set,
 				const char* count_colname)
 {
 	StringInfoData	querybuf;

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -828,16 +828,6 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	/* run the plan */
 	ExecutorRun(queryDesc, ForwardScanDirection, 0L, true);
 
-	/*
-	 * GPDB: The total processed tuples here is always 0 on QD since we get it
-	 * before we fetch the total processed tuples from segments(which is done by
-	 * ExecutorEnd).
-	 * In upstream, the number is used to update pgstat, but in GPDB we do the
-	 * pgstat update on segments.
-	 * Since the processed is not used, no need to get correct value here.
-	 */
-	processed = queryDesc->estate->es_processed;
-
 	/* and clean up */
 	ExecutorFinish(queryDesc);
 	ExecutorEnd(queryDesc);

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -3412,10 +3412,10 @@ clean_up_IVM_hash_entry(MV_TriggerHashEntry *entry, bool is_abort)
 static void
 clean_up_ivm_dsm_entry(MV_TriggerHashEntry *entry)
 {
-	SnapshotDumpEntry	*pDump;
 	if (entry->snapname && entry->snapname[0] != '\0' && Gp_is_writer)
 	{
-		bool found;
+		bool 				found;
+		SnapshotDumpEntry	*pDump;
 		LWLockAcquire(GPIVMResLock, LW_EXCLUSIVE);
 		pDump = (SnapshotDumpEntry *) hash_search(mv_trigger_snapshot,
 													(void *)entry->snapname,

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -101,7 +101,6 @@ static void AfterTriggerSaveEvent(EState *estate, ResultRelInfo *relinfo,
 static void AfterTriggerEnlargeQueryState(void);
 static bool before_stmt_triggers_fired(Oid relid, CmdType cmdType);
 
-static char* make_delta_ts_name(const char *prefix, Oid relid, int count);
 /*
  * Create a trigger.  Returns the address of the created trigger.
  *
@@ -4486,13 +4485,13 @@ SetTransitionTableName(Oid relid, CmdType cmdType, Oid mvoid)
 		{
 			if (table->new_tuplestore)
 			{
-				char *name = make_delta_ts_name("new", relid, gp_command_count);
+				char *name = MakeDeltaName("new", relid, gp_command_count);
 				tuplestore_set_sharedname(table->new_tuplestore, name);
 				tuplestore_set_tableid(table->new_tuplestore, relid);
 			}
 			if (table->old_tuplestore)
 			{
-				char *name = make_delta_ts_name("old", relid, gp_command_count);
+				char *name = MakeDeltaName("old", relid, gp_command_count);
 				tuplestore_set_sharedname(table->old_tuplestore, name);
 				tuplestore_set_tableid(table->old_tuplestore, relid);
 			}
@@ -6175,13 +6174,13 @@ pg_trigger_depth(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(MyTriggerDepth);
 }
 
-static char*
-make_delta_ts_name(const char *prefix, Oid relid, int count)
+char*
+MakeDeltaName(const char *prefix, Oid relid, int count)
 {
 	char buf[NAMEDATALEN];
 	char *name;
 
-	snprintf(buf, NAMEDATALEN, "__ivm_%s_%u_%u", prefix, relid, count);
+	snprintf(buf, NAMEDATALEN, "__ivm_%s_%u_%d", prefix, relid, count);
 	name = pstrdup(buf);
 
 	return name;

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -259,6 +259,8 @@ extern List* AfterTriggerGetMvList(void);
 extern void AfterTriggerAppendMvList(Oid matview_id);
 extern void SetTransitionTableName(Oid relid, CmdType cmdType, Oid mvoid);
 
+extern char* MakeDeltaName(const char *prefix, Oid relid, int count);
+
 /*
  * in utils/adt/ri_triggers.c
  */


### PR DESCRIPTION
Long log:

- Make function make_delta_ts_name() an extern function
- Fix a wrong placeholder
- Reduce the scope of pDump
- Clean a unused reassigned value
- Fix different input order of function's declaration and definition

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

_**Note**: please review it commit by commit for easier understand._