### PR TITLE
Remove the HTBL in motion

### DIFF
--- a/contrib/interconnect/ic_common.c
+++ b/contrib/interconnect/ic_common.c
@@ -296,9 +296,6 @@ createChunkTransportState(ChunkTransportState * transportStates,
 	for (i = 0; i < pEntry->numConns; i++)
 	{
 		MotionConn *conn = NULL;
-		MotionConnKey motion_conn_key;
-		MotionConnSentRecordTypmodEnt *motion_conn_ent;
-
 		getMotionConn(pEntry, i, &conn);
 
 		/* Initialize MotionConn entry. */
@@ -310,13 +307,7 @@ createChunkTransportState(ChunkTransportState * transportStates,
 		conn->stopRequested = false;
 		conn->cdbProc = NULL;
 		conn->remapper = NULL;
-
-		motion_conn_key.mot_node_id = motNodeID;
-		motion_conn_key.conn_index = i;
-
-		motion_conn_ent = (MotionConnSentRecordTypmodEnt *) hash_search(transportStates->conn_sent_record_typmod,
-																		&motion_conn_key, HASH_ENTER, NULL);
-		motion_conn_ent->sent_record_typmod = 0;
+		conn->sent_record_typmod = 0;
 	}
 
 	return pEntry;
@@ -542,6 +533,24 @@ GetMotionConnTupleRemapper(ChunkTransportState * transportStates,
 	Assert(conn);
 
 	return conn->remapper;
+}
+
+
+int32 *
+GetMotionSentRecordTypmod(ChunkTransportState * transportStates,
+						   int16 motNodeID,
+						   int16 targetRoute)
+{
+	MotionConn *conn;
+	ChunkTransportStateEntry *pEntry = NULL;
+	getChunkTransportState(transportStates, motNodeID, &pEntry);
+
+	if (targetRoute == BROADCAST_SEGIDX)
+		conn = &pEntry->conns[0];
+	else
+		conn = &pEntry->conns[targetRoute];
+
+	return &conn->sent_record_typmod;
 }
 
 /*

--- a/contrib/interconnect/ic_common.h
+++ b/contrib/interconnect/ic_common.h
@@ -137,6 +137,11 @@ extern TupleRemapper * GetMotionConnTupleRemapper(ChunkTransportState *transport
 		int16 motNodeID,
 		int16 targetRoute);
 
+int32 *
+GetMotionSentRecordTypmod(ChunkTransportState * transportStates,
+								   int16 motNodeID,
+								   int16 targetRoute);
+
 extern void DirectPutRxBufferTCP(ChunkTransportState *transportStates, int motNodeID, int route);
 extern uint32 GetActiveMotionConnsTCP(void);
 #endif

--- a/contrib/interconnect/ic_internal.h
+++ b/contrib/interconnect/ic_internal.h
@@ -87,6 +87,15 @@ typedef struct MotionConn
 										 * play it safe */
 
 	/*
+	 * used by the sender.
+	 *
+	 * the typmod of last sent record type in current connection,
+	 * if the connection is for broadcasting then we only check
+	 * and update this attribute on connection 0.
+	 */
+	int32		 sent_record_typmod;
+
+	/*
 	 * used by the receiver.
 	 *
 	 * all the remap information.

--- a/contrib/interconnect/ic_modules.c
+++ b/contrib/interconnect/ic_modules.c
@@ -59,6 +59,7 @@ MotionIPCLayer tcp_ipc_layer = {
 #endif
 
     .GetMotionConnTupleRemapper = GetMotionConnTupleRemapper,
+    .GetMotionSentRecordTypmod = GetMotionSentRecordTypmod,
 };
 
 MotionIPCLayer proxy_ipc_layer = {
@@ -97,6 +98,7 @@ MotionIPCLayer proxy_ipc_layer = {
 #endif
 
     .GetMotionConnTupleRemapper = GetMotionConnTupleRemapper,
+    .GetMotionSentRecordTypmod = GetMotionSentRecordTypmod,
 };
 
 
@@ -136,6 +138,7 @@ MotionIPCLayer udpifc_ipc_layer = {
 #endif
 
     .GetMotionConnTupleRemapper = GetMotionConnTupleRemapper,
+    .GetMotionSentRecordTypmod = GetMotionSentRecordTypmod,
 };
 
 void

--- a/contrib/interconnect/tcp/ic_tcp.c
+++ b/contrib/interconnect/tcp/ic_tcp.c
@@ -1283,7 +1283,6 @@ SetupTCPInterconnect(EState *estate)
 	/* we can have at most one of these. */
 	ChunkTransportStateEntry *sendingChunkTransportState = NULL;
 	ChunkTransportState *interconnect_context;
-	HASHCTL		conn_sent_record_typmod_ctl;
 
 	SIMPLE_FAULT_INJECTOR("interconnect_setup_palloc");
 	interconnect_context = palloc0(sizeof(ChunkTransportState));
@@ -1299,13 +1298,6 @@ SetupTCPInterconnect(EState *estate)
 	interconnect_context->incompleteConns = NIL;
 	interconnect_context->sliceTable = copyObject(sliceTable);
 	interconnect_context->sliceId = sliceTable->localSlice;
-
-	conn_sent_record_typmod_ctl.keysize = sizeof(MotionConnKey);
-	conn_sent_record_typmod_ctl.entrysize = sizeof(MotionConnSentRecordTypmodEnt);
-	conn_sent_record_typmod_ctl.hcxt = CurrentMemoryContext;
-
-	interconnect_context->conn_sent_record_typmod = hash_create(
-																"MotionConn sent record typmod mapping", 128, &conn_sent_record_typmod_ctl, HASH_CONTEXT | HASH_ELEM | HASH_BLOBS);
 
 #ifdef ENABLE_IC_PROXY
 	ic_proxy_backend_init_context(interconnect_context);
@@ -2177,8 +2169,6 @@ TeardownTCPInterconnect(ChunkTransportState * transportStates, bool hasErrors)
 
 	if (transportStates->states != NULL)
 		pfree(transportStates->states);
-	if (transportStates->conn_sent_record_typmod)
-		hash_destroy(transportStates->conn_sent_record_typmod);
 
 	pfree(transportStates);
 

--- a/contrib/interconnect/udp/ic_udpifc.c
+++ b/contrib/interconnect/udp/ic_udpifc.c
@@ -3062,7 +3062,6 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 
 	ChunkTransportStateEntry *sendingChunkTransportState = NULL;
 	ChunkTransportState *interconnect_context;
-	HASHCTL conn_sent_record_typmod_ctl;
 
 	pthread_mutex_lock(&ic_control_info.lock);
 
@@ -3085,10 +3084,6 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 		ic_control_info.ic_instance_id = sliceTable->ic_instance_id;
 	}
 
-	conn_sent_record_typmod_ctl.keysize = sizeof(MotionConnKey);
-	conn_sent_record_typmod_ctl.entrysize = sizeof(MotionConnSentRecordTypmodEnt);
-	conn_sent_record_typmod_ctl.hcxt = CurrentMemoryContext;
-
 	interconnect_context = palloc0(sizeof(ChunkTransportState));
 
 	/* initialize state variables */
@@ -3102,8 +3097,6 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 	interconnect_context->incompleteConns = NIL;
 	interconnect_context->sliceTable = copyObject(sliceTable);
 	interconnect_context->sliceId = sliceTable->localSlice;
-	interconnect_context->conn_sent_record_typmod = hash_create(
-        "MotionConn sent record typmod mapping", 128, &conn_sent_record_typmod_ctl, HASH_CONTEXT | HASH_ELEM | HASH_BLOBS);
 
 	mySlice = &interconnect_context->sliceTable->slices[sliceTable->localSlice];
 
@@ -3742,8 +3735,6 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 			pfree(transportStates->states);
 			transportStates->states = NULL;
 		}
