### PR TITLE
Fix wrong result due to ignore PlaceHolderVar.

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -215,6 +215,15 @@ CorrelatedVarWalker(Node *node, CorrelatedVarWalkerContext *ctx)
 		}
 		return false;
 	}
+	else if (IsA(node, PlaceHolderVar))
+	{
+		PlaceHolderVar *phv = (PlaceHolderVar *) node;
+		if (phv->phlevelsup > ctx->maxLevelsUp)
+		{
+			ctx->maxLevelsUp = phv->phlevelsup;
+		}
+		return false;
+	}
 	else if (IsA(node, Query))
 	{
 		return query_tree_walker((Query *) node, CorrelatedVarWalker, ctx, 0 /* flags */);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -63,6 +63,45 @@ select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum fr
 (3 rows)
 
 --
+-- Another case correlations in the targetlist: PlaceHolderVar
+--
+drop table if exists phv_t;
+NOTICE:  table "phv_t" does not exist, skipping
+create table phv_t(a int, b int) distributed by (a);
+insert into phv_t values(1,1),(2,2);
+explain(costs off) select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
+(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: t1.a, t1.b
+   ->  Sort
+         Sort Key: t1.a, t1.b
+         ->  Hash Left Join
+               Hash Cond: (t1.b = t2.a)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: t1.b
+                     ->  Seq Scan on phv_t t1
+               ->  Hash
+                     ->  Seq Scan on phv_t t2
+               SubPlan 1
+                 ->  Limit
+                       ->  Result
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on phv_t t3
+ Optimizer: Postgres query optimizer
+(18 rows)
+
+select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
+(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
+ a | b | x | y  | z  
+---+---+---+----+----
+ 1 | 1 | 1 | 42 | 42
+ 2 | 2 | 2 | 42 | 42
+(2 rows)
+
+--
 -- CSQs with partitioned tables
 --
 drop table if exists csq_t1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -63,6 +63,46 @@ select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum fr
 (3 rows)
 
 --
+-- Another case correlations in the targetlist: PlaceHolderVar
+--
+drop table if exists phv_t;
+NOTICE:  table "phv_t" does not exist, skipping
+create table phv_t(a int, b int) distributed by (a);
+insert into phv_t values(1,1),(2,2);
+explain(costs off) select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
+(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: phv_t.a, phv_t.b
+   ->  Result
+         ->  Sort
+               Sort Key: phv_t.a, phv_t.b
+               ->  Hash Left Join
+                     Hash Cond: (phv_t.b = phv_t_1.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: phv_t.b
+                           ->  Seq Scan on phv_t
+                     ->  Hash
+                           ->  Seq Scan on phv_t phv_t_1
+         SubPlan 1
+           ->  Limit
+                 ->  Result
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                   ->  Seq Scan on phv_t phv_t_2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
+
+select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
+(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
+ a | b | x | y  | z  
+---+---+---+----+----
+ 1 | 1 | 1 | 42 | 42
+ 2 | 2 | 2 | 42 | 42
+(2 rows)
+
+--
 -- CSQs with partitioned tables
 --
 drop table if exists csq_t1;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -53,6 +53,22 @@ select csq_t1.x, (select sum(bar.x) from csq_t1 bar where bar.x = csq_t1.x) as s
 select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum from csq_t1 order by csq_t1.x;
 
 --
+-- Another case correlations in the targetlist: PlaceHolderVar
+--
+
+drop table if exists phv_t;
+
+create table phv_t(a int, b int) distributed by (a);
+
+insert into phv_t values(1,1),(2,2);
+
+explain(costs off) select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
+(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
+
+select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
+(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;
+
+--
 -- CSQs with partitioned tables
 --
 


### PR DESCRIPTION
I found a wrong result when I debugged the cbdb Postgres planner. For example:

create table phv_t(a int, b int) distributed by (a);
insert into phv_t values(1,1),(2,2);
explain(costs off) select *, (select ss.y as z from phv_t as t3 limit 1) from phv_t t1 left join
(select a as x, 42 as y from phv_t t2) ss on t1.b = ss.x order by 1,2;

The plan and result that pg planner returned are as below:
postgres=# set optimizer = off;
SET
postgres=#  select *, (select ss.y as z from t as t3 limit 1) from t t1 left join
(select a as x, 42 as y from t t2) ss on t1.b = ss.x order by 1,2;
 a | b | x | y  | z 
---+---+---+----+---
 1 | 1 | 1 | 42 | 0
 2 | 2 | 2 | 42 | 0
(2 rows)

postgres=# explain(costs off) select *, (select ss.y as z from t as t3 limit 1) from t t1 left join
(select a as x, 42 as y from t t2) ss on t1.b = ss.x order by 1,2;
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Merge Key: t1.a, t1.b
   ->  Sort
         Sort Key: t1.a, t1.b
         ->  Hash Left Join
               Hash Cond: (t1.b = t2.a)
               ->  Redistribute Motion 3:3  (slice4; segments: 3)
                     Hash Key: t1.b
                     ->  Seq Scan on t t1
               ->  Hash
                     ->  Seq Scan on t t2
               SubPlan 1
                 ->  Materialize
                       ->  Broadcast Motion 1:3  (slice2)
                             ->  Limit
                                   ->  Gather Motion 3:1  (slice3; segments: 3)
                                         ->  Limit
                                               ->  Seq Scan on t t3
 Optimizer: Postgres query optimizer

But the output of Orca will be as below:
postgres=# set optimizer = on;
SET
postgres=# explain(costs off) select *, (select ss.y as z from t as t3 limit 1) from t t1 left join
(select a as x, 42 as y from t t2) ss on t1.b = ss.x order by 1,2;
                                 QUERY PLAN                                  
-----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Merge Key: t.a, t.b
   ->  Result
         ->  Sort
               Sort Key: t.a, t.b
               ->  Hash Left Join
                     Hash Cond: (t.b = t_1.a)
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                           Hash Key: t.b
                           ->  Seq Scan on t
                     ->  Hash
                           ->  Seq Scan on t t_1
         SubPlan 1
           ->  Limit
                 ->  Result
                       ->  Materialize
                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                   ->  Seq Scan on t t_2
 Optimizer: Pivotal Optimizer (GPORCA)
(19 rows)

postgres=#  select *, (select ss.y as z from t as t3 limit 1) from t t1 left join
(select a as x, 42 as y from t t2) ss on t1.b = ss.x order by 1,2;
 a | b | x | y  | z  
---+---+---+----+----
 1 | 1 | 1 | 42 | 42
 2 | 2 | 2 | 42 | 42
(2 rows)

I double check the upstream 14.4, the result is same with Orca.

I think the plan of subquery in origin query  created by Postgres planner is wrong.  As far as I know, in Postgres optimizer code,
Var and PlaceholderVar in most times  appear at the same time. 

What will happen if we forget to process PlaceHolderVar in this case?   IsSubqueryCorrelated() will return false, then,
root->is_correlated_subplan will be false when we go into (select ss.y as z from t as t3 limit 1) .

The code in make_rel_from_joinlist() will not call bring_to_outer_query() if root->is_correlated_subplan is false.
So, a wrong plan will be created.



