### PR TITLE
Replace std::shared_ptr<File> by std::unique_ptr<File>

### DIFF
--- a/contrib/pax_storage/src/api/python3/paxfilereader_type.cc
+++ b/contrib/pax_storage/src/api/python3/paxfilereader_type.cc
@@ -107,7 +107,7 @@ static int paxfilereader_init(PyObject *self, PyObject *args,
   PyObject *schema = NULL, *proj = NULL, *pax_file = NULL;
   PaxFileObject *pax_file_obj;
   std::shared_ptr<pax::Bitmap8> visible_map_bm = nullptr;
-  std::shared_ptr<pax::File> toast_file = nullptr;
+  std::unique_ptr<pax::File> toast_file = nullptr;
 
   PaxFileReaderObject *pax_file_reader;
   pax_file_reader = (PaxFileReaderObject *)self;
@@ -205,7 +205,7 @@ static int paxfilereader_init(PyObject *self, PyObject *args,
 
     auto file_ptr = pax::Singleton<pax::LocalFileSystem>::GetInstance()->Open(
         pax_file_obj->filepath, pax::fs::kReadMode);
-    auto reader = new pax::OrcReader(std::move(file_ptr), toast_file);
+    auto reader = new pax::OrcReader(std::move(file_ptr), std::move(toast_file));
     reader->Open(std::move(read_options));
     pax_file_reader->reader = reader;
   } catch (cbdb::CException &e) {

--- a/contrib/pax_storage/src/cpp/clustering/pax_clustering_reader.cc
+++ b/contrib/pax_storage/src/cpp/clustering/pax_clustering_reader.cc
@@ -63,8 +63,8 @@ bool PaxClusteringReader::GetNextTuple(TupleTableSlot *slot) {
         file->Close();
       }
 
-      std::shared_ptr<File> file;
-      std::shared_ptr<File> toast_file;
+      std::unique_ptr<File> file;
+      std::unique_ptr<File> toast_file;
       file =
           file_system_->Open(meta_info.GetFileName(), pax::fs::kReadMode);
 
@@ -75,7 +75,7 @@ bool PaxClusteringReader::GetNextTuple(TupleTableSlot *slot) {
       }
 
       reader_ = MicroPartitionFileFactory::CreateMicroPartitionReader(
-          options, ReaderFlags::FLAGS_EMPTY, file, toast_file);
+          options, ReaderFlags::FLAGS_EMPTY, std::move(file), std::move(toast_file));
     } else {
       return false;
     }

