### PR TITLE
Fix an "unexpected gang size" issue.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1025,6 +1025,7 @@ fix_subplan_motion(PlannerInfo *root, Plan *subplan, Flow *outer_query_flow)
 		{
 			initPlans = list_concat(initPlans, subplan->initPlan);
 			subplan = subplan->lefttree;
+			subFlow = subplan->flow;
 		}
 
 		/*
@@ -1041,6 +1042,7 @@ fix_subplan_motion(PlannerInfo *root, Plan *subplan, Flow *outer_query_flow)
 
 			sendSlice = strippedMotion->senderSliceInfo;
 			subplan = subplan->lefttree;
+			subFlow = subplan->flow;
 			initPlans = list_concat(initPlans, strippedMotion->plan.initPlan);
 		}
 		else

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -298,6 +298,51 @@ select * from mrs_u1 join mrs_u2 on mrs_u1.a=mrs_u2.a where mrs_u1.a in (1,11) o
 drop table if exists mrs_u1;
 drop table if exists mrs_u2;
 --
+-- Set right motion type to subquery
+--
+drop table if exists gs_tab;
+NOTICE:  table "gs_tab" does not exist, skipping
+create table gs_tab(a int, b int, c int) distributed by (a);
+insert into gs_tab values (1,1,1),(2,2,2);
+explain(costs off)
+select a from gs_tab t1 where b in
+	(select b from gs_tab t2 where c in
+		(select c from gs_tab t3)
+		or (c >= 2))
+	or (b <= 3)
+order by a;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: t1.a
+   ->  Sort
+         Sort Key: t1.a
+         ->  Seq Scan on gs_tab t1
+               Filter: ((hashed SubPlan 2) OR (b <= 3))
+               SubPlan 2
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                       ->  Seq Scan on gs_tab t2
+                             Filter: ((hashed SubPlan 1) OR (c >= 2))
+                             SubPlan 1
+                               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                     ->  Seq Scan on gs_tab t3
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select a from gs_tab t1 where b in
+	(select b from gs_tab t2 where c in
+		(select c from gs_tab t3)
+		or (c >= 2))
+	or (b <= 3)
+order by a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+drop table if exists gs_tab;
+--
 -- MPP-13758
 --
 drop table if exists csq_m1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -275,6 +275,67 @@ select * from mrs_u1 join mrs_u2 on mrs_u1.a=mrs_u2.a where mrs_u1.a in (1,11) o
 drop table if exists mrs_u1;
 drop table if exists mrs_u2;
 --
+-- Set right motion type to subquery
+--
+drop table if exists gs_tab;
+NOTICE:  table "gs_tab" does not exist, skipping
+create table gs_tab(a int, b int, c int) distributed by (a);
+insert into gs_tab values (1,1,1),(2,2,2);
+explain(costs off)
+select a from gs_tab t1 where b in
+	(select b from gs_tab t2 where c in
+		(select c from gs_tab t3)
+		or (c >= 2))
+	or (b <= 3)
+order by a;
+                                                                                                                                         QUERY PLAN                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: gs_tab_2.a
+   ->  Sort
+         Sort Key: gs_tab_2.a
+         ->  Result
+               Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((gs_tab_2.b = gs_tab_1.b) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END OR (gs_tab_2.b <= 3))
+               ->  GroupAggregate
+                     Group Key: gs_tab_2.a, gs_tab_2.b, gs_tab_2.ctid, gs_tab_2.gp_segment_id
+                     ->  Sort
+                           Sort Key: gs_tab_2.a, gs_tab_2.b, gs_tab_2.ctid, gs_tab_2.gp_segment_id
+                           ->  Nested Loop Left Join
+                                 Join Filter: ((gs_tab_2.b = gs_tab_1.b) IS NOT FALSE)
+                                 ->  Seq Scan on gs_tab gs_tab_2
+                                 ->  Materialize
+                                       ->  Result
+                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                   ->  Result
+                                                         Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((gs_tab_1.c = gs_tab.c) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END OR (gs_tab_1.c >= 2))
+                                                         ->  GroupAggregate
+                                                               Group Key: gs_tab_1.a, gs_tab_1.b, gs_tab_1.c, gs_tab_1.ctid, gs_tab_1.gp_segment_id
+                                                               ->  Sort
+                                                                     Sort Key: gs_tab_1.a, gs_tab_1.b, gs_tab_1.c, gs_tab_1.ctid, gs_tab_1.gp_segment_id
+                                                                     ->  Nested Loop Left Join
+                                                                           Join Filter: ((gs_tab_1.c = gs_tab.c) IS NOT FALSE)
+                                                                           ->  Seq Scan on gs_tab gs_tab_1
+                                                                           ->  Materialize
+                                                                                 ->  Result
+                                                                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                                                             ->  Seq Scan on gs_tab
+ Optimizer: Pivotal Optimizer (GPORCA)
+(30 rows)
+
+select a from gs_tab t1 where b in
+	(select b from gs_tab t2 where c in
+		(select c from gs_tab t3)
+		or (c >= 2))
+	or (b <= 3)
+order by a;
+ a 
+---
+ 1
+ 2
+(2 rows)
+
+drop table if exists gs_tab;
+--
 -- MPP-13758
 --
 drop table if exists csq_m1;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -136,6 +136,31 @@ drop table if exists mrs_u1;
 drop table if exists mrs_u2;
 
 --
+-- Set right motion type to subquery
+--
+
+drop table if exists gs_tab;
+
+create table gs_tab(a int, b int, c int) distributed by (a);
+insert into gs_tab values (1,1,1),(2,2,2);
+explain(costs off)
+select a from gs_tab t1 where b in
+	(select b from gs_tab t2 where c in
+		(select c from gs_tab t3)
+		or (c >= 2))
+	or (b <= 3)
+order by a;
+
+select a from gs_tab t1 where b in
+	(select b from gs_tab t2 where c in
+		(select c from gs_tab t3)
+		or (c >= 2))
+	or (b <= 3)
+order by a;
+
+drop table if exists gs_tab;
+
+--
 -- MPP-13758
 --
 


### PR DESCRIPTION
Hi,

Recently, I came across an "unexpected gang size" issue.

How to reproduce

```
create table gs_tab(a int, b int, c int) distributed by (a);
insert into gs_tab values (1,1,1),(2,2,2);
set optimizer = off;
explain select a from gs_tab t1 where b in
    (select b from gs_tab t2 where c in
        (select c from gs_tab t3)
        or (c >= 2))
    or (b <= 3)
order by a;
```

Orca doesn't have this problem.

In the Postgres planner, the two subqueries won't be pulled up. So they will
be optimized to Subplan.  After top_plan has been produced, we have to
adjust the Motion type of subplans, which will call cdbllize_decorate_subplans_with_motions().

In cdbllize_decorate_subplans_with_motions(), it first find the subplan that referred directly
by top_plan, if found, the subplan will be added to a working queue list. 

In this case, (select b from gs_tab t2 where c in ...) will be added to the working list.
After collecting subplans, it will iterator this working list and call fix_subplan_motion()
to adjust the Motion type of subplan. Finishing this job, it will add its referred subplan to the working list.

The problem is when we adjust the motion type of the first subplan in the list; in this case, it is 
(select b from gs_tab t2 where c in ...).  After optimizing, the subplan looks like as below:
```
Motion
    motiontype: gather
    flow: [flotype=FLOW_SINGLETON locustype=CdbLocusType_Entry]
    > seqscan
        qual: [...]
        flow: [flotype=FLOW_PARTITIONED locustype=CdbLocusType_Hashed]
```

The type of outer query is FLOW_PARTITIONED, according to the func logic, we will create a
A new broadcast motion will replace the old gather motion.

However, the flow type of subplan below the new motion is assigned the wrong type. In this case, the seqscan's
flow changed to [flotype=FLOW_SINGLETON locustype=CdbLocusType_Entry].

When we process the second subplan(e.g., select c from gs_tab t3), its plan looks like as below:
```
Motion
    motiontype: gather
    flow: [flotype=FLOW_SINGLETON locustype=CdbLocusType_Entry]
    > seqscan
        flow: [flotype=FLOW_PARTITIONED locustype=CdbLocusType_Hashed]
```

The outer_query_flow is FLOW_SINGLETON; according to the logic, its motion type will not change.
The correct motion type should be broadcast. So, an "unexpected gang size" error will be reported.