### PR TITLE
Fix wrong join_rel size estimates for anti join.

### DIFF
--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -406,14 +406,7 @@ clauselist_selectivity_ext(PlannerInfo *root,
 	}
 
 	pfree(rgsel);
-	/* 
-	 * For Anti Semi Join, selectivity is determined by the fraction of 
-	 * tuples that do no match 
-	 */
-	if (JOIN_ANTI == jointype || JOIN_LASJ_NOTIN == jointype)
-	{
-		s1 = (1 - s1);
-	}
+
 	return s1;
 }
 

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -48,6 +48,34 @@ select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1
 (5 rows)
 
 --
+-- test anti_join/left_anti_semi_join selectivities
+--
+create table aj_t1(a int, b int, c int) distributed by (a);
+create table aj_t2(a int, b int, c int) distributed by (a);
+insert into aj_t1 values(1,1,1);
+insert into aj_t2 values(1,1,1),(2,2,2);
+explain(costs off) select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: ((t1.b = t2.b) AND (t1.c = t2.c))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: t1.b, t1.c
+               ->  Seq Scan on aj_t1 t1
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: t2.b, t2.c
+                     ->  Seq Scan on aj_t2 t2
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
+ a 
+---
+(0 rows)
+
+--
 -- test hash join
 --
 create table hjtest (i int, j int) distributed by (i,j);

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -48,6 +48,31 @@ select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1
 (5 rows)
 
 --
+-- test anti_join/left_anti_semi_join selectivities
+--
+create table aj_t1(a int, b int, c int) distributed by (a);
+create table aj_t2(a int, b int, c int) distributed by (a);
+insert into aj_t1 values(1,1,1);
+insert into aj_t2 values(1,1,1),(2,2,2);
+explain(costs off) select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: ((aj_t1.b = aj_t2.b) AND (aj_t1.c = aj_t2.c))
+         ->  Seq Scan on aj_t1
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on aj_t2
+ Optimizer: GPORCA
+(8 rows)
+
+select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
+ a 
+---
+(0 rows)
+
+--
 -- test hash join
 --
 create table hjtest (i int, j int) distributed by (i,j);

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -55,15 +55,15 @@ create table aj_t2(a int, b int, c int) distributed by (a);
 insert into aj_t1 values(1,1,1);
 insert into aj_t2 values(1,1,1),(2,2,2);
 explain(costs off) select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Anti Join
-         Hash Cond: ((aj_t1.b = aj_t2.b) AND (aj_t1.c = aj_t2.c))
-         ->  Seq Scan on aj_t1
+         Hash Cond: ((t1.b = t2.b) AND (t1.c = t2.c))
+         ->  Seq Scan on aj_t1 t1
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on aj_t2
+                     ->  Seq Scan on aj_t2 t2
  Optimizer: GPORCA
 (8 rows)
 

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -317,19 +317,19 @@ select c1 from t1 where c1 > 6 and c1 not in
 --
 explain select c1 from t1,t2 where c1 not in 
 	(select c3 from t3) and c1 = c2;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=5.38..8.62 rows=4 width=4)
-   ->  Hash Join  (cost=5.38..8.62 rows=2 width=4)
-         Hash Cond: (t1.c1 = t2.c2)
-         ->  Hash Left Anti Semi (Not-In) Join  (cost=2.26..5.46 rows=2 width=4)
-               Hash Cond: (t1.c1 = t3.c3)
-               ->  Seq Scan on t1  (cost=0.00..3.10 rows=4 width=4)
-               ->  Hash  (cost=2.15..2.15 rows=3 width=4)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..2.15 rows=3 width=4)
-                           ->  Seq Scan on t3  (cost=0.00..2.03 rows=1 width=4)
-         ->  Hash  (cost=3.05..3.05 rows=2 width=4)
-               ->  Seq Scan on t2  (cost=0.00..3.05 rows=2 width=4)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.12..3.25 rows=4 width=4)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=2.12..3.20 rows=1 width=4)
+         Hash Cond: (t1.c1 = t3.c3)
+         ->  Hash Join  (cost=1.04..2.10 rows=2 width=4)
+               Hash Cond: (t1.c1 = t2.c2)
+               ->  Seq Scan on t1  (cost=0.00..1.03 rows=3 width=4)
+               ->  Hash  (cost=1.02..1.02 rows=2 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..1.02 rows=2 width=4)
+         ->  Hash  (cost=1.05..1.05 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.05 rows=3 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..1.01 rows=1 width=4)
  Optimizer: Postgres query optimizer
 (12 rows)
 

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -25,6 +25,18 @@ insert into l values (1), (1), (2);
 select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1.a = 2 order by 1,2,3;
 
 --
