### PR TITLE
CI: enable daily coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -80,4 +80,4 @@ jobs:
           --form file=@cov.tar.gz \
           --form version="Commit $GITHUB_SHA" \
           --form description="Build submitted via CI" \
-          https://scan.coverity.com/builds?project=cloudberry
+          https://scan.coverity.com/builds?project=apache%2Fcloudberry

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Download Coverity build tool
       run: |
-        wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=cloudberry" -O coverity_tool.tar.gz
+        wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=apache%2Fcloudberry" -O coverity_tool.tar.gz
         mkdir coverity_tool
         tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
     - name: Build with Coverity build tool

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,83 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# GitHub Actions Workflow: Apache Cloudberry Coverity Scan Pipeline
+# --------------------------------------------------------------------
+# Description:
+#
+#   This workflow performs scheduled coverity scan of Apache Cloudberry.
+#
+# Workflow Overview:
+# 1. **Check Skip**:
+#    - workflow run currently is limited to "apache" GitHub organization, forks are ignored
+#
+# 2. **scan Job**:
+#    - performs scan and upload result to https://scan.coverity.com/projects/cloudberry?tab=overview
+# Triggers:
+# - daily schedule
+# - optional manual dispatch.
+#
+# Notes:
+# - COVERITY_SCAN_TOKEN secret is used.
+# --------------------------------------------------------------------
+name: Coverity
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'apache' }}
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install apt dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bison cmake curl flex git-core gcc g++ inetutils-ping krb5-kdc krb5-admin-server libapr1-dev libbz2-dev libcurl4-gnutls-dev libevent-dev libkrb5-dev libpam-dev libperl-dev libreadline-dev libssl-dev libxerces-c-dev libxml2-dev libyaml-dev libzstd-dev locales net-tools ninja-build openssh-client openssh-server openssl pkg-config python3-dev python3-pip python3-psutil python3-pygresql python3-yaml zlib1g-dev
+        pip3 install conan
+
+    - name: Download Coverity build tool
+      run: |
+        wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=cloudberry" -O coverity_tool.tar.gz
+        mkdir coverity_tool
+        tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
+    - name: Build with Coverity build tool
+      run: |
+        ./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/cloudberrydb
+        export PATH=`pwd`/coverity_tool/bin:$PATH
+        cov-build --dir cov-int make -j$(nproc)
+    - name: Submit build result to Coverity Scan
+      run: |
+        tar czvf cov.tar.gz cov-int
+        curl --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
+          --form email=wangdianjin@gmail.com \
+          --form file=@cov.tar.gz \
+          --form version="Commit $GITHUB_SHA" \
+          --form description="Build submitted via CI" \
+          https://scan.coverity.com/builds?project=cloudberry


### PR DESCRIPTION
### What does this PR do?

introduce workflow mentioned in https://github.com/apache/cloudberry/discussions/842

### Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update


### Additional Context

next steps:

1) grant Cloudberry developers permissions on Coverity project (I can add by email or feel free to request join at https://scan.coverity.com/projects/cloudberry?tab=overview )
2) add [COVERITY_SCAN_TOKEN](https://scan.coverity.com/projects/cloudberry?tab=project_settings) to [GHA secrets](https://github.com/apache/cloudberry/settings/secrets/actions)
3) enjoy


P.S. I forgot to mention reeasoning for daily scheduling. Coverity has [limits](https://scan.coverity.com/faq#frequency)
