### PR TITLE
Fix potential use-after-free in error handling.

### DIFF
--- a/src/backend/cdb/cdbsreh.c
+++ b/src/backend/cdb/cdbsreh.c
@@ -1098,13 +1098,13 @@ TruncateErrorLog(text *relname, bool persistent)
 			Datum		value;
 			bool		isnull;
 			struct pg_result *pgresult = cdb_pgresults.pg_results[i];
-
-			if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+			ExecStatusType status = PQresultStatus(pgresult);
+			if (status != PGRES_TUPLES_OK)
 			{
 				cdbdisp_clearCdbPgResults(&cdb_pgresults);
 				ereport(ERROR,
 						(errmsg("unexpected result from segment: %d",
-								PQresultStatus(pgresult))));
+								status)));
 			}
 			value = ResultToDatum(pgresult, 0, 0, boolin, &isnull);
 			allResults &= (!isnull && DatumGetBool(value));

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -5109,29 +5109,30 @@ calculate_correlation_use_weighted_mean(CdbPgResults *cdb_pgresults,
 
 	for (int segno = 0; segno < segmentNum; segno++)
 	{
-		int			rows;
+		int			rows, nfields;
 		float4		correlationValue;
 		int			attno;
 		struct pg_result *pgresult = cdb_pgresults->pg_results[segno];
 		int			index;
-
-		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		ExecStatusType status = PQresultStatus(pgresult);
+		if (status != PGRES_TUPLES_OK)
 		{
 			cdbdisp_clearCdbPgResults(cdb_pgresults);
 			ereport(ERROR,
 					(errmsg("unexpected result from segment: %d",
-							PQresultStatus(pgresult))));
+							status)));
 		}
 		/*
 		 * gp_acquire_correlations returns a result for each alive columns.
 		 */
 		rows = PQntuples(pgresult);
-		if (rows != live_natts || PQnfields(pgresult) != 1)
+		nfields = PQnfields(pgresult);
+		if (rows != live_natts || nfields != 1)
 		{
 			cdbdisp_clearCdbPgResults(cdb_pgresults);
 			ereport(ERROR,
 					(errmsg("unexpected shape of result from segment (%d rows, %d cols)",
-							rows, PQnfields(pgresult))));
+							rows, nfields)));
 		}
 		for (int j = 0; j < rows; j++)
 		{
@@ -5232,28 +5233,29 @@ calculate_correlation_use_mean(CdbPgResults *cdb_pgresults,
 
 	for (int segno = 0; segno < segmentNum; segno++)
 	{
-		int			ntuples;
+		int			ntuples, nfields;
 		float4		correlationValue;
 		int			attno;
 		struct pg_result *pgresult = cdb_pgresults->pg_results[segno];
-
-		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		ExecStatusType  status = PQresultStatus(pgresult);
+		if (status != PGRES_TUPLES_OK)
 		{
 			cdbdisp_clearCdbPgResults(cdb_pgresults);
 			ereport(ERROR,
 					(errmsg("unexpected result from segment: %d",
-							PQresultStatus(pgresult))));
+							status)));
 		}
 		/*
 		 * gp_acquire_correlations returns a result for each alive columns.
 		 */
 		ntuples = PQntuples(pgresult);
-		if (ntuples != live_natts || PQnfields(pgresult) != 1)
+		nfields = PQnfields(pgresult);
+		if (ntuples != live_natts || nfields != 1)
 		{
 			cdbdisp_clearCdbPgResults(cdb_pgresults);
 			ereport(ERROR,
 					(errmsg("unexpected shape of result from segment (%d rows, %d cols)",
-							ntuples, PQnfields(pgresult))));
+							ntuples, nfields)));
 		}
 		for (int j = 0; j < ntuples; j++)
 		{

--- a/src/backend/commands/dirtablecmds.c
+++ b/src/backend/commands/dirtablecmds.c
@@ -478,22 +478,24 @@ remove_file(PG_FUNCTION_ARGS)
 	numDeletes = 0;
 	for (i = 0; i < cdbPgresults.numResults; i++)
 	{
+		int ntuples, nfields;
 		Datum value;
 		struct pg_result *pgresult = cdbPgresults.pg_results[i];
-
-		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		ExecStatusType status = PQresultStatus(pgresult);
+		if (status != PGRES_TUPLES_OK)
 		{
 			cdbdisp_clearCdbPgResults(&cdbPgresults);
 			ereport(ERROR,
-					(errmsg("unexpected result from segment: %d", PQresultStatus(pgresult))));
+					(errmsg("unexpected result from segment: %d", status)));
 		}
-
-		if (PQntuples(pgresult) != 1 || PQnfields(pgresult) != 1)
+		ntuples = PQntuples(pgresult);
+		nfields = PQnfields(pgresult);
+		if (ntuples != 1 || nfields != 1)
 		{
 			cdbdisp_clearCdbPgResults(&cdbPgresults);
 			ereport(ERROR,
 					(errmsg("unexpected shape of result from segment (%d rows, %d cols)",
-							PQntuples(pgresult), PQnfields(pgresult))));
+							ntuples, nfields)));
 		}
 		if (PQgetisnull(pgresult, 0, 0))
 			value = 0;


### PR DESCRIPTION

Fixes #ISSUE_Number

### What does this PR do?

Motivation:
The original code called PQresultStatus() after invoking cdbdisp_clearCdbPgResults(), 
which can lead to undefined behavior or potential segmentation faults. 
Accessing a pg_result pointer after clearing the CDB results may reference 
already freed memory.

Changes:
- Capture the result of PQresultStatus() in a local variable before clearing results
- Use the cached status for error reporting and comparison
- Prevent accessing pg_result after memory deallocation

This change ensures that all result status checks and error reporting occur 
before releasing the memory associated with the query results.

Enhances safety and readability in segment result processing

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
