### PR TITLE
Update GitHub CI contexts in .asf.yaml (#1035) [skip ci]

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -78,27 +78,26 @@ github:
         # Require branches to be up to date before merging
         strict: true
 
-      # Required status checks that must pass
-      # Note: These contexts match the exact job names in GitHub
-      # Actions workflows. They do not include the workflow name as a
-      # prefix
-      contexts:
-        - check-skip
-        - Build Apache Cloudberry
-        - RPM Install Test Apache Cloudberry
-        - ic-good-opt-off
-        - ic-good-opt-on
-        - ic-expandshrink
-        - ic-singlenode
-        - ic-resgroup-v2
-        - ic-contrib
-        - ic-gpcontrib
-        - ic-fixme
-        - ic-isolation2
-        - ic-isolation2-crash
-        - ic-parallel-retrieve-cursor
-        - Generate Apache Cloudberry Build Report
-        - ic-cbdb-parallel
+        # Required status checks that must pass
+        # Note: These contexts match the exact job names in GitHub
+        # Actions workflows. They do not include the workflow name as a
+        # prefix
+        contexts:
+          - check-skip
+          - Build Apache Cloudberry RPM
+          - RPM Install Test Apache Cloudberry
+          - ic-good-opt-off
+          - ic-good-opt-on
+          - ic-expandshrink
+          - ic-singlenode
+          - ic-resgroup-v2
+          - ic-contrib
+          - ic-gpcontrib
+          - ic-fixme
+          - ic-isolation2
+          - ic-isolation2-crash
+          - ic-parallel-retrieve-cursor
+          - Generate Apache Cloudberry Build Report
 
       # Pull request review requirements
       required_pull_request_reviews:


### PR DESCRIPTION
Fix branch protection config: correct nesting and rename check

- Moved 'contexts' under 'required_status_checks' to match ASF YAML schema
- Renamed 'Build Apache Cloudberry' to 'Build Apache Cloudberry RPM'
- Removed obsolete 'ic-cbdb-parallel' status check

Fixes #1035