+-- test anti_join/left_anti_semi_join selectivities
+--
+create table aj_t1(a int, b int, c int) distributed by (a);
+create table aj_t2(a int, b int, c int) distributed by (a);
+insert into aj_t1 values(1,1,1);
+insert into aj_t2 values(1,1,1),(2,2,2);
+
+explain(costs off) select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
+
+select t1.a from aj_t1 t1 where not exists (select 1 from aj_t2 t2 where t1.b = t2.b and t1.c = t2.c);
+
+--
 -- test hash join
 --
 


### PR DESCRIPTION
I found $SUBJECT when I did TPCH benchmark. In query 16, join rel size estimate has big gap with output of explain analyze.
Details are as below:
The 16th query is:
```
select
    p_brand,
    p_type,
    p_size,
    count(distinct ps_suppkey) as supplier_cnt
from
    partsupp,
    part
where
    p_partkey = ps_partkey
    and p_brand <> 'Brand#44'
    and p_type not like 'SMALL BURNISHED%'
    and p_size in (36, 27, 34, 45, 11, 6, 25, 16)
    and ps_suppkey not in (
        select
            s_suppkey
        from
            supplier
        where
            s_comment like '%Customer%Complaints%'
    )
group by
    p_brand,
    p_type,
    p_size
order by
    supplier_cnt desc,
    p_brand,
    p_type,
    p_size;
```

In Postgres planner, its plan looks like below:

```
                                                                                          QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=68817.76..68818.05 rows=20 width=44) (actual time=19394.798..19437.429 rows=27839 loops=1)
   Merge Key: (count(DISTINCT partsupp.ps_suppkey)), part.p_brand, part.p_type, part.p_size
   ->  Sort  (cost=68817.76..68817.78 rows=7 width=44) (actual time=18325.335..18328.372 rows=9410 loops=1)
         Sort Key: (count(DISTINCT partsupp.ps_suppkey)) DESC, part.p_brand, part.p_type, part.p_size
         Sort Method:  quicksort  Memory: 3570kB
         ->  GroupAggregate  (cost=68817.52..68817.67 rows=7 width=44) (actual time=17517.702..18287.814 rows=9410 loops=1)
               Group Key: part.p_brand, part.p_type, part.p_size
               ->  Sort  (cost=68817.52..68817.54 rows=7 width=40) (actual time=17517.529..17822.904 rows=400936 loops=1)
                     Sort Key: part.p_brand, part.p_type, part.p_size
                     Sort Method:  external merge  Disk: 60448kB
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=48369.10..68817.43 rows=7 width=40) (actual time=7132.199..15967.319 rows=400936 loops=1)
                           Hash Key: part.p_brand, part.p_type, part.p_size
                           ->  Hash Join  (cost=48369.10..68817.29 rows=7 width=40) (actual time=9108.262..11288.461 rows=396839 loops=1)
                                 Hash Cond: (part.p_partkey = partsupp.ps_partkey)
                                 Extra Text: (seg2)   Initial batch 0:
 (seg2)     Wrote 36480K bytes to inner workfile.
 (seg2)     Wrote 7456K bytes to outer workfile.
 (seg2)   Overflow batch 1:
 (seg2)     Read 36484K bytes from inner workfile.
 (seg2)     Read 7473K bytes from outer workfile.
 (seg2)   Hash chain length 5.4 avg, 28 max, using 493953 of 1048576 buckets.
                                 ->  Seq Scan on part  (cost=0.00..20051.67 rows=105720 width=40) (actual time=0.266..1208.562 rows=99260 loops=1)
                                       Filter: ((p_brand <> 'Brand#44'::bpchar) AND ((p_type)::text !~~ 'SMALL BURNISHED%'::text) AND (p_size = ANY ('{36,27,34,45,11,6,25,16}'::integer[])))
                                       Rows Removed by Filter: 567371
                                 ->  Hash  (cost=48369.01..48369.01 rows=8 width=8) (actual time=6876.148..6876.169 rows=2669156 loops=1)
                                       Buckets: 524288 (originally 262144)  Batches: 2 (originally 1)  Memory Usage: 59755kB
                                       ->  Hash Left Anti Semi (Not-In) Join  (cost=600.93..48369.01 rows=8 width=8) (actual time=39.783..5232.001 rows=2669156 loops=1)
                                             Hash Cond: (partsupp.ps_suppkey = supplier.s_suppkey)
                                             Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 56 of 262144 buckets.
                                             ->  Seq Scan on partsupp  (cost=0.00..41101.13 rows=2666513 width=8) (actual time=0.217..3245.678 rows=2670680 loops=1)
                                             ->  Hash  (cost=600.80..600.80 rows=10 width=4) (actual time=4.142..4.148 rows=56 loops=1)
                                                   Buckets: 262144  Batches: 1  Memory Usage: 2050kB
                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..600.80 rows=10 width=4) (actual time=0.032..4.086 rows=56 loops=1)
                                                         ->  Seq Scan on supplier  (cost=0.00..600.67 rows=3 width=4) (actual time=8.156..55.336 rows=22 loops=1)
                                                               Filter: ((s_comment)::text ~~ '%Customer%Complaints%'::text)
                                                               Rows Removed by Filter: 33189
 Planning Time: 16.820 ms
   (slice0)    Executor memory: 180K bytes.
   (slice1)    Executor memory: 52339K bytes avg x 3x(0) workers, 52346K bytes max (seg1).  Work_mem: 42602K bytes max.
 * (slice2)    Executor memory: 66128K bytes avg x 3x(0) workers, 66128K bytes max (seg0).  Work_mem: 59755K bytes max, 108360K bytes wanted.
   (slice3)    Executor memory: 113K bytes avg x 3x(0) workers, 113K bytes max (seg0).
 Memory used:  128000kB
 Memory wanted:  542599kB
 Optimizer: Postgres query optimizer
 Execution Time: 19475.738 ms
```