-		if (transportStates->conn_sent_record_typmod)
-			hash_destroy(transportStates->conn_sent_record_typmod);
 		pfree(transportStates);
 	}
 

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -178,18 +178,6 @@ struct ChunkTransportStateEntry;
 typedef struct MotionConn MotionConn;
 typedef struct ChunkTransportStateEntry ChunkTransportStateEntry;
 
-typedef struct MotionConnKey 
-{
-	int mot_node_id;
-	int conn_index;
-} MotionConnKey;
-
-typedef struct MotionConnSentRecordTypmodEnt
-{
-	MotionConnKey key;
-	int32 sent_record_typmod;
-} MotionConnSentRecordTypmodEnt;
-
 typedef struct ChunkTransportState
 {
 	/* array of per-motion-node chunk transport state
@@ -222,17 +210,6 @@ typedef struct ChunkTransportState
 
 	/* Estate pointer for this statement */
 	struct EState *estate;
-
-	/*
-	 * used by the sender.
-	 *
-	 * the typmod of last sent record type in current connection,
-	 * if the connection is for broadcasting then we only check
-	 * and update this attribute on connection 0.
-	 * 
-	 * mapping the MotionConn -> int32
-	 */
-	HTAB* conn_sent_record_typmod;
 
 	/* ic_proxy backend context */
 	struct ICProxyBackendContext *proxyContext;

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -285,6 +285,10 @@ typedef struct MotionIPCLayer
 		int16 motNodeID,
 		int16 targetRoute);
 
+	int32 *(*GetMotionSentRecordTypmod)  (ChunkTransportState *transportStates,
+		int16 motNodeID,
+		int16 targetRoute);
+
 } MotionIPCLayer;
 
 /* MotionIPCLayer selected */


### PR DESCRIPTION
In the previous interconnect modular reconstruction, `MotionConn` was no longer exposed to the CBDB kernel method, and we add a HashTable used to cache `sent_record_typmod`. This change requires a `hash_search` operation every time `motion->sendtuple` is called.

Current change adds the `GetMotionSentRecordTypmod` method so that motion no longer needs to obtain `sent_record_typmod` from HashTable.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
