### PR TITLE
CI: Enable submodule checkout and remove manual submodule update

### DIFF
--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -435,6 +435,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: true
 
       - name: Checkout CI Build/Test Scripts
         if: needs.check-skip.outputs.should_skip != 'true'
@@ -517,11 +518,6 @@ jobs:
           SRC_DIR: ${{ github.workspace }}
         run: |
           set -eo pipefail
-
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && git submodule update --init"; then
-            echo "::error::Fail to pull submodule."
-            exit 1
-          fi
 
           chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh
           if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh"; then

--- a/.github/workflows/build-dbg-cloudberry.yml
+++ b/.github/workflows/build-dbg-cloudberry.yml
@@ -344,6 +344,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: true
 
       - name: Checkout CI Build/Test Scripts
         if: needs.check-skip.outputs.should_skip != 'true'
@@ -426,11 +427,6 @@ jobs:
           SRC_DIR: ${{ github.workspace }}
         run: |
           set -eo pipefail
-
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && git submodule update --init"; then
-            echo "::error::Fail to pull submodule."
-            exit 1
-          fi
 
           chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh
           if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh"; then


### PR DESCRIPTION
- Updated both build-cloudberry.yml and build-dbg-cloudberry.yml to enable submodules during actions/checkout.
- Removed redundant manual 'git submodule update --init' commands from the build script steps.
- This ensures submodules are initialized properly at checkout time, simplifies the workflow, and reduces potential errors during PR and main branch builds.