Let's look at the hashjoin part of above plan,
```
>  Hash Join  (cost=48369.10..68817.29 rows=7 width=40) (actual time=9108.262..11288.461 rows=396839 loops=1)
    Hash Cond: (part.p_partkey = partsupp.ps_partkey)
    ->  Seq Scan on part  (cost=0.00..20051.67 rows=105720 width=40) (actual time=0.266..1208.562 rows=99260 loops=1)
        Filter: ((p_brand <> 'Brand#44'::bpchar) AND ((p_type)::text !~~ 'SMALL BURNISHED%'::text) AND (p_size = ANY ('{36,27,34,45,11,6,25,16}'::integer[])))
        Rows Removed by Filter: 567371
    ->  Hash  (cost=48369.01..48369.01 rows=8 width=8) (actual time=6876.148..6876.169 rows=2669156 loops=1)
        Buckets: 524288 (originally 262144)  Batches: 2 (originally 1)  Memory Usage: 59755kB
        ->  Hash Left Anti Semi (Not-In) Join  (cost=600.93..48369.01 rows=8 width=8) (actual time=39.783..5232.001 rows=2669156 loops=1)
            Hash Cond: (partsupp.ps_suppkey = supplier.s_suppkey)
            ->  Seq Scan on partsupp  (cost=0.00..41101.13 rows=2666513 width=8) (actual time=0.217..3245.678 rows=2670680 loops=1)
            ->  Hash  (cost=600.80..600.80 rows=10 width=4) (actual time=4.142..4.148 rows=56 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2050kB
                ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..600.80 rows=10 width=4) (actual time=0.032..4.086 rows=56 loops=1)
                    ->  Seq Scan on supplier  (cost=0.00..600.67 rows=3 width=4) (actual time=8.156..55.336 rows=22 loops=1)
                        Filter: ((s_comment)::text ~~ '%Customer%Complaints%'::text)
                        Rows Removed by Filter: 33189
```

**The Hash Left Anti Semi(Not-In) Join size estimate has big gap with real execution. In this case rows = 8 vs rows = 2669156.**
For anti join,  the selectivity is determined by the fraction of tuples that do not match. But in current planner codes, we have two places that calculate anti join selectivity.
The first place at the calc_joinrel_size_estimate(), we have below codes:
```
		case JOIN_ANTI:
		case JOIN_LASJ_NOTIN:
			nrows = outer_rows * (1.0 - fkselec * jselec);
			nrows *= pselec;
			break;
```
And  the second  place at the end of clauselist_selectivity_ext(), we have below codes:
```
       /* 
	 * For Anti Semi Join, selectivity is determined by the fraction of 
	 * tuples that do no match 
	 */
	if (JOIN_ANTI == jointype || JOIN_LASJ_NOTIN == jointype)
	{
		s1 = (1 - s1);
	}
```
I think we should keep the first place just like upstream does,  otherwise, the selectivity of anti join is same with inner join.
Because in clauselist_selectivity_ext() we do "s1 = 1 - s1",  return from clauselist_selectivity_ext(), in calc_joinrel_size_estimate(),
we do "(1.0 - fkselec*jselec)" again.

