### PR TITLE
Add RPM to build step

### DIFF
--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -364,7 +364,7 @@ jobs:
   ## ======================================================================
 
   build:
-    name: Build Apache Cloudberry
+    name: Build Apache Cloudberry RPM
     env:
       JOB_TYPE: build
     needs: [check-skip]


### PR DESCRIPTION

I am going to add an additional step that will build a Debian package. Since we will have two building steps, I have renamed the existing one to "Build Apache CloudBerry RPM". Suppose we add "Build Apache cloudberry DEB" in the next commit.


