### PR TITLE
Revert "Prepare GUC option string only once during gang creation"

### DIFF
--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -51,8 +51,6 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	PostgresPollingStatusType	*pollingStatus = NULL;
 	SegmentDatabaseDescriptor	*segdbDesc = NULL;
 	struct timeval	startTS;
-	char	   	*options = NULL;
-	char	   	*diff_options = NULL;
 	Gang	*newGangDefinition;
 	int		create_gang_retry_counter = 0;
 	int		in_recovery_mode_count = 0;
@@ -75,8 +73,6 @@ cdbgang_createGang_async(List *segments, SegmentType segmentType)
 	ELOG_DISPATCHER_DEBUG("createGang size = %d, segment type = %d", size, segmentType);
 
 	Assert(CurrentGangCreating == NULL);
-
-	makeOptions(&options, &diff_options);
 
 	/* If we're in a retry, we may need to reset our initial state, a bit */
 	newGangDefinition = NULL;
@@ -139,6 +135,8 @@ create_gang_retry:
 		{
 			bool		ret;
 			char		gpqeid[100];
+			char	   *options = NULL;
+			char	   *diff_options = NULL;
 
 			/*
 			 * Create the connection requests.	If we find a segment without a
@@ -172,6 +170,8 @@ create_gang_retry:
 				ereport(ERROR,
 						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						 errmsg("failed to construct connectionstring")));
+
+			makeOptions(&options, &diff_options);
 
 			/* start connection in asynchronous way */
 			cdbconn_doConnectStart(segdbDesc, gpqeid, options, diff_options);


### PR DESCRIPTION
This reverts commit 76b2ad511484745af282e1903df52e87abdf3576.

In most cases, the connections are reused in cdbgang_createGang_async. We should make the GUC options when building connections actually.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
