### PR TITLE
ORCA: fallback the locking clause

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4723,14 +4723,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 		isSplit = true; // AO tables are always use split updates
 	}
 	
-	if (md_rel->IsPartitioned())
-	{
-		dml->forceTupleRouting = true;
-	}
-	else
-	{
-		dml->forceTupleRouting = false;
-	}
+	dml->forceTupleRouting = md_rel->IsPartitioned();
 
 	if (IMDRelation::EreldistrMasterOnly != md_rel->GetRelDistribution())
 	{

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -627,6 +627,12 @@ CTranslatorQueryToDXL::TranslateSelectQueryToDXL()
 		}
 	}
 
+	// Locking clause is not supported.
+	if (m_query->canOptSelectLockingClause) {
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+			GPOS_WSZ_LIT("Locking clause"));
+	}
+
 	// RETURNING is not supported yet.
 	if (m_query->returningList)
 	{

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -402,10 +402,7 @@ UPDATE 1
 
 2: begin;
 BEGIN
--- TODO: turn off orca, we should fix this until ORCA
--- can generate lockrows plannode.
-2: set optimizer = off;
-SET
+-- ORCA will fallback
 2&: select * from t_splitupdate_raise_error for update;  <waiting ...>
 
 1: end;

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -402,10 +402,7 @@ UPDATE 1
 
 2: begin;
 BEGIN
--- TODO: turn off orca, we should fix this until ORCA
--- can generate lockrows plannode.
-2: set optimizer = off;
-SET
+-- ORCA will fallback
 2&: select * from t_splitupdate_raise_error for update;  <waiting ...>
 
 1: end;

--- a/src/test/isolation2/sql/gdd/concurrent_update.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_update.sql
@@ -240,9 +240,7 @@ insert into test values (1, 1, 1), (1, 2, 1);
 1: update t_splitupdate_raise_error set a = a + 1;
 
 2: begin;
--- TODO: turn off orca, we should fix this until ORCA
--- can generate lockrows plannode.
-2: set optimizer = off;
+-- ORCA will fallback
 2&: select * from t_splitupdate_raise_error for update;
 
 1: end;


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #1031

### What does this PR do?
If the current GDD is closed and there is a `forupdate` statement, ORCA and planner does not need to generate a `LockRows` operator, expect the table is foreign table. However, if the current GDD is enabled, ORCA will generate a plan without the `LockRows` operator, which is a wrong plan.

Supporting locking clauses in ORCA is a very difficult thing. Because ORCA does not fill `root->glob->paramExecTypes` in every operator, even if ORCA generates the `LockRows` operator, it may not working in the executor. For details, please refer to the EPQ(evalPlanQual) mechanism.

Also I don't think ORCA should consider supporting locking clause. ORCA is an optimizer that is more biased towards OLAP scenarios. Support the EPQ mechanism will make ORCA more complex and more difficult to expand.


### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