In query 16 case, the anti join clause length is 1,  so we return directly in below code:
```
if (list_length(clauses) == 1)
		return clause_selectivity_ext(root, (Node *) linitial(clauses),
									  varRelid, jointype, sjinfo,
									  use_extended_stats, use_damping);
```
But for pselec, we  are not lucky, in this case, pselec is null, so it will run the end of clauselist_selectivity_ext(), and return s1=0.
So the join rel size is very small.
With this pr, query 16 plan looks like below:
```
                                                                                                QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=142534.89..144770.04 rows=157775 width=44) (actual time=17604.002..17644.780 rows=27839 loops=1)
   Merge Key: (count(DISTINCT partsupp.ps_suppkey)), part.p_brand, part.p_type, part.p_size
   ->  Sort  (cost=142534.89..142666.37 rows=52592 width=44) (actual time=17511.103..17514.690 rows=9410 loops=1)
         Sort Key: (count(DISTINCT partsupp.ps_suppkey)) DESC, part.p_brand, part.p_type, part.p_size
         Sort Method:  quicksort  Memory: 3570kB
         ->  GroupAggregate  (cost=132599.94..138411.04 rows=52592 width=44) (actual time=16559.956..17459.772 rows=9410 loops=1)
               Group Key: part.p_brand, part.p_type, part.p_size
               ->  Sort  (cost=132599.94..133656.98 rows=422814 width=40) (actual time=16559.757..16910.262 rows=400936 loops=1)
                     Sort Key: part.p_brand, part.p_type, part.p_size
                     Sort Method:  external merge  Disk: 60480kB
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=21974.09..93088.65 rows=422814 width=40) (actual time=1111.295..14910.234 rows=400936 loops=1)
                           Hash Key: part.p_brand, part.p_type, part.p_size
                           ->  Hash Left Anti Semi (Not-In) Join  (cost=21974.09..84632.36 rows=422814 width=40) (actual time=1307.675..11466.605 rows=396839 loops=1)
                                 Hash Cond: (partsupp.ps_suppkey = supplier.s_suppkey)
                                 Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 56 of 131072 buckets.
                                 ->  Hash Join  (cost=21373.17..78746.05 rows=422857 width=40) (actual time=1175.142..11022.790 rows=397040 loops=1)
                                       Hash Cond: (partsupp.ps_partkey = part.p_partkey)
                                       Extra Text: (seg0)   Hash chain length 1.4 avg, 7 max, using 69507 of 131072 buckets.
                                       ->  Seq Scan on partsupp  (cost=0.00..41101.13 rows=2666513 width=8) (actual time=3.526..8470.135 rows=2670680 loops=1)
                                       ->  Hash  (cost=20051.67..20051.67 rows=105720 width=40) (actual time=1168.854..1168.869 rows=99260 loops=1)
                                             Buckets: 131072  Batches: 1  Memory Usage: 8204kB
                                             ->  Seq Scan on part  (cost=0.00..20051.67 rows=105720 width=40) (actual time=0.346..1026.829 rows=99260 loops=1)
                                                   Filter: ((p_brand <> 'Brand#44'::bpchar) AND ((p_type)::text !~~ 'SMALL BURNISHED%'::text) AND (p_size = ANY ('{36,27,34,45,11,6,25,16}'::integer[])))
                                                   Rows Removed by Filter: 567371
                                 ->  Hash  (cost=600.80..600.80 rows=10 width=4) (actual time=84.655..84.656 rows=56 loops=1)
                                       Buckets: 131072  Batches: 1  Memory Usage: 1026kB
                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..600.80 rows=10 width=4) (actual time=8.873..84.547 rows=56 loops=1)
                                             ->  Seq Scan on supplier  (cost=0.00..600.67 rows=3 width=4) (actual time=51.387..126.987 rows=22 loops=1)
                                                   Filter: ((s_comment)::text ~~ '%Customer%Complaints%'::text)
                                                   Rows Removed by Filter: 33189
 Planning Time: 26.042 ms
   (slice0)    Executor memory: 181K bytes.
   (slice1)    Executor memory: 52182K bytes avg x 3x(0) workers, 52189K bytes max (seg1).  Work_mem: 42474K bytes max.
   (slice2)    Executor memory: 9546K bytes avg x 3x(0) workers, 9578K bytes max (seg0).  Work_mem: 8204K bytes max.
   (slice3)    Executor memory: 113K bytes avg x 3x(0) workers, 113K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution Time: 17701.394 ms
```
As you can see, this time the estimate is much more accurate. And the execution time is also 2 seconds faster. I'm guessing the performance gap will be even bigger if the s option changes bigger. In this case, I choose s = 10(e.g. 10GB).