### PR TITLE
Optimize Materialized View Status Maintenance for Partitioned Tables

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -553,7 +553,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	else
 		shouldDispatch = false;
 
-	if (GP_ROLE_DISPATCH == Gp_role && has_writable_operation)
+	if (IS_QD_OR_SINGLENODE() && has_writable_operation)
 	{
 		InitExtendProtocolData();
 	}

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -114,4 +114,31 @@ extern void CdbDispatchCopyEnd(struct CdbCopy *cdbCopy);
 
 extern ParamListInfo deserializeExternParams(struct SerializedParams *sparams);
 
+/*
+ * Extended protocol for libpq.
+ */
+#define PQExtendProtocol 'e'
+
+typedef enum
+{
+	EP_TAG_I,	/* insert */
+	EP_TAG_U,	/* update */
+	EP_TAG_D,	/* delete */
+	EP_TAG_MAX,	/* the last, new added one should be put before this. */
+} ExtendProtocolSubTag;
+
+typedef struct ExtendProtocolDataStore
+{
+	List *subtagdata;	/* capacity of EP_TAG_MAX */
+	int	consumed_bitmap; /* bitmap to indentify subtag consumed status */
+} ExtendProtocolDataStore;
+
+typedef ExtendProtocolDataStore* ExtendProtocolData;
+
+extern ExtendProtocolData epd;
+
+extern void InitExtendProtocolData(void);
+
+extern void ConsumeExtendProtocolData(ExtendProtocolSubTag subtag, void *consume_p);
+
 #endif   /* CDBDISP_QUERY_H */

--- a/src/include/cdb/cdbpq.h
+++ b/src/include/cdb/cdbpq.h
@@ -25,4 +25,9 @@ extern PGcmdQueueEntry *pqAllocCmdQueueEntry(PGconn *conn);
 extern void pqRecycleCmdQueueEntry(PGconn *conn, PGcmdQueueEntry *entry);
 extern void pqAppendCmdQueueEntry(PGconn *conn, PGcmdQueueEntry *entry);
 
+/*
+ * Handle extend protocol aside from upstream.
+ */
+extern bool HandleExtendProtocol(PGconn *conn);
+
 #endif

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1349,6 +1349,12 @@ typedef struct ModifyTableState
 
 	/* controls transition table population for INSERT...ON CONFLICT UPDATE */
 	struct TransitionCaptureState *mt_oc_transition_capture;
+
+	/* Record modified leaf relation(s) */
+	bool		has_leaf_changed;
+	Bitmapset	*mt_leaf_relids_inserted;
+	Bitmapset	*mt_leaf_relids_updated;
+	Bitmapset	*mt_leaf_relids_deleted;
 } ModifyTableState;
 
 /* ----------------

--- a/src/test/regress/expected/aqumv.out
+++ b/src/test/regress/expected/aqumv.out
@@ -3181,7 +3181,7 @@ create materialized view mv_par1 as select   count(*) from par_1_prt_1;
 create materialized view mv_par1_1 as select count(*) from par_1_prt_1_2_prt_1;
 create materialized view mv_par1_2 as select count(*) from par_1_prt_1_2_prt_2;
 create materialized view mv_par2 as select   count(*) from par_1_prt_2;
-create materialized view mv_par2_2 as select count(*) from par_1_prt_2_2_prt_1;
+create materialized view mv_par2_1 as select count(*) from par_1_prt_2_2_prt_1;
 create materialized view mv_par_prune as select count(*) from par where b = 1;
 set enable_answer_query_using_materialized_views = on;
 explain(costs off, verbose)

--- a/src/test/regress/expected/aqumv.out
+++ b/src/test/regress/expected/aqumv.out
@@ -3239,6 +3239,73 @@ reset enable_partition_pruning;
 --
 -- End of test partitioned tables
 --
+begin;
+insert into par values(1, 1, 1), (1, 1, 2);
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: count
+   ->  Seq Scan on aqumv.mv_par2
+         Output: count
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+insert into par_1_prt_1_2_prt_1 values (1, 1, 1);
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: count
+   ->  Seq Scan on aqumv.mv_par2
+         Output: count
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+delete from par_1_prt_1_2_prt_1;
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: count
+   ->  Seq Scan on aqumv.mv_par2
+         Output: count
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+update par set c = 2 where b = 1 and c = 1;
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: count
+   ->  Seq Scan on aqumv.mv_par2
+         Output: count
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+update par set c = 2, a = 2 where  b = 1 and c = 1;
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: count
+   ->  Seq Scan on aqumv.mv_par2
+         Output: count
+ Settings: enable_answer_query_using_materialized_views = 'on', optimizer = 'off'
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+abort;
 reset optimizer;
 reset enable_answer_query_using_materialized_views;
 -- start_ignore

--- a/src/test/regress/expected/matview_data.out
+++ b/src/test/regress/expected/matview_data.out
@@ -491,7 +491,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1_1 | i
  mv_par1   | i
  mv_par    | i
- mv_par2   | i
+ mv_par2   | u
 (6 rows)
 
 refresh materialized view mv_par;

--- a/src/test/regress/expected/matview_data.out
+++ b/src/test/regress/expected/matview_data.out
@@ -454,7 +454,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create materialized view mv_par2 as select * from  par_1_prt_2;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create materialized view mv_par2_2 as select * from  par_1_prt_2_2_prt_1;
+create materialized view mv_par2_1 as select * from  par_1_prt_2_2_prt_1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
@@ -465,7 +465,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1_1 | u
  mv_par1_2 | u
  mv_par2   | u
- mv_par2_2 | u
+ mv_par2_1 | u
 (6 rows)
 
 insert into par_1_prt_1 values (1, 1, 1);
@@ -473,11 +473,11 @@ insert into par_1_prt_1 values (1, 1, 1);
 select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
   mvname   | datastatus 
 -----------+------------
+ mv_par1_2 | u
  mv_par2   | u
- mv_par2_2 | u
- mv_par1   | i
+ mv_par2_1 | u
  mv_par1_1 | i
- mv_par1_2 | i
+ mv_par1   | i
  mv_par    | i
 (6 rows)
 
@@ -486,12 +486,12 @@ insert into par values (1, 2, 2);
 select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
   mvname   | datastatus 
 -----------+------------
- mv_par1   | i
+ mv_par1_2 | u
+ mv_par2_1 | u
  mv_par1_1 | i
- mv_par1_2 | i
+ mv_par1   | i
  mv_par    | i
  mv_par2   | i
- mv_par2_2 | i
 (6 rows)
 
 refresh materialized view mv_par;
@@ -499,7 +499,7 @@ refresh materialized view mv_par1;
 refresh materialized view mv_par1_1;
 refresh materialized view mv_par1_2;
 refresh materialized view mv_par2;
-refresh materialized view mv_par2_2;
+refresh materialized view mv_par2_1;
 begin;
 insert into par_1_prt_2_2_prt_1 values (1, 2, 1);
 -- mv_par1* should not be updated
@@ -509,7 +509,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1   | u
  mv_par1_1 | u
  mv_par1_2 | u
- mv_par2_2 | i
+ mv_par2_1 | i
  mv_par2   | i
  mv_par    | i
 (6 rows)
@@ -524,7 +524,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1   | u
  mv_par1_1 | u
  mv_par1_2 | u
- mv_par2_2 | e
+ mv_par2_1 | e
  mv_par2   | e
  mv_par    | e
 (6 rows)
@@ -538,7 +538,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1   | u
  mv_par1_1 | u
  mv_par1_2 | u
- mv_par2_2 | e
+ mv_par2_1 | e
  mv_par2   | e
  mv_par    | e
 (6 rows)
@@ -548,14 +548,14 @@ refresh materialized view mv_par1;
 refresh materialized view mv_par1_1;
 refresh materialized view mv_par1_2;
 refresh materialized view mv_par2;
-refresh materialized view mv_par2_2;
+refresh materialized view mv_par2_1;
 vacuum full par_1_prt_1_2_prt_1;
 select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
   mvname   | datastatus 
 -----------+------------
  mv_par1_2 | u
  mv_par2   | u
- mv_par2_2 | u
+ mv_par2_1 | u
  mv_par1_1 | r
  mv_par1   | r
  mv_par    | r
@@ -566,7 +566,7 @@ refresh materialized view mv_par1;
 refresh materialized view mv_par1_1;
 refresh materialized view mv_par1_2;
 refresh materialized view mv_par2;
-refresh materialized view mv_par2_2;
+refresh materialized view mv_par2_1;
 vacuum full par;
 -- all should be updated.
 select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
@@ -574,7 +574,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
 -----------+------------
  mv_par2   | r
  mv_par    | r
- mv_par2_2 | r
+ mv_par2_1 | r
  mv_par1_2 | r
  mv_par1   | r
  mv_par1_1 | r
@@ -585,7 +585,7 @@ refresh materialized view mv_par1;
 refresh materialized view mv_par1_1;
 refresh materialized view mv_par1_2;
 refresh materialized view mv_par2;
-refresh materialized view mv_par2_2;
+refresh materialized view mv_par2_1;
 begin;
 create table par_1_prt_1_2_prt_3  partition of par_1_prt_1 for values from  (3) to (4);
 NOTICE:  table has parent, setting distribution columns to match parent table
@@ -596,7 +596,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1_1 | u
  mv_par1_2 | u
  mv_par2   | u
- mv_par2_2 | u
+ mv_par2_1 | u
  mv_par1   | e
  mv_par    | e
 (6 rows)
@@ -613,7 +613,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
   mvname   | datastatus 
 -----------+------------
  mv_par2   | u
- mv_par2_2 | u
+ mv_par2_1 | u
  mv_par    | e
 (3 rows)
 
@@ -627,7 +627,7 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1_1 | u
  mv_par1_2 | u
  mv_par2   | u
- mv_par2_2 | u
+ mv_par2_1 | u
  mv_par1   | e
  mv_par    | e
 (6 rows)
@@ -645,12 +645,177 @@ select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
  mv_par1_1 | u
  mv_par1_2 | u
  mv_par2   | u
- mv_par2_2 | u
+ mv_par2_1 | u
  mv_par1   | e
  mv_par    | e
 (6 rows)
 
 abort;
+--
+-- Maintain materialized views on partitioned tables from bottom to up.
+--
+insert into par values(1, 1, 1), (1, 1, 2), (2, 2, 1), (2, 2, 2);
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_1;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+insert into par values(1, 1, 1), (1, 1, 2);
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_1 | i
+ mv_par1   | i
+ mv_par    | i
+ mv_par1_2 | i
+(6 rows)
+
+abort;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+insert into par_1_prt_2_2_prt_1 values(2, 2, 1);
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | i
+ mv_par2   | i
+ mv_par    | i
+(6 rows)
+
+abort;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+delete from par where b = 2  and c = 1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | e
+ mv_par2   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+delete from par_1_prt_1_2_prt_2;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_2 | e
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+-- Across partition update.
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+update par set c = 2 where b = 1 and c = 1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_2 | i
+ mv_par1_1 | e
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+-- Split Update with acrosss partition update.
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+update par set c = 2, a = 2 where  b = 1 and c = 1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_2 | i
+ mv_par1_1 | e
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+--
+-- End of Maintain materialized views on partitioned tables from bottom to up.
+--
 --start_ignore
 drop schema matview_data_schema cascade;
 NOTICE:  drop cascades to 3 other objects

--- a/src/test/regress/sql/aqumv.sql
+++ b/src/test/regress/sql/aqumv.sql
@@ -809,7 +809,7 @@ create materialized view mv_par1 as select   count(*) from par_1_prt_1;
 create materialized view mv_par1_1 as select count(*) from par_1_prt_1_2_prt_1;
 create materialized view mv_par1_2 as select count(*) from par_1_prt_1_2_prt_2;
 create materialized view mv_par2 as select   count(*) from par_1_prt_2;
-create materialized view mv_par2_2 as select count(*) from par_1_prt_2_2_prt_1;
+create materialized view mv_par2_1 as select count(*) from par_1_prt_2_2_prt_1;
 create materialized view mv_par_prune as select count(*) from par where b = 1;
 set enable_answer_query_using_materialized_views = on;
 
@@ -829,6 +829,28 @@ reset enable_partition_pruning;
 --
 -- End of test partitioned tables
 --
+
+begin;
+insert into par values(1, 1, 1), (1, 1, 2);
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+
+insert into par_1_prt_1_2_prt_1 values (1, 1, 1);
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+
+delete from par_1_prt_1_2_prt_1;
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+
+update par set c = 2 where b = 1 and c = 1;
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+
+update par set c = 2, a = 2 where  b = 1 and c = 1;
+explain(costs off, verbose)
+select count(*) from par_1_prt_2;
+abort;
 
 reset optimizer;
 reset enable_answer_query_using_materialized_views;

--- a/src/test/singlenode_regress/expected/matview_data.out
+++ b/src/test/singlenode_regress/expected/matview_data.out
@@ -403,6 +403,390 @@ select mvname, datastatus from gp_matview_aux where mvname in ('tri_mv1', 'tri_m
 
 drop trigger trigger_insert_tri_t2 on tri_t1;
 drop function trigger_insert_tri_t2;
+-- test partitioned tables
+create table par(a int, b int, c int) partition by range(b)
+    subpartition by range(c) subpartition template (start (1) end (3) every (1))
+    (start(1) end(3) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into par values(1, 1, 1), (1, 1, 2), (2, 2, 1), (2, 2, 2);
+create materialized view mv_par as select * from par;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par1 as select * from  par_1_prt_1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par1_1 as select * from par_1_prt_1_2_prt_1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par1_2 as select * from par_1_prt_1_2_prt_2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par2 as select * from  par_1_prt_2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_par2_1 as select * from  par_1_prt_2_2_prt_1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+insert into par_1_prt_1 values (1, 1, 1);
+-- mv_par1* shoud be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_1 | i
+ mv_par1   | i
+ mv_par    | i
+(6 rows)
+
+insert into par values (1, 2, 2);
+-- mv_par* should be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_2 | u
+ mv_par2_1 | u
+ mv_par1_1 | i
+ mv_par1   | i
+ mv_par    | i
+ mv_par2   | u
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_1;
+begin;
+insert into par_1_prt_2_2_prt_1 values (1, 2, 1);
+-- mv_par1* should not be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | i
+ mv_par2   | i
+ mv_par    | i
+(6 rows)
+
+abort;
+begin;
+truncate par_1_prt_2;
+-- mv_par1* should not be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | e
+ mv_par2   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+truncate par_1_prt_2;
+-- mv_par1* should not be updated
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | e
+ mv_par2   | e
+ mv_par    | e
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_1;
+vacuum full par_1_prt_1_2_prt_1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_1 | r
+ mv_par1   | r
+ mv_par    | r
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_1;
+vacuum full par;
+-- all should be updated.
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | r
+ mv_par    | r
+ mv_par2_1 | r
+ mv_par1_2 | r
+ mv_par1   | r
+ mv_par1_1 | r
+(6 rows)
+
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_1;
+begin;
+create table par_1_prt_1_2_prt_3  partition of par_1_prt_1 for values from  (3) to (4);
+NOTICE:  table has parent, setting distribution columns to match parent table
+-- update status when partition of
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+begin;
+drop table par_1_prt_1 cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to materialized view mv_par1_1
+drop cascades to materialized view mv_par1_2
+drop cascades to materialized view mv_par1
+-- update status when drop table 
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par    | e
+(3 rows)
+
+abort;
+begin;
+alter table par_1_prt_1 detach partition par_1_prt_1_2_prt_1;
+-- update status when detach
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+begin;
+create table new_par(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- update status when attach
+alter table par_1_prt_1 attach partition new_par for values from (4) to (5);
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+--
+-- Maintain materialized views on partitioned tables from bottom to up.
+--
+insert into par values(1, 1, 1), (1, 1, 2), (2, 2, 1), (2, 2, 2);
+refresh materialized view mv_par;
+refresh materialized view mv_par1;
+refresh materialized view mv_par1_1;
+refresh materialized view mv_par1_2;
+refresh materialized view mv_par2;
+refresh materialized view mv_par2_1;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+insert into par values(1, 1, 1), (1, 1, 2);
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_1 | i
+ mv_par1   | i
+ mv_par    | i
+ mv_par1_2 | i
+(6 rows)
+
+abort;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+insert into par_1_prt_2_2_prt_1 values(2, 2, 1);
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | i
+ mv_par2   | i
+ mv_par    | i
+(6 rows)
+
+abort;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+delete from par where b = 2  and c = 1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2_1 | e
+ mv_par2   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+delete from par_1_prt_1_2_prt_2;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par1_1 | u
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_2 | e
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+-- Across partition update.
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+update par set c = 2 where b = 1 and c = 1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_2 | i
+ mv_par1_1 | e
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+-- Split Update with acrosss partition update.
+begin;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par    | u
+ mv_par1   | u
+ mv_par1_1 | u
+ mv_par1_2 | u
+ mv_par2   | u
+ mv_par2_1 | u
+(6 rows)
+
+update par set c = 2, a = 2 where  b = 1 and c = 1;
+select mvname, datastatus from gp_matview_aux where mvname like 'mv_par%';
+  mvname   | datastatus 
+-----------+------------
+ mv_par2   | u
+ mv_par2_1 | u
+ mv_par1_2 | i
+ mv_par1_1 | e
+ mv_par1   | e
+ mv_par    | e
+(6 rows)
+
+abort;
+--
+-- End of Maintain materialized views on partitioned tables from bottom to up.
+--
 -- start_ignore
 drop schema matview_data_schema cascade;
 NOTICE:  drop cascades to 9 other objects


### PR DESCRIPTION
Previously, write operations on partitioned tables would alter the materialized view (MV) status of both ancestor and descendant tables, leading to unnecessary invalidations of MVs that depended on unaffected partitions. 

This commit introduces a more efficient approach to updating MV statuses for partitioned tables by focusing on leaf partitions that have actually undergone data changes.

## example:

```sql
create table par(a int, b int, c int) partition by range(b)
    subpartition by range(c) subpartition template (start (1) end (3) every (1))
    (start(1) end(3) every(1));
insert into par values(1, 1, 1), (1, 1, 2), (2, 2, 1), (2, 2, 2);
create materialized view mv_par as select * from par;
create materialized view mv_par1 as select * from  par_1_prt_1;
create materialized view mv_par1_1 as select * from par_1_prt_1_2_prt_1;
create materialized view mv_par1_2 as select * from par_1_prt_1_2_prt_2;
create materialized view mv_par2 as select * from  par_1_prt_2;
create materialized view mv_par2_2 as select * from  par_1_prt_2_2_prt2;
```
<div align="center">
  <img src="https://github.com/user-attachments/assets/9688221a-1822-4010-bf0a-67d5f9a0c8cc" alt="Description">
</div>

### INSERT INTO Partitioned Table
```sql
INSERT INTO P1 VALUES (1, 1, 1);
```
#### before this commit:

<div align="center">
  <img src="https://github.com/user-attachments/assets/1f77a1c7-964a-4892-a74b-3edf9ddc503f" alt="Description">
</div>

It is known that data was successfully inserted into P1, which is a descendant node of P0. Due to the increased data, the status needs to be propagated upwards to invalidate the materialized view MV_0 based on P0.

At the same time, P1 is a partitioned table, and it also needs to propagate the status downwards to its child tables. Since it is unclear which child tables have undergone data changes, all materialized views of the child tables must be invalidated.

Consequently, the materialized views MV_0, MV_1, MV_1_1, and MV_1_2 are all invalidated.

#### after this commit:

<div align="center">
  <img src="https://github.com/user-attachments/assets/ce28995b-eaaf-4266-9e97-e400997590dd" alt="Description">
</div>

When data is inserted into a partitioned table, it is ultimately routed to the child tables at the leaf nodes. The system monitors these leaf nodes for any data changes and propagates the status upward, while ignoring the changes directly made to the partition table P0 in the SQL.

The tuple (1, 1, 1) will be routed to the partition P1_1, invalidating the materialized views of P1_1 and its ancestor partition tables. In contrast, the other sub-partition P1_2 experiences no data changes, so the materialized view MV_1_2 remains valid.

As a result, the materialized views MV_0, MV_1, and MV_1_1 are invalidated, while MV_1_2 remains unaffected.

The new approach allows for status propagation only from the leaf nodes upward, rather than sending status updates in both directions through the intermediate nodes of the partition tree. This safeguards unrelated materialized views from unnecessary refreshes.

### (Split) Across Partition Update on root table
```sql
UPDATE P0 SET c = 2 WHERE b = 2 AND c = 1;
```
#### before this commit:

<div align="center">
  <img src="https://github.com/user-attachments/assets/80caa835-e5b5-4cc6-a095-1519720218dd" alt="Description">
</div>

When the data in the root node is updated, and since it is unclear which specific child table was updated, the status is propagated downwards to all descendant child tables.

As a result, all materialized views based on the partition tree are invalidated: MV_0, MV_1, MV_1_1, MV_1_2, and MV_2_2.

#### after this commit:

<div align="center">
  <img src="https://github.com/user-attachments/assets/32c51952-a78f-4d23-9c47-97090a808f11" alt="Description">
</div>

Since `c` is the partition key, updating the partition key will cause data movement **across partitions** in the child tables. The **UPDATE** operation on the parent table will be translated into an **INSERT** for one child table and a **DELETE** for another.

The system monitors the changed leaf node child tables: P2_1 and P2_2, and only propagates their respective statuses upward, invalidating the materialized views based on their ancestor tables. The materialized views related to the left subtree P1 remain unaffected.

As a result, MV_0 and MV_2_2 are invalidated, while MV_1, MV_1_1, and MV_1_2 remain valid.

## Extend protocol of libpq

The executor (QE) records the modified partition child tables during the data modification process. A mechanism is needed to transmit these results to the QD for updating the metadata. The libpq protocol has been extended to support this data transfer.

### Processing on the QE and QD sides:

<div align="center">
  <img src="https://github.com/user-attachments/assets/419bb47e-83b0-43ab-8f5a-2299dcab8d5d" alt="Description">
</div>

Each QE records the IDs of the child tables it has modified, deduplicates them in a local bitmap, and sends this information to the QD.

The data changes on each segment node may not be the same. For example, in the diagram, seg0 has changes in two tables, while seg1 has no changes (as the data to be updated is not located on the seg1 node due to distribution).

The QD collects multiple bitmaps returned from the segment nodes and consolidates them into a single bitmap, removing duplicate relids. This deduplicated bitmap is then used to update the status of the ancestor nodes.

### Extend Protocol Design

<div align="center">
  <img src="https://github.com/user-attachments/assets/301e7de8-dd21-4b7e-a4af-f875f9d527ea" alt="Description">
</div>

Based on libpq, the protocol has been extended with an **'e'** protocol, which stands for "extend protocol," to unify the handling of information returns.

Each transmission begins with the **'e'** protocol, followed immediately by data blocks. A single transmission can carry multiple data blocks.

Each data block corresponds to a specific type of data and is distinguished by a **subtag**. Following the subtag is a 32-bit integer, **num**, which indicates the total number of relids in the subsequent array.

The relid array follows the num value. After all data blocks have been written, the transmission concludes with a **subtag_max**.

The **subtag_max**, which belongs to the same enum category as the **subtag**, is specifically used to indicate the termination of an extended protocol transmission.

## Key changes:

- Leaf Partition Tracking: Instead of updating the MV status based on the parent table, we now detect and track changes at the leaf partition level. This ensures that only partitions with actual data modifications trigger MV status updates, significantly reducing unnecessary refreshes.

- Cross-Partition Updates: For operations like UPDATEs that span multiple partitions (e.g., decomposed into an INSERT on one leaf and a DELETE on another), the MV status is updated based on the real data state of the affected leaf partitions, rather than propagating changes through the parent table. This avoids invalidating MVs that depend on unrelated partitions.

- Executor Enhancements: The executor now detects dynamic partition expansion during query execution and records data modification bitmaps for each partition on the QE. These bitmaps are aggregated on the QD to update MV statuses accurately.

- Protocol Extension: The libpq protocol has been extended to handle QE feedback uniformly, ensuring that partition-level modification information is properly collected and consumed by the QD.

This optimization minimizes the impact on MVs by ensuring that only relevant partitions trigger status updates, improving performance and reducing unnecessary invalidations.

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