--- a/contrib/pax_storage/src/cpp/storage/micro_partition.h
+++ b/contrib/pax_storage/src/cpp/storage/micro_partition.h
@@ -181,7 +181,7 @@ class MicroPartitionReader {
     // fetch, compression/encoding. At the same time, pax column can also be
     // used as a general interface for internal using, because it's zero copy
     // from buffer. more details in `storage/columns`
-    virtual const std::shared_ptr<PaxColumns> &GetAllColumns() const = 0;
+    virtual const std::unique_ptr<PaxColumns> &GetAllColumns() const = 0;
 
     virtual void SetVisibilityMap(
         std::shared_ptr<Bitmap8> visibility_bitmap) = 0;

--- a/contrib/pax_storage/src/cpp/storage/micro_partition_file_factory.cc
+++ b/contrib/pax_storage/src/cpp/storage/micro_partition_file_factory.cc
@@ -38,9 +38,9 @@ namespace pax {
 std::unique_ptr<MicroPartitionReader>
 MicroPartitionFileFactory::CreateMicroPartitionReader(
     const MicroPartitionReader::ReaderOptions &options, int32 flags,
-    std::shared_ptr<File> file, std::shared_ptr<File> toast_file) {
+    std::unique_ptr<File> file, std::unique_ptr<File> toast_file) {
   std::unique_ptr<MicroPartitionReader> reader =
-      std::make_unique<OrcReader>(file, toast_file);
+      std::make_unique<OrcReader>(std::move(file), std::move(toast_file));
 
 #ifdef VEC_BUILD
   if (flags & ReaderFlags::FLAGS_VECTOR_PATH) {
@@ -63,13 +63,13 @@ MicroPartitionFileFactory::CreateMicroPartitionReader(
 std::unique_ptr<MicroPartitionWriter>
 MicroPartitionFileFactory::CreateMicroPartitionWriter(
     const MicroPartitionWriter::WriterOptions &options,
-    std::shared_ptr<File> file, std::shared_ptr<File> toast_file) {
+    std::unique_ptr<File> file, std::unique_ptr<File> toast_file) {
   std::vector<pax::porc::proto::Type_Kind> type_kinds;
   type_kinds = OrcWriter::BuildSchema(
       options.rel_tuple_desc,
       options.storage_format == PaxStorageFormat::kTypeStoragePorcVec);
-  return std::make_unique<OrcWriter>(options, std::move(type_kinds), file,
-                                     toast_file);
+  return std::make_unique<OrcWriter>(options, std::move(type_kinds),
+                                     std::move(file), std::move(toast_file));
 }
 
 }  // namespace pax

--- a/contrib/pax_storage/src/cpp/storage/micro_partition_file_factory.h
+++ b/contrib/pax_storage/src/cpp/storage/micro_partition_file_factory.h
@@ -52,13 +52,13 @@ class MicroPartitionFileFactory final {
  public:
   static std::unique_ptr<MicroPartitionWriter> CreateMicroPartitionWriter(
       const MicroPartitionWriter::WriterOptions &options,
-      std::shared_ptr<File> file,
-      std::shared_ptr<File> toast_file = nullptr);
+      std::unique_ptr<File> file,
+      std::unique_ptr<File> toast_file = nullptr);
 
   static std::unique_ptr<MicroPartitionReader> CreateMicroPartitionReader(
       const MicroPartitionReader::ReaderOptions &options, int32 flags,
-      std::shared_ptr<File> file,
-      std::shared_ptr<File> toast_file = nullptr);
+      std::unique_ptr<File> file,
+      std::unique_ptr<File> toast_file = nullptr);
 };
 
 }  // namespace pax

--- a/contrib/pax_storage/src/cpp/storage/micro_partition_file_factory_test.cc
+++ b/contrib/pax_storage/src/cpp/storage/micro_partition_file_factory_test.cc
@@ -72,8 +72,8 @@ TEST_F(MicroPartitionFileFactoryTest, CreateMicroPartitionWriter) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<std::tuple<ColumnEncoding_Kind, int>> types_encoding;
   types_encoding.emplace_back(
@@ -88,7 +88,7 @@ TEST_F(MicroPartitionFileFactoryTest, CreateMicroPartitionWriter) {
   writer_options.encoding_opts = types_encoding;
 
   auto writer = MicroPartitionFileFactory::CreateMicroPartitionWriter(
-      writer_options, file_ptr);
+      writer_options, std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->Close();
@@ -101,8 +101,8 @@ TEST_F(MicroPartitionFileFactoryTest, CreateMicroPartitionReader) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<std::tuple<ColumnEncoding_Kind, int>> types_encoding;
   types_encoding.emplace_back(
@@ -117,7 +117,7 @@ TEST_F(MicroPartitionFileFactoryTest, CreateMicroPartitionReader) {
   writer_options.encoding_opts = types_encoding;
 
   auto writer = MicroPartitionFileFactory::CreateMicroPartitionWriter(
-      writer_options, file_ptr);
+      writer_options, std::move(file_ptr));
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
 
   writer->WriteTuple(tuple_slot);
@@ -130,7 +130,7 @@ TEST_F(MicroPartitionFileFactoryTest, CreateMicroPartitionReader) {
   int32 flags = FLAGS_EMPTY;
 
   auto reader = MicroPartitionFileFactory::CreateMicroPartitionReader(
-      reader_options, flags, file_ptr);
+      reader_options, flags, std::move(file_ptr));
   reader->ReadTuple(tuple_slot_empty);
   EXPECT_TRUE(VerifyTestTupleTableSlot(tuple_slot_empty));
 
@@ -145,8 +145,8 @@ TEST_F(MicroPartitionFileFactoryTest, OrcReadWithVisibilitymap) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<std::tuple<ColumnEncoding_Kind, int>> types_encoding;
   types_encoding.emplace_back(
@@ -161,7 +161,7 @@ TEST_F(MicroPartitionFileFactoryTest, OrcReadWithVisibilitymap) {
   writer_options.encoding_opts = types_encoding;
 
   auto writer = MicroPartitionFileFactory::CreateMicroPartitionWriter(
-      writer_options, file_ptr);
+      writer_options, std::move(file_ptr));
 
   int tuple_count = 1000;
   for (int i = 0; i < tuple_count; i++) {
@@ -186,7 +186,7 @@ TEST_F(MicroPartitionFileFactoryTest, OrcReadWithVisibilitymap) {
 
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot();
   auto reader = MicroPartitionFileFactory::CreateMicroPartitionReader(
-      reader_options, flags, file_ptr);
+      reader_options, flags, std::move(file_ptr));
 
   int read_tuple_count = 0;
   while (reader->ReadTuple(tuple_slot_empty)) {
@@ -210,8 +210,8 @@ TEST_F(MicroPartitionFileFactoryTest, VecReadWithVisibilitymap) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<std::tuple<ColumnEncoding_Kind, int>> types_encoding;
   types_encoding.emplace_back(
@@ -226,7 +226,7 @@ TEST_F(MicroPartitionFileFactoryTest, VecReadWithVisibilitymap) {
   writer_options.encoding_opts = types_encoding;
 
   auto writer = MicroPartitionFileFactory::CreateMicroPartitionWriter(
-      writer_options, file_ptr);
+      writer_options, std::move(file_ptr));
 
   int tuple_count = 1000;
   for (int i = 0; i < tuple_count; i++) {
@@ -264,7 +264,7 @@ TEST_F(MicroPartitionFileFactoryTest, VecReadWithVisibilitymap) {
       CreateVecEmptyTupleSlot(tuple_slot->tts_tupleDescriptor);
 
   auto reader = MicroPartitionFileFactory::CreateMicroPartitionReader(
-      reader_options, flags, file_ptr);
+      reader_options, flags, std::move(file_ptr));
 
   auto ret = reader->ReadTuple(read_tuple_slot);
   ASSERT_TRUE(ret);

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_dump_reader.cpp
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_dump_reader.cpp
@@ -91,8 +91,8 @@ OrcDumpReader::OrcDumpReader(DumpConfig *config)
 bool OrcDumpReader::Open() {
   FileSystem *fs = nullptr;
   std::shared_ptr<FileSystemOptions> fs_opt;
-  std::shared_ptr<File> open_file;
-  std::shared_ptr<File> open_toast_file;
+  std::unique_ptr<File> open_file;
+  std::unique_ptr<File> open_toast_file;
 
   assert(config_);
   assert(config_->file_name);
@@ -111,7 +111,7 @@ bool OrcDumpReader::Open() {
     }
   }
 
-  format_reader_ = new OrcFormatReader(open_file, open_toast_file);
+  format_reader_ = new OrcFormatReader(std::move(open_file), std::move(open_toast_file));
   format_reader_->Open();
 
   return true;

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.cc
@@ -35,8 +35,8 @@
 
 namespace pax {
 
-OrcFormatReader::OrcFormatReader(std::shared_ptr<File> file,
-                                 std::shared_ptr<File> toast_file)
+OrcFormatReader::OrcFormatReader(std::unique_ptr<File> file,
+                                 std::unique_ptr<File> toast_file)
     : file_(std::move(file)),
       toast_file_(std::move(toast_file)),
       reused_buffer_(nullptr),

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.h
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.h
@@ -38,7 +38,7 @@ class OrcDumpReader;
 }
 class OrcFormatReader final {
  public:
-  explicit OrcFormatReader(std::shared_ptr<File> file, std::shared_ptr<File> toast_file = nullptr);
+  explicit OrcFormatReader(std::unique_ptr<File> file, std::unique_ptr<File> toast_file = nullptr);
 
   ~OrcFormatReader();
 
@@ -78,8 +78,8 @@ class OrcFormatReader final {
   friend class OrcGroupStatsProvider;
   std::vector<pax::porc::proto::Type_Kind> column_types_;
   std::vector<std::map<std::string, std::string>> column_attrs_;
-  std::shared_ptr<File> file_;
-  std::shared_ptr<File> toast_file_;
+  std::unique_ptr<File> file_;
+  std::unique_ptr<File> toast_file_;
   std::shared_ptr<DataBuffer<char>> reused_buffer_;
   size_t num_of_stripes_;
   bool is_vec_;

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_group.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_group.cc
@@ -64,7 +64,7 @@ inline static std::pair<Datum, bool> GetColumnDatum(PaxColumn *column,
   return {rc, false};
 }
 
-OrcGroup::OrcGroup(std::unique_ptr<PaxColumns> &&pax_column, size_t row_offset,
+OrcGroup::OrcGroup(std::unique_ptr<PaxColumns> pax_column, size_t row_offset,
                    const std::vector<int> *proj_col_index,
                    std::shared_ptr<Bitmap8> micro_partition_visibility_bitmap)
     : pax_columns_(std::move(pax_column)),
@@ -88,7 +88,7 @@ size_t OrcGroup::GetRows() const { return pax_columns_->GetRows(); }
 
 size_t OrcGroup::GetRowOffset() const { return row_offset_; }
 
-const std::shared_ptr<PaxColumns> &OrcGroup::GetAllColumns() const {
+const std::unique_ptr<PaxColumns> &OrcGroup::GetAllColumns() const {
   return pax_columns_;
 }
 

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_group.h
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_group.h
@@ -40,7 +40,7 @@ class OrcDumpReader;
 class OrcGroup : public MicroPartitionReader::Group {
  public:
   OrcGroup(
-      std::unique_ptr<PaxColumns> &&pax_column, size_t row_offset,
+      std::unique_ptr<PaxColumns> pax_column, size_t row_offset,
       const std::vector<int> *proj_col_index,
       std::shared_ptr<Bitmap8> micro_partition_visibility_bitmap = nullptr);
 
@@ -50,7 +50,7 @@ class OrcGroup : public MicroPartitionReader::Group {
 
   size_t GetRowOffset() const override;
 
-  const std::shared_ptr<PaxColumns> &GetAllColumns() const override;
+  const std::unique_ptr<PaxColumns> &GetAllColumns() const override;
 
   virtual std::pair<bool, size_t> ReadTuple(TupleTableSlot *slot) override;
 
@@ -74,7 +74,7 @@ class OrcGroup : public MicroPartitionReader::Group {
                                                  size_t row_index);
 
  protected:
-  std::shared_ptr<PaxColumns> pax_columns_;
+  std::unique_ptr<PaxColumns> pax_columns_;
   std::shared_ptr<Bitmap8> micro_partition_visibility_bitmap_;
   size_t row_offset_;
   size_t current_row_index_;

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_reader.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_reader.cc
@@ -102,12 +102,12 @@ class OrcGroupStatsProvider final : public ColumnStatsProvider {
   size_t group_index_;
 };
 
-OrcReader::OrcReader(std::shared_ptr<File> file,
-                     std::shared_ptr<File> toast_file)
+OrcReader::OrcReader(std::unique_ptr<File> file,
+                     std::unique_ptr<File> toast_file)
     : working_group_(nullptr),
       cached_group_(nullptr),
       current_group_index_(0),
-      format_reader_(file, toast_file),
+      format_reader_(std::move(file), std::move(toast_file)),
       is_closed_(true) {}
 
 std::unique_ptr<ColumnStatsProvider> OrcReader::GetGroupStatsInfo(

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_test.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_test.cc
@@ -144,7 +144,7 @@ TEST_F(OrcTest, WriteTuple) {
   ASSERT_NE(nullptr, local_fs);
 
   auto file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   OrcWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
@@ -164,7 +164,7 @@ TEST_F(OrcTest, OpenOrc) {
   ASSERT_NE(nullptr, local_fs);
 
   auto file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
@@ -192,8 +192,8 @@ TEST_F(OrcTest, WriteReadStripes) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
@@ -201,7 +201,7 @@ TEST_F(OrcTest, WriteReadStripes) {
   // file_ptr in orc writer will be freed when writer do destruct
   // current OrcWriter::CreateWriter only for test
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->Close();
@@ -210,7 +210,7 @@ TEST_F(OrcTest, WriteReadStripes) {
 
   // file_ptr in orc reader will be freed when reader do destruct
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   EXPECT_EQ(1UL, reader->GetGroupNums());
@@ -229,13 +229,13 @@ TEST_F(OrcTest, WriteReadStripesTwice) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->WriteTuple(tuple_slot);
@@ -244,7 +244,7 @@ TEST_F(OrcTest, WriteReadStripesTwice) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   EXPECT_EQ(1UL, reader->GetGroupNums());
@@ -280,14 +280,14 @@ TEST_F(OrcTest, WriteReadMultiStripes) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->Flush();
@@ -298,7 +298,7 @@ TEST_F(OrcTest, WriteReadMultiStripes) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   EXPECT_EQ(2UL, reader->GetGroupNums());
@@ -319,14 +319,14 @@ TEST_F(OrcTest, WriteReadCloseEmptyOrc) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
   writer->WriteTuple(tuple_slot);
   writer->Flush();
 
@@ -336,7 +336,7 @@ TEST_F(OrcTest, WriteReadCloseEmptyOrc) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   EXPECT_EQ(1UL, reader->GetGroupNums());
@@ -353,14 +353,14 @@ TEST_F(OrcTest, WriteReadEmptyOrc) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
   // flush empty
   writer->Flush();
   // direct close
@@ -369,7 +369,7 @@ TEST_F(OrcTest, WriteReadEmptyOrc) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(0UL, reader->GetGroupNums());
   reader->Close();
@@ -382,14 +382,14 @@ TEST_F(OrcTest, ReadTuple) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
 
   writer->WriteTuple(tuple_slot);
@@ -398,7 +398,7 @@ TEST_F(OrcTest, ReadTuple) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(1UL, reader->GetGroupNums());
   reader->ReadTuple(tuple_slot_empty);
@@ -415,15 +415,15 @@ TEST_F(OrcTest, GetTuple) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
   writer_options.group_limit = 100;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
   for (int i = 0; i < 1000; i++) {
     if (i % 5 == 0) {
       tuple_slot->tts_isnull[0] = true;
@@ -440,7 +440,7 @@ TEST_F(OrcTest, GetTuple) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
 
   reader->Open(reader_options);
@@ -521,11 +521,11 @@ TEST_F(OrcTest, WriteReadTupleWithToast) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
-  std::shared_ptr<File> toast_file_ptr = local_fs->Open(toast_file_name, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> toast_file_ptr = local_fs->Open(toast_file_name, fs::kWriteMode);
+  EXPECT_NE(nullptr, toast_file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
@@ -539,7 +539,7 @@ TEST_F(OrcTest, WriteReadTupleWithToast) {
   std::vector<pax::porc::proto::Type_Kind> types_for_read = types;
 
   auto writer = OrcWriter::CreateWriter(writer_options, std::move(types),
-                                        file_ptr, toast_file_ptr);
+                                        std::move(file_ptr), std::move(toast_file_ptr));
   for (int i = 0; i < 106; i++) {
     switch (i % 3) {
       case 0: {
@@ -574,12 +574,12 @@ TEST_F(OrcTest, WriteReadTupleWithToast) {
 
   // begin full read without projection
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
-  EXPECT_NE(nullptr, file_ptr);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   toast_file_ptr = local_fs->Open(toast_file_name, fs::kReadMode);
-  EXPECT_NE(nullptr, file_ptr);
+  EXPECT_NE(nullptr, toast_file_ptr.get());
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr, toast_file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr), std::move(toast_file_ptr));
   tuple_slot_empty = MakeTupleTableSlot(tuple_desc, &TTSOpsVirtual);
 
   reader->Open(reader_options);
@@ -657,16 +657,16 @@ TEST_F(OrcTest, WriteReadTupleWithToast) {
 
   // begin read with projection
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
-  EXPECT_NE(nullptr, file_ptr);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   toast_file_ptr = local_fs->Open(toast_file_name, fs::kReadMode);
-  EXPECT_NE(nullptr, file_ptr);
+  EXPECT_NE(nullptr, toast_file_ptr.get());
   std::vector<bool> projection = {false, true, true, true};
   std::shared_ptr<PaxFilter> filter = std::make_shared<PaxFilter>();
 
   filter->SetColumnProjection(std::move(projection));
   reader_options.filter = filter;
-  reader = new OrcReader(file_ptr, toast_file_ptr);
+  reader = new OrcReader(std::move(file_ptr), std::move(toast_file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(6UL, reader->GetGroupNums());
 
@@ -776,8 +776,8 @@ TEST_P(OrcEncodingTest, ReadTupleWithEncoding) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<pax::porc::proto::Type_Kind> types;
   types.emplace_back(pax::porc::proto::Type_Kind::Type_Kind_LONG);
@@ -789,7 +789,7 @@ TEST_P(OrcEncodingTest, ReadTupleWithEncoding) {
   writer_options.encoding_opts = types_encoding;
   writer_options.rel_tuple_desc = tuple_desc;
 
-  auto writer = new OrcWriter(writer_options, types, file_ptr);
+  auto writer = new OrcWriter(writer_options, types, std::move(file_ptr));
 
   for (size_t i = 0; i < 10000; i++) {
     tuple_slot->tts_values[0] = Int64GetDatum(i);
@@ -802,7 +802,7 @@ TEST_P(OrcEncodingTest, ReadTupleWithEncoding) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(1UL, reader->GetGroupNums());
   for (size_t i = 0; i < 10000; i++) {
@@ -847,8 +847,8 @@ TEST_P(OrcCompressTest, ReadTupleWithCompress) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<pax::porc::proto::Type_Kind> types;
   types.emplace_back(pax::porc::proto::Type_Kind::Type_Kind_STRING);
@@ -860,7 +860,7 @@ TEST_P(OrcCompressTest, ReadTupleWithCompress) {
   writer_options.encoding_opts = types_encoding;
   writer_options.rel_tuple_desc = tuple_desc;
 
-  auto writer = new OrcWriter(writer_options, types, file_ptr);
+  auto writer = new OrcWriter(writer_options, types, std::move(file_ptr));
 
   for (size_t i = 0; i < COLUMN_SIZE; i++) {
     column_buff_str[i] = i;
@@ -878,7 +878,7 @@ TEST_P(OrcCompressTest, ReadTupleWithCompress) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   ASSERT_EQ(1UL, reader->GetGroupNums());
@@ -918,14 +918,14 @@ TEST_F(OrcTest, ReadTupleDefaultColumn) {
   auto *local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->Close();
@@ -933,7 +933,7 @@ TEST_F(OrcTest, ReadTupleDefaultColumn) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(1UL, reader->GetGroupNums());
 
@@ -969,14 +969,14 @@ TEST_F(OrcTest, ReadTupleDroppedColumn) {
   auto *local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->Close();
@@ -984,7 +984,7 @@ TEST_F(OrcTest, ReadTupleDroppedColumn) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(1UL, reader->GetGroupNums());
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
@@ -1004,21 +1004,21 @@ TEST_F(OrcTest, ReadTupleDroppedColumnWithProjection) {
   auto *local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
   writer->WriteTuple(tuple_slot);
   writer->Close();
 
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(1UL, reader->GetGroupNums());
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
@@ -1058,8 +1058,8 @@ TEST_F(OrcTest, WriteReadBigTuple) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   std::vector<pax::porc::proto::Type_Kind> types;
   types.emplace_back(pax::porc::proto::Type_Kind::Type_Kind_INT);
@@ -1067,7 +1067,7 @@ TEST_F(OrcTest, WriteReadBigTuple) {
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_desc;
 
-  auto writer = OrcWriter::CreateWriter(writer_options, types, file_ptr);
+  auto writer = OrcWriter::CreateWriter(writer_options, types, std::move(file_ptr));
 
   for (size_t i = 0; i < 10000; i++) {
     tuple_slot->tts_values[0] = Int32GetDatum(i);
@@ -1080,7 +1080,7 @@ TEST_F(OrcTest, WriteReadBigTuple) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   EXPECT_EQ(1UL, reader->GetGroupNums());
   for (size_t i = 0; i < 10000; i++) {
@@ -1102,14 +1102,14 @@ TEST_F(OrcTest, WriteReadNoFixedColumnInSameTuple) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
 
@@ -1125,7 +1125,7 @@ TEST_F(OrcTest, WriteReadNoFixedColumnInSameTuple) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   EXPECT_EQ(1UL, reader->GetGroupNums());
@@ -1154,14 +1154,14 @@ TEST_F(OrcTest, WriteReadWithNullField) {
   auto *local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   OrcWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   // str str int
   // null null int
@@ -1189,7 +1189,7 @@ TEST_F(OrcTest, WriteReadWithNullField) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
 
@@ -1231,14 +1231,14 @@ TEST_F(OrcTest, WriteReadWithBoundNullField) {
   auto *local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   OrcWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   // null null null
   // str str int
@@ -1263,7 +1263,7 @@ TEST_F(OrcTest, WriteReadWithBoundNullField) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
 
@@ -1297,14 +1297,14 @@ TEST_F(OrcTest, WriteReadWithALLNullField) {
   auto *local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   OrcWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   tuple_slot->tts_isnull[0] = true;
   tuple_slot->tts_isnull[1] = true;
@@ -1317,7 +1317,7 @@ TEST_F(OrcTest, WriteReadWithALLNullField) {
   file_ptr = local_fs->Open(file_name_, fs::kReadMode);
 
   MicroPartitionReader::ReaderOptions reader_options;
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
   TupleTableSlot *tuple_slot_empty = CreateTestTupleTableSlot(false);
 
@@ -1353,14 +1353,14 @@ TEST_P(OrcTestProjection, ReadTupleWithProjectionColumn) {
     proj_map[proj_index] = !proj_map[proj_index];
   }
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   MicroPartitionWriter::WriterOptions writer_options;
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
 
   writer->WriteTuple(tuple_slot);
   writer->Flush();
@@ -1375,7 +1375,7 @@ TEST_P(OrcTestProjection, ReadTupleWithProjectionColumn) {
   MicroPartitionReader::ReaderOptions reader_options;
   reader_options.filter = pax_filter;
 
-  auto reader = new OrcReader(file_ptr);
+  auto reader = new OrcReader(std::move(file_ptr));
   reader->Open(reader_options);
 
   EXPECT_EQ(2UL, reader->GetGroupNums());
@@ -1414,9 +1414,9 @@ TEST_P(OrcEncodingTest, WriterMerge) {
 
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file1_ptr = local_fs->Open(file1_name, fs::kReadWriteMode);
-  std::shared_ptr<File> file2_ptr = local_fs->Open(file2_name, fs::kReadWriteMode);
-  std::shared_ptr<File> file3_ptr = local_fs->Open(file3_name, fs::kReadWriteMode);
+  std::unique_ptr<File> file1_ptr = local_fs->Open(file1_name, fs::kReadWriteMode);
+  std::unique_ptr<File> file2_ptr = local_fs->Open(file2_name, fs::kReadWriteMode);
+  std::unique_ptr<File> file3_ptr = local_fs->Open(file3_name, fs::kReadWriteMode);
   EXPECT_NE(nullptr, file1_ptr);
   EXPECT_NE(nullptr, file2_ptr);
   EXPECT_NE(nullptr, file3_ptr);
@@ -1431,11 +1431,11 @@ TEST_P(OrcEncodingTest, WriterMerge) {
   writer_options.rel_tuple_desc = tuple_slot->tts_tupleDescriptor;
 
   auto *writer1 = new OrcWriter(writer_options,
-                                std::move(CreateTestSchemaTypes()), file1_ptr);
+                                std::move(CreateTestSchemaTypes()), std::move(file1_ptr));
   auto *writer2 = new OrcWriter(writer_options,
-                                std::move(CreateTestSchemaTypes()), file2_ptr);
+                                std::move(CreateTestSchemaTypes()), std::move(file2_ptr));
   auto *writer3 = new OrcWriter(writer_options,
-                                std::move(CreateTestSchemaTypes()), file3_ptr);
+                                std::move(CreateTestSchemaTypes()), std::move(file3_ptr));
 
   // two group + 51 rows in memory
   for (size_t i = 0; i < 251; i++) {
@@ -1472,7 +1472,7 @@ TEST_P(OrcEncodingTest, WriterMerge) {
   MicroPartitionReader::ReaderOptions reader_options;
   file3_ptr = local_fs->Open(file3_name, fs::kReadMode);
 
-  auto reader = new OrcReader(file3_ptr);
+  auto reader = new OrcReader(std::move(file3_ptr));
   reader->Open(reader_options);
 
   // no memory merge
@@ -1625,8 +1625,8 @@ TEST_F(OrcTest, ReadException) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
-  EXPECT_NE(nullptr, file_ptr);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  EXPECT_NE(nullptr, file_ptr.get());
 
   current_pb_func_call_times = 0;
   target_pb_func_call_times = 0;
@@ -1636,7 +1636,7 @@ TEST_F(OrcTest, ReadException) {
   writer_options.group_limit = 10;
 
   auto writer = OrcWriter::CreateWriter(
-      writer_options, std::move(CreateTestSchemaTypes()), file_ptr);
+      writer_options, std::move(CreateTestSchemaTypes()), std::move(file_ptr));
   for (int i = 0; i < 50; i++) {
     writer->WriteTuple(tuple_slot);
   }

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_vec_test.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_vec_test.cc
@@ -97,7 +97,7 @@ TEST_F(OrcVecTest, WriteReadGroup) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
   EXPECT_NE(nullptr, file_ptr);
 
   std::vector<pax::porc::proto::Type_Kind> types;
@@ -240,7 +240,7 @@ TEST_F(OrcVecTest, WriteReadGroupWithEncoding) {
   auto local_fs = Singleton<LocalFileSystem>::GetInstance();
   ASSERT_NE(nullptr, local_fs);
 
-  std::shared_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
+  std::unique_ptr<File> file_ptr = local_fs->Open(file_name_, fs::kWriteMode);
   EXPECT_NE(nullptr, file_ptr);
 
   std::vector<pax::porc::proto::Type_Kind> types;

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_writer.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_writer.cc
@@ -225,12 +225,12 @@ static std::unique_ptr<PaxColumns> BuildColumns(
 OrcWriter::OrcWriter(
     const MicroPartitionWriter::WriterOptions &writer_options,
     const std::vector<pax::porc::proto::Type_Kind> &column_types,
-    std::shared_ptr<File> file, std::shared_ptr<File> toast_file)
+    std::unique_ptr<File> file, std::unique_ptr<File> toast_file)
     : MicroPartitionWriter(writer_options),
       is_closed_(false),
       column_types_(column_types),
-      file_(file),
-      toast_file_(toast_file),
+      file_(std::move(file)),
+      toast_file_(std::move(toast_file)),
       current_written_phy_size_(0),
       row_index_(0),
       total_rows_(0),

--- a/contrib/pax_storage/src/cpp/storage/orc/porc.h
+++ b/contrib/pax_storage/src/cpp/storage/orc/porc.h
@@ -50,7 +50,7 @@ class OrcWriter : public MicroPartitionWriter {
  public:
   OrcWriter(const MicroPartitionWriter::WriterOptions &orc_writer_options,
             const std::vector<pax::porc::proto::Type_Kind> &column_types,
-            std::shared_ptr<File> file, std::shared_ptr<File> toast_file = nullptr);
+            std::unique_ptr<File> file, std::unique_ptr<File> toast_file = nullptr);
 
   ~OrcWriter() override;
 
@@ -75,8 +75,8 @@ class OrcWriter : public MicroPartitionWriter {
   // only for test
   static std::unique_ptr<MicroPartitionWriter> CreateWriter(
       MicroPartitionWriter::WriterOptions options,
-      const std::vector<pax::porc::proto::Type_Kind> &column_types, std::shared_ptr<File> file,
-      std::shared_ptr<File> toast_file = nullptr) {
+      const std::vector<pax::porc::proto::Type_Kind> &column_types, std::unique_ptr<File> file,
+      std::unique_ptr<File> toast_file = nullptr) {
     std::vector<std::tuple<ColumnEncoding_Kind, int>> all_no_encoding_types;
     for (auto _ : column_types) {
       (void)_;
@@ -86,7 +86,7 @@ class OrcWriter : public MicroPartitionWriter {
 
     options.encoding_opts = all_no_encoding_types;
 
-    return std::make_unique<OrcWriter>(options, column_types, file, toast_file);
+    return std::make_unique<OrcWriter>(options, column_types, std::move(file), std::move(toast_file));
   }
 #endif
 
@@ -125,8 +125,8 @@ class OrcWriter : public MicroPartitionWriter {
   std::vector<void*> detoast_memory_holder_;
 
   const std::vector<pax::porc::proto::Type_Kind> column_types_;
-  std::shared_ptr<File> file_;
-  std::shared_ptr<File> toast_file_;
+  std::unique_ptr<File> file_;
+  std::unique_ptr<File> toast_file_;
   int32 current_written_phy_size_;
   WriteSummary summary_;
 
@@ -142,7 +142,7 @@ class OrcWriter : public MicroPartitionWriter {
 
 class OrcReader : public MicroPartitionReader {
  public:
-  explicit OrcReader(std::shared_ptr<File> file, std::shared_ptr<File> toast_file = nullptr);
+  explicit OrcReader(std::unique_ptr<File> file, std::unique_ptr<File> toast_file = nullptr);
 
   ~OrcReader() override = default;
 

--- a/contrib/pax_storage/src/cpp/storage/vec_parallel_common.cc
+++ b/contrib/pax_storage/src/cpp/storage/vec_parallel_common.cc
@@ -132,7 +132,7 @@ bool PaxFragmentInterface::OpenFile() {
   InitAdapter();
 
   auto data_file = file_system->Open(m->GetFileName(), fs::kReadMode, desc->GetFileSystemOptions());
-  std::shared_ptr<File> toast_file;
+  std::unique_ptr<File> toast_file;
   if (auto name = m->GetToastName(); !name.empty()) {
     toast_file = file_system->Open(name, fs::kReadMode, desc->GetFileSystemOptions());
   }


### PR DESCRIPTION
Shared smart pointer will introduce additional cost, and it also make the ownership complicated.
Use unique pointer to make the ownership explicitly visible.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
