### PR TITLE
Cherry pick NodeSummary in EXPLAIN ANALYZE

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -277,6 +277,9 @@ int			gp_hashjoin_tuples_per_bucket = 5;
 /* Analyzing aid */
 int			gp_motion_slice_noop = 0;
 
+/* Apache Cloudberry EXPLAIN Feature GUCs */
+bool		gp_enable_explain_node_summary = false;
+
 /* Apache Cloudberry Experimental Feature GUCs */
 bool		gp_enable_explain_allstat = false;
 bool		gp_enable_motion_deadlock_sanity = false;	/* planning time sanity

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1636,7 +1636,7 @@ cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
 		appendStringInfoSpaces(es->str, ns_spaces);
 		appendStringInfoString(es->str, "StatInsts:\n");
 		appendStringInfoSpaces(es->str, ns_spaces + 2);
-		appendStringInfoString(es->str, "(segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched\n");
+		appendStringInfoString(es->str, "(segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes nworkers_launched\n");
 	}
 	else {
 		ExplainOpenGroup("CdbExplain_NodeSummary", "CdbExplain_NodeSummary", true, es);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1605,7 +1605,7 @@ cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
 
 		appendStringInfoSpaces(es->str, ns_spaces);
 		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->nloops);
-		appendStringInfo(es->str, "nloops:               %s\n", aggbuf);
+		appendStringInfo(es->str, "nloops:                %s\n", aggbuf);
 
 		appendStringInfoSpaces(es->str, ns_spaces);
 		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->execmemused);
@@ -1636,7 +1636,7 @@ cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
 		appendStringInfoSpaces(es->str, ns_spaces);
 		appendStringInfoString(es->str, "StatInsts:\n");
 		appendStringInfoSpaces(es->str, ns_spaces + 2);
-		appendStringInfoString(es->str, "(segN) pstype starttime counter firsttuple startup total ntuples ntuples nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched\n");
+		appendStringInfoString(es->str, "(segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched\n");
 	}
 	else {
 		ExplainOpenGroup("CdbExplain_NodeSummary", "CdbExplain_NodeSummary", true, es);

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1591,9 +1591,9 @@ cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
 	if (es->format == EXPLAIN_FORMAT_TEXT)
 	{
 		/*
-			* create a header for all stats: separate each individual stat by an
-			* underscore, separate the grouped stats for each node by a slash
-			*/
+		 * create a header for all stats: separate each individual stat by an
+		 * underscore, separate the grouped stats for each node by a slash
+		 */
 		appendStringInfoSpaces(es->str, es->indent * 2);
 		appendStringInfoString(es->str, "Node Summary:                  vmax       vsum       vcnt       imax\n");
 

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1474,6 +1474,44 @@ cdbexplain_formatSeg(char *outbuf, int bufsize, int segindex, int nInst)
 
 
 /*
+ * cdbexplain_formatAgg
+ *	  Convert CdbExplain_Agg to string.
+ *
+ *		outbuf:  		[output] pointer to a char buffer to be filled
+ *		bufsize: 		[input] maximum number of characters to write to outbuf (must be set by the caller)
+ *		CdbExplain_Agg:	[input] pointer to a struct CdbExplain_Agg
+ */
+static void
+cdbexplain_formatAgg(char *outbuf, int bufsize, CdbExplain_Agg agg)
+{
+	Assert(outbuf != NULL && "CDBEXPLAIN: char buffer is null");
+	Assert(bufsize > 0 && "CDBEXPLAIN: size of char buffer is zero");
+	/* check if truncation occurs */
+#ifdef USE_ASSERT_CHECKING
+	int			nchars_written =
+#endif							/* USE_ASSERT_CHECKING */
+	snprintf(outbuf, bufsize, "%10.0f %10.0f %10d %10d", agg.vmax, agg.vsum, agg.vcnt, agg.imax);
+
+	Assert(nchars_written < bufsize &&
+		   "CDBEXPLAIN:  size of char buffer is smaller than the required number of chars");
+}								/* cdbexplain_formatAgg */
+
+
+static void
+ExplainPropertyAgg(const char *qlabel, CdbExplain_Agg agg, ExplainState *es)
+{
+	ExplainOpenGroup(qlabel, qlabel, true, es);
+
+	ExplainPropertyFloat("vmax", agg.vmax, 0, es);
+	ExplainPropertyFloat("vsum", agg.vsum, 0, es);
+	ExplainPropertyInteger("vcnt", agg.vcnt, es);
+	ExplainPropertyInteger("imax", agg.imax, es);
+
+	ExplainCloseGroup(qlabel, qlabel, true, es);
+}
+
+
+/*
  * cdbexplain_showExecStatsBegin
  *	  Called by qDisp process to create a CdbExplain_ShowStatCtx structure
  *	  in which to accumulate overall statistics for a query.
@@ -1544,6 +1582,133 @@ nodeSupportWorkfileCaching(PlanState *planstate)
 			(IsA(planstate, AggState) &&((Agg *) planstate->plan)->aggstrategy == AGG_HASHED) ||
 			IsA(planstate, MaterialState));
 }
+
+void
+cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
+	int			i;
+	char		aggbuf[100];
+	
+	if (es->format == EXPLAIN_FORMAT_TEXT)
+	{
+		/*
+			* create a header for all stats: separate each individual stat by an
+			* underscore, separate the grouped stats for each node by a slash
+			*/
+		appendStringInfoSpaces(es->str, es->indent * 2);
+		appendStringInfoString(es->str, "Node Summary:                  vmax       vsum       vcnt       imax\n");
+
+		int ns_spaces = es->indent * 2 + 2;
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->ntuples);
+		appendStringInfo(es->str, "ntuples:               %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->execmemused);
+		appendStringInfo(es->str, "execmemused:           %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->workmemused);
+		appendStringInfo(es->str, "workmemused:           %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->workmemwanted);
+		appendStringInfo(es->str, "workmemwanted:         %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->totalWorkfileCreated);
+		appendStringInfo(es->str, "totalWorkfileCreated:  %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->peakMemBalance);
+		appendStringInfo(es->str, "peakMemBalance:        %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		cdbexplain_formatAgg(aggbuf, sizeof(aggbuf), ns->totalPartTableScanned);
+		appendStringInfo(es->str, "totalPartTableScanned: %s\n", aggbuf);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		appendStringInfo(es->str, "segindex0: %d\n", ns->segindex0);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		appendStringInfo(es->str, "ninst: %d\n", ns->ninst);
+
+		appendStringInfoSpaces(es->str, ns_spaces);
+		appendStringInfoString(es->str, "StatInsts:\n");
+		appendStringInfoSpaces(es->str, ns_spaces + 2);
+		appendStringInfoString(es->str, "(segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes\n");
+	}
+	else {
+		ExplainOpenGroup("CdbExplain_NodeSummary", "CdbExplain_NodeSummary", true, es);
+
+		ExplainPropertyAgg("ntuples", ns->ntuples, es);
+		ExplainPropertyAgg("execmemused", ns->execmemused, es);
+		ExplainPropertyAgg("workmemused", ns->workmemused, es);
+		ExplainPropertyAgg("workmemwanted", ns->workmemwanted, es);
+		ExplainPropertyAgg("totalWorkfileCreated", ns->totalWorkfileCreated, es);
+		ExplainPropertyAgg("peakMemBalance", ns->peakMemBalance, es);
+		ExplainPropertyAgg("totalPartTableScanned", ns->totalPartTableScanned, es);
+
+		ExplainPropertyInteger("segindex0", ns->segindex0, es);
+		ExplainPropertyInteger("ninst", ns->ninst, es);
+
+		ExplainOpenGroup("CdbExplain_StatInsts", "CdbExplain_StatInsts", false, es);
+	}
+	for (i = 0; i < ns->ninst; i++)
+	{
+		CdbExplain_StatInst *nsi = &ns->insts[i];
+
+		if (es->format == EXPLAIN_FORMAT_TEXT)
+		{
+			int nsi_spaces = es->indent * 2 + 4;
+
+			appendStringInfoSpaces(es->str, nsi_spaces);
+
+			appendStringInfo(es->str, "(seg%d) %d %.2f %.2f %.2f %.2f %.2f %.0f %.0f %.0f %.0f %.0f %d %.2f %.0f %d %d %d %ld %d %d\n", 
+				ns->segindex0 + i, 
+				nsi->pstype, 
+				nsi->starttime.tv_sec, nsi->counter.tv_sec, nsi->firsttuple, nsi->startup, nsi->total,
+				nsi->ntuples, nsi->nloops, nsi->execmemused, nsi->workmemused, nsi->workmemwanted,
+				nsi->workfileCreated,
+				nsi->firststart.tv_sec,
+				nsi->peakMemBalance,
+				nsi->numPartScanned, nsi->sortMethod, nsi->sortSpaceType,
+				nsi->sortSpaceUsed,
+				nsi->bnotes, nsi->enotes);
+		}
+		else
+		{
+			ExplainOpenGroup("CdbExplain_StatInst", NULL, true, es);
+			ExplainPropertyInteger("Segment", ns->segindex0 + i, es);
+			ExplainPropertyInteger("pstype", nsi->pstype, es);
+			ExplainPropertyFloat("starttime", nsi->starttime.tv_sec, 2, es);
+			ExplainPropertyFloat("counter", nsi->counter.tv_sec, 2, es);
+			ExplainPropertyFloat("firsttuple", nsi->firsttuple, 2, es);
+			ExplainPropertyFloat("startup", nsi->startup, 2, es);
+			ExplainPropertyFloat("total", nsi->total, 2, es);
+			ExplainPropertyFloat("ntuples", nsi->ntuples, 0, es);
+			ExplainPropertyFloat("nloops", nsi->nloops, 0, es);
+			ExplainPropertyFloat("execmemused", nsi->execmemused, 0, es);
+			ExplainPropertyFloat("workmemused", nsi->workmemused, 0, es);
+			ExplainPropertyFloat("workmemwanted", nsi->workmemwanted, 0, es);
+			ExplainPropertyInteger("workfileCreated", nsi->workfileCreated, es);
+			ExplainPropertyFloat("firststart", nsi->firststart.tv_sec, 2, es);
+			ExplainPropertyFloat("peakMemBalance", nsi->peakMemBalance, 0, es);
+			ExplainPropertyInteger("numPartScanned", nsi->numPartScanned, es);
+			ExplainPropertyInteger("sortMethod", nsi->sortMethod, es);
+			ExplainPropertyInteger("sortSpaceType", nsi->sortSpaceType, es);
+			ExplainPropertyLong("sortSpaceUsed", nsi->sortSpaceUsed, es);
+			ExplainPropertyInteger("bnotes", nsi->bnotes, es);
+			ExplainPropertyInteger("enotes", nsi->enotes, es);
+			ExplainCloseGroup("CdbExplain_StatInst", NULL, true, es);
+		}
+	}
+
+	if (es->format != EXPLAIN_FORMAT_TEXT) {
+		ExplainCloseGroup("CdbExplain_StatInsts", "CdbExplain_StatInsts", false, es);
+		ExplainCloseGroup("CdbExplain_NodeSummary", "CdbExplain_NodeSummary", true, es);
+	}
+}								/* cdbexplain_NodeSummary */
 
 /*
  * cdbexplain_showExecStats
@@ -1863,6 +2028,12 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 			appendStringInfoString(es->str, "//end\n");
 		else
 			ExplainCloseGroup("Allstat", "Allstat", true, es);
+	}
+	/*
+	 * Dump CdbExplain_NodeSummary
+	 */
+	if (gp_enable_explain_node_summary) {
+		cdbexplain_NodeSummary(es, ns);
 	}
 }								/* cdbexplain_showExecStats */
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -831,6 +831,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
+		{"gp_enable_explain_node_summary", PGC_USERSET, CLIENT_CONN_OTHER,
+			gettext_noop("Dump CdbExplain_NodeSummary for every node in EXPLAIN ANALYZE."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_explain_node_summary,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_enable_sort_limit", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable LIMIT operation to be performed while sorting."),
 			gettext_noop("Sort more efficiently when plan requires the first <n> rows at most.")

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -619,6 +619,12 @@ extern bool gp_enable_preunique;
  */
 extern bool gp_enable_explain_allstat;
 
+/* May Greenplum dump node summary from CdbExplain_NodeSummary
+ * during EXPLAIN ANALYZE?
+ *
+ */
+extern bool gp_enable_explain_node_summary;
+
 /*
  * What level of details of the memory accounting information to show during EXPLAIN ANALYZE?
  */

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -619,9 +619,8 @@ extern bool gp_enable_preunique;
  */
 extern bool gp_enable_explain_allstat;
 
-/* May Greenplum dump node summary from CdbExplain_NodeSummary
+/* May Cloudberry dump node summary from CdbExplain_NodeSummary
  * during EXPLAIN ANALYZE?
- *
  */
 extern bool gp_enable_explain_node_summary;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -186,6 +186,7 @@
 		"gp_enable_ao_indexscan",
 		"gp_enable_direct_dispatch",
 		"gp_enable_explain_allstat",
+		"gp_enable_explain_node_summary",
 		"gp_enable_fast_sri",
 		"gp_enable_global_deadlock_detector",
 		"gp_enable_groupext_distinct_gather",

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -501,6 +501,51 @@ explain (slicetable, costs off, format json) SELECT * FROM explaintest;
  ]
 (1 row)
 
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.476..0.484 rows=10 loops=1)
+   Node Summary:                  vmax       vsum       vcnt       imax
+     ntuples:                       10         10          1         -1
+     execmemused:                    0          0          0          0
+     workmemused:                    0          0          0          0
+     workmemwanted:                  0          0          0          0
+     totalWorkfileCreated:           0          0          0          0
+     peakMemBalance:              5336       5336          1         -1
+     totalPartTableScanned:          0          0          0          0
+     segindex0: -1
+     ninst: 1
+     StatInsts:
+       (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
+       (seg-1) 241 0.00 0.00 0.00 10.00 1.00 0 0 0 0 0 0 5336.00 0 0 0 0 0 0 0
+   ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.017..0.018 rows=5 loops=1)
+         Node Summary:                  vmax       vsum       vcnt       imax
+           ntuples:                        5         10          3          0
+           execmemused:                    0          0          0          0
+           workmemused:                    0          0          0          0
+           workmemwanted:                  0          0          0          0
+           totalWorkfileCreated:           0          0          0          0
+           peakMemBalance:             15872      47616          3          0
+           totalPartTableScanned:          0          0          0          0
+           segindex0: 0
+           ninst: 3
+           StatInsts:
+             (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
+             (seg0) 211 0.00 0.00 0.00 5.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+             (seg1) 211 0.00 0.00 0.00 1.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+             (seg2) 211 0.00 0.00 0.00 4.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+ Planning time: 6.834 ms
+   (slice0)    Executor memory: 27K bytes.
+   (slice1)    Executor memory: 25K bytes avg x 3 workers, 25K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 0.900 ms
+(36 rows)
+
+set gp_enable_explain_node_summary=DEFAULT;
+
 --
 -- The same slice may have different number of plan nodes on every qExec.
 -- Check if explain analyze can work in that case

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -444,10 +444,12 @@ set gp_enable_explain_allstat=DEFAULT;
 -- s/\(cost=\d+.\d+..\d+.\d+ /(cost=X.X..X.X /
 -- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
 -- s/\(actual time=\d+.\d+..\d+.\d+ /(actual time=X.X..X.X /
--- m/"firststart": \d+,/
--- s/"firststart": \d+,/"firststart": XXXXXX,/
--- m/"Actual Total Time": \d+,/
--- s/"Actual Total Time": \d+,/"Actual Total Time": X.XXX,/
+-- m/"firststart": \d+,\s*/
+-- s/"firststart": \d+,\s*/"firststart": XXXXXX, /
+-- m/"Actual Total Time": \d+\.\d+\s*/
+-- s/"Actual Total Time": \d+\.\d+,\s*/"Actual Total Time": X.XXX, /
+-- m/"Actual Startup Time": \d+\.\d+,\s*/
+-- s/"Actual Startup Time": \d+\.\d+,\s*/"Actual Startup Time": X.XXX, /
 -- end_matchsubs
 set gp_enable_explain_node_summary=on;
 explain (analyze, summary off)
@@ -506,8 +508,8 @@ SELECT * FROM explaintest;
        "Total Cost": 1.17,                    +
        "Plan Rows": 10,                       +
        "Plan Width": 4,                       +
-       "Actual Startup Time": 0.000,          +
-       "Actual Total Time": 0.000,            +
+       "Actual Startup Time": X.XXX, +
+       "Actual Total Time": X.XXX, +
        "Actual Rows": 10,                     +
        "Actual Loops": 1,                     +
        "CdbExplain_NodeSummary": {            +
@@ -573,7 +575,7 @@ SELECT * FROM explaintest;
              "workmemused": 0,                +
              "workmemwanted": 0,              +
              "workfileCreated": false,        +
-             "firststart": XXXXXX,            +
+             "firststart": XXXXXX, +
              "numPartScanned": 0,             +
              "bnotes": 0,                     +
              "enotes": 0,                     +
@@ -596,8 +598,8 @@ SELECT * FROM explaintest;
            "Total Cost": 1.03,                +
            "Plan Rows": 3,                    +
            "Plan Width": 4,                   +
-           "Actual Startup Time": 0.000,      +
-           "Actual Total Time": 0.000,        +
+           "Actual Startup Time": X.XXX, +
+           "Actual Total Time": X.XXX, +
            "Actual Rows": 5,                  +
            "Actual Loops": 1,                 +
            "CdbExplain_NodeSummary": {        +
@@ -663,7 +665,7 @@ SELECT * FROM explaintest;
                  "workmemused": 0,            +
                  "workmemwanted": 0,          +
                  "workfileCreated": false,    +
-                 "firststart": XXXXXX,        +
+                 "firststart": XXXXXX, +
                  "numPartScanned": 0,         +
                  "bnotes": 0,                 +
                  "enotes": 0,                 +
@@ -686,7 +688,7 @@ SELECT * FROM explaintest;
                  "workmemused": 0,            +
                  "workmemwanted": 0,          +
                  "workfileCreated": false,    +
-                 "firststart": XXXXXX,        +
+                 "firststart": XXXXXX, +
                  "numPartScanned": 0,         +
                  "bnotes": 0,                 +
                  "enotes": 0,                 +
@@ -709,7 +711,7 @@ SELECT * FROM explaintest;
                  "workmemused": 0,            +
                  "workmemwanted": 0,          +
                  "workfileCreated": false,    +
-                 "firststart": XXXXXX,        +
+                 "firststart": XXXXXX, +
                  "numPartScanned": 0,         +
                  "bnotes": 0,                 +
                  "enotes": 0,                 +

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -436,6 +436,50 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.17 rows=10 width=4) (actual time=1.000..1.000 rows=10 loops=1)
+   Node Summary:                  vmax       vsum       vcnt       imax
+     ntuples:                       10         10          1         -1
+     nloops:                         1          1          1         -1
+     execmemused:                    0          0          0          0
+     workmemused:                    0          0          0          0
+     workmemwanted:                  0          0          0          0
+     totalWorkfileCreated:           0          0          0          0
+     totalPartTableScanned:          0          0          0          0
+     segindex0: -1
+     ninst: 1
+     StatInsts:
+       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
+       (seg-1) 138 0 0 0.00 0.00 0.00 10 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+   ->  Seq Scan on explaintest  (cost=0.00..1.03 rows=3 width=4) (actual time=0.000..0.000 rows=5 loops=1)
+         Node Summary:                  vmax       vsum       vcnt       imax
+           ntuples:                        5         10          3          0
+           nloops:                         1          3          3          0
+           execmemused:                    0          0          0          0
+           workmemused:                    0          0          0          0
+           workmemwanted:                  0          0          0          0
+           totalWorkfileCreated:           0          0          0          0
+           totalPartTableScanned:          0          0          0          0
+           segindex0: 0
+           ninst: 3
+           StatInsts:
+             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
+             (seg0) 95 0 0 0.00 0.00 0.00 5 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+             (seg1) 95 0 0 0.00 0.00 0.00 1 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+             (seg2) 95 0 0 0.00 0.00 0.00 4 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+ Planning Time: 0.079 ms
+   (slice0)    Executor memory: 111K bytes.
+   (slice1)    Executor memory: 110K bytes avg x 3x(0) workers, 110K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 0.496 ms
+(36 rows)
+
+set gp_enable_explain_node_summary=DEFAULT;
 --
 -- Test GPDB-specific EXPLAIN (SLICETABLE) option.
 --
@@ -500,51 +544,6 @@ explain (slicetable, costs off, format json) SELECT * FROM explaintest;
    }                                          +
  ]
 (1 row)
-
--- Test explain node summary.
-set gp_enable_explain_node_summary=on;
-explain analyze SELECT * FROM explaintest;
-                                                                                                               QUERY PLAN                                                                                                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.476..0.484 rows=10 loops=1)
-   Node Summary:                  vmax       vsum       vcnt       imax
-     ntuples:                       10         10          1         -1
-     execmemused:                    0          0          0          0
-     workmemused:                    0          0          0          0
-     workmemwanted:                  0          0          0          0
-     totalWorkfileCreated:           0          0          0          0
-     peakMemBalance:              5336       5336          1         -1
-     totalPartTableScanned:          0          0          0          0
-     segindex0: -1
-     ninst: 1
-     StatInsts:
-       (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
-       (seg-1) 241 0.00 0.00 0.00 10.00 1.00 0 0 0 0 0 0 5336.00 0 0 0 0 0 0 0
-   ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.017..0.018 rows=5 loops=1)
-         Node Summary:                  vmax       vsum       vcnt       imax
-           ntuples:                        5         10          3          0
-           execmemused:                    0          0          0          0
-           workmemused:                    0          0          0          0
-           workmemwanted:                  0          0          0          0
-           totalWorkfileCreated:           0          0          0          0
-           peakMemBalance:             15872      47616          3          0
-           totalPartTableScanned:          0          0          0          0
-           segindex0: 0
-           ninst: 3
-           StatInsts:
-             (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
-             (seg0) 211 0.00 0.00 0.00 5.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
-             (seg1) 211 0.00 0.00 0.00 1.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
-             (seg2) 211 0.00 0.00 0.00 4.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
- Planning time: 6.834 ms
-   (slice0)    Executor memory: 27K bytes.
-   (slice1)    Executor memory: 25K bytes avg x 3 workers, 25K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 0.900 ms
-(36 rows)
-
-set gp_enable_explain_node_summary=DEFAULT;
 
 --
 -- The same slice may have different number of plan nodes on every qExec.

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -437,11 +437,24 @@ explain analyze SELECT * FROM explaintest;
 
 set gp_enable_explain_allstat=DEFAULT;
 -- Test explain node summary.
+-- start_matchsubs
+-- m/\(seg-?\d+\) \d+ \d+ \d+ \d+.\d+ \d+.\d+ \d+.\d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+/
+-- s/\(seg-?\d+\) \d+ \d+ \d+ \d+.\d+ \d+.\d+ \d+.\d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+/(segX) X X X X.X X.X X.X X X X X X X X X X X X X X X/
+-- m/\(cost=\d+.\d+..\d+.\d+ rows=\d+ width=\d+\)/
+-- s/\(cost=\d+.\d+..\d+.\d+ /(cost=X.X..X.X /
+-- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+.\d+..\d+.\d+ /(actual time=X.X..X.X /
+-- m/"firststart": \d+,/
+-- s/"firststart": \d+,/"firststart": XXXXXX,/
+-- m/"Actual Total Time": \d+,/
+-- s/"Actual Total Time": \d+,/"Actual Total Time": X.XXX,/
+-- end_matchsubs
 set gp_enable_explain_node_summary=on;
-explain analyze SELECT * FROM explaintest;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.17 rows=10 width=4) (actual time=1.000..1.000 rows=10 loops=1)
+explain (analyze, summary off)
+SELECT * FROM explaintest;
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.17 rows=10 width=4) (actual time=0.000..0.000 rows=10 loops=1)
    Node Summary:                  vmax       vsum       vcnt       imax
      ntuples:                       10         10          1         -1
      nloops:                         1          1          1         -1
@@ -453,8 +466,8 @@ explain analyze SELECT * FROM explaintest;
      segindex0: -1
      ninst: 1
      StatInsts:
-       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
-       (seg-1) 138 0 0 0.00 0.00 0.00 10 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes nworkers_launched
+       (seg-1) 138 0 0 0.00 0.00 0.00 10 0 1 0 0 0 0 0 0 686899 0 0 0 0
    ->  Seq Scan on explaintest  (cost=0.00..1.03 rows=3 width=4) (actual time=0.000..0.000 rows=5 loops=1)
          Node Summary:                  vmax       vsum       vcnt       imax
            ntuples:                        5         10          3          0
@@ -467,17 +480,254 @@ explain analyze SELECT * FROM explaintest;
            segindex0: 0
            ninst: 3
            StatInsts:
-             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
-             (seg0) 95 0 0 0.00 0.00 0.00 5 0 1 0 0 0 0 0 0 1798475 0 0 0 0
-             (seg1) 95 0 0 0.00 0.00 0.00 1 0 1 0 0 0 0 0 0 1798475 0 0 0 0
-             (seg2) 95 0 0 0.00 0.00 0.00 4 0 1 0 0 0 0 0 0 1798475 0 0 0 0
- Planning Time: 0.079 ms
-   (slice0)    Executor memory: 111K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3x(0) workers, 110K bytes max (seg0).
- Memory used:  128000kB
+             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes nworkers_launched
+             (seg0) 95 0 0 0.00 0.00 0.00 5 0 1 0 0 0 0 0 0 686899 0 0 0 0
+             (seg1) 95 0 0 0.00 0.00 0.00 1 0 1 0 0 0 0 0 0 686899 0 0 0 0
+             (seg2) 95 0 0 0.00 0.00 0.00 4 0 1 0 0 0 0 0 0 686899 0 0 0 0
  Optimizer: Postgres query optimizer
- Execution Time: 0.496 ms
-(36 rows)
+(31 rows)
+
+explain (analyze, summary off, format json)
+SELECT * FROM explaintest;
+                  QUERY PLAN                   
+-----------------------------------------------
+ [                                            +
+   {                                          +
+     "Plan": {                                +
+       "Node Type": "Gather Motion",          +
+       "Senders": 3,                          +
+       "Receivers": 1,                        +
+       "Slice": 1,                            +
+       "Segments": 3,                         +
+       "Gang Type": "primary reader",         +
+       "Parallel Aware": false,               +
+       "Async Capable": false,                +
+       "Startup Cost": 0.00,                  +
+       "Total Cost": 1.17,                    +
+       "Plan Rows": 10,                       +
+       "Plan Width": 4,                       +
+       "Actual Startup Time": 0.000,          +
+       "Actual Total Time": 0.000,            +
+       "Actual Rows": 10,                     +
+       "Actual Loops": 1,                     +
+       "CdbExplain_NodeSummary": {            +
+         "ntuples": {                         +
+           "vmax": 10,                        +
+           "vsum": 10,                        +
+           "vcnt": 1,                         +
+           "imax": -1                         +
+         },                                   +
+         "nloops": {                          +
+           "vmax": 1,                         +
+           "vsum": 1,                         +
+           "vcnt": 1,                         +
+           "imax": -1                         +
+         },                                   +
+         "execmemused": {                     +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "workmemused": {                     +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "workmemwanted": {                   +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "totalWorkfileCreated": {            +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "totalPartTableScanned": {           +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "segindex0": -1,                     +
+         "ninst": 1,                          +
+         "CdbExplain_StatInsts": [            +
+           {                                  +
+             "Segment": -1,                   +
+             "pstype": 138,                   +
+             "starttime": 0,                  +
+             "counter": 0,                    +
+             "firsttuple": 0.00,              +
+             "startup": 0.00,                 +
+             "total": 0.00,                   +
+             "ntuples": 10,                   +
+             "ntuples2": 0,                   +
+             "nloops": 1,                     +
+             "nfiltered1": 0,                 +
+             "nfiltered2": 0,                 +
+             "execmemused": 0,                +
+             "workmemused": 0,                +
+             "workmemwanted": 0,              +
+             "workfileCreated": false,        +
+             "firststart": XXXXXX,            +
+             "numPartScanned": 0,             +
+             "bnotes": 0,                     +
+             "enotes": 0,                     +
+             "nworkers_launched": 0           +
+           }                                  +
+         ]                                    +
+       },                                     +
+       "Plans": [                             +
+         {                                    +
+           "Node Type": "Seq Scan",           +
+           "Parent Relationship": "Outer",    +
+           "Slice": 1,                        +
+           "Segments": 3,                     +
+           "Gang Type": "primary reader",     +
+           "Parallel Aware": false,           +
+           "Async Capable": false,            +
+           "Relation Name": "explaintest",    +
+           "Alias": "explaintest",            +
+           "Startup Cost": 0.00,              +
+           "Total Cost": 1.03,                +
+           "Plan Rows": 3,                    +
+           "Plan Width": 4,                   +
+           "Actual Startup Time": 0.000,      +
+           "Actual Total Time": 0.000,        +
+           "Actual Rows": 5,                  +
+           "Actual Loops": 1,                 +
+           "CdbExplain_NodeSummary": {        +
+             "ntuples": {                     +
+               "vmax": 5,                     +
+               "vsum": 10,                    +
+               "vcnt": 3,                     +
+               "imax": 0                      +
+             },                               +
+             "nloops": {                      +
+               "vmax": 1,                     +
+               "vsum": 3,                     +
+               "vcnt": 3,                     +
+               "imax": 0                      +
+             },                               +
+             "execmemused": {                 +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "workmemused": {                 +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "workmemwanted": {               +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "totalWorkfileCreated": {        +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "totalPartTableScanned": {       +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "segindex0": 0,                  +
+             "ninst": 3,                      +
+             "CdbExplain_StatInsts": [        +
+               {                              +
+                 "Segment": 0,                +
+                 "pstype": 95,                +
+                 "starttime": 0,              +
+                 "counter": 0,                +
+                 "firsttuple": 0.00,          +
+                 "startup": 0.00,             +
+                 "total": 0.00,               +
+                 "ntuples": 5,                +
+                 "ntuples2": 0,               +
+                 "nloops": 1,                 +
+                 "nfiltered1": 0,             +
+                 "nfiltered2": 0,             +
+                 "execmemused": 0,            +
+                 "workmemused": 0,            +
+                 "workmemwanted": 0,          +
+                 "workfileCreated": false,    +
+                 "firststart": XXXXXX,        +
+                 "numPartScanned": 0,         +
+                 "bnotes": 0,                 +
+                 "enotes": 0,                 +
+                 "nworkers_launched": 0       +
+               },                             +
+               {                              +
+                 "Segment": 1,                +
+                 "pstype": 95,                +
+                 "starttime": 0,              +
+                 "counter": 0,                +
+                 "firsttuple": 0.00,          +
+                 "startup": 0.00,             +
+                 "total": 0.00,               +
+                 "ntuples": 1,                +
+                 "ntuples2": 0,               +
+                 "nloops": 1,                 +
+                 "nfiltered1": 0,             +
+                 "nfiltered2": 0,             +
+                 "execmemused": 0,            +
+                 "workmemused": 0,            +
+                 "workmemwanted": 0,          +
+                 "workfileCreated": false,    +
+                 "firststart": XXXXXX,        +
+                 "numPartScanned": 0,         +
+                 "bnotes": 0,                 +
+                 "enotes": 0,                 +
+                 "nworkers_launched": 0       +
+               },                             +
+               {                              +
+                 "Segment": 2,                +
+                 "pstype": 95,                +
+                 "starttime": 0,              +
+                 "counter": 0,                +
+                 "firsttuple": 0.00,          +
+                 "startup": 0.00,             +
+                 "total": 0.00,               +
+                 "ntuples": 4,                +
+                 "ntuples2": 0,               +
+                 "nloops": 1,                 +
+                 "nfiltered1": 0,             +
+                 "nfiltered2": 0,             +
+                 "execmemused": 0,            +
+                 "workmemused": 0,            +
+                 "workmemwanted": 0,          +
+                 "workfileCreated": false,    +
+                 "firststart": XXXXXX,        +
+                 "numPartScanned": 0,         +
+                 "bnotes": 0,                 +
+                 "enotes": 0,                 +
+                 "nworkers_launched": 0       +
+               }                              +
+             ]                                +
+           }                                  +
+         }                                    +
+       ]                                      +
+     },                                       +
+     "Settings": {                            +
+       "Optimizer": "Postgres query optimizer"+
+     },                                       +
+     "Triggers": [                            +
+     ]                                        +
+   }                                          +
+ ]
+(1 row)
 
 set gp_enable_explain_node_summary=DEFAULT;
 --

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -458,6 +458,50 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.17 rows=10 width=4) (actual time=1.000..1.000 rows=10 loops=1)
+   Node Summary:                  vmax       vsum       vcnt       imax
+     ntuples:                       10         10          1         -1
+     nloops:                         1          1          1         -1
+     execmemused:                    0          0          0          0
+     workmemused:                    0          0          0          0
+     workmemwanted:                  0          0          0          0
+     totalWorkfileCreated:           0          0          0          0
+     totalPartTableScanned:          0          0          0          0
+     segindex0: -1
+     ninst: 1
+     StatInsts:
+       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
+       (seg-1) 138 0 0 0.00 0.00 0.00 10 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+   ->  Seq Scan on explaintest  (cost=0.00..1.03 rows=3 width=4) (actual time=0.000..0.000 rows=5 loops=1)
+         Node Summary:                  vmax       vsum       vcnt       imax
+           ntuples:                        5         10          3          0
+           nloops:                         1          3          3          0
+           execmemused:                    0          0          0          0
+           workmemused:                    0          0          0          0
+           workmemwanted:                  0          0          0          0
+           totalWorkfileCreated:           0          0          0          0
+           totalPartTableScanned:          0          0          0          0
+           segindex0: 0
+           ninst: 3
+           StatInsts:
+             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
+             (seg0) 95 0 0 0.00 0.00 0.00 5 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+             (seg1) 95 0 0 0.00 0.00 0.00 1 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+             (seg2) 95 0 0 0.00 0.00 0.00 4 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+ Planning Time: 0.079 ms
+   (slice0)    Executor memory: 111K bytes.
+   (slice1)    Executor memory: 110K bytes avg x 3x(0) workers, 110K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution Time: 0.496 ms
+(36 rows)
+
+set gp_enable_explain_node_summary=DEFAULT;
 --
 -- Test GPDB-specific EXPLAIN (SLICETABLE) option.
 --

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -466,10 +466,12 @@ set gp_enable_explain_allstat=DEFAULT;
 -- s/\(cost=\d+.\d+..\d+.\d+ /(cost=X.X..X.X /
 -- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
 -- s/\(actual time=\d+.\d+..\d+.\d+ /(actual time=X.X..X.X /
--- m/"firststart": \d+,/
--- s/"firststart": \d+,/"firststart": XXXXXX,/
--- m/"Actual Total Time": \d+,/
--- s/"Actual Total Time": \d+,/"Actual Total Time": X.XXX,/
+-- m/"firststart": \d+,\s*/
+-- s/"firststart": \d+,\s*/"firststart": XXXXXX, /
+-- m/"Actual Total Time": \d+\.\d+\s*/
+-- s/"Actual Total Time": \d+\.\d+,\s*/"Actual Total Time": X.XXX, /
+-- m/"Actual Startup Time": \d+\.\d+,\s*/
+-- s/"Actual Startup Time": \d+\.\d+,\s*/"Actual Startup Time": X.XXX, /
 -- end_matchsubs
 set gp_enable_explain_node_summary=on;
 explain (analyze, summary off)
@@ -528,8 +530,8 @@ SELECT * FROM explaintest;
        "Total Cost": 1.17,                    +
        "Plan Rows": 10,                       +
        "Plan Width": 4,                       +
-       "Actual Startup Time": 0.000,          +
-       "Actual Total Time": 0.000,            +
+       "Actual Startup Time": X.XXX, +
+       "Actual Total Time": X.XXX, +
        "Actual Rows": 10,                     +
        "Actual Loops": 1,                     +
        "CdbExplain_NodeSummary": {            +
@@ -595,7 +597,7 @@ SELECT * FROM explaintest;
              "workmemused": 0,                +
              "workmemwanted": 0,              +
              "workfileCreated": false,        +
-             "firststart": XXXXXX,            +
+             "firststart": XXXXXX, +
              "numPartScanned": 0,             +
              "bnotes": 0,                     +
              "enotes": 0,                     +
@@ -618,8 +620,8 @@ SELECT * FROM explaintest;
            "Total Cost": 1.03,                +
            "Plan Rows": 3,                    +
            "Plan Width": 4,                   +
-           "Actual Startup Time": 0.000,      +
-           "Actual Total Time": 0.000,        +
+           "Actual Startup Time": X.XXX, +
+           "Actual Total Time": X.XXX, +
            "Actual Rows": 5,                  +
            "Actual Loops": 1,                 +
            "CdbExplain_NodeSummary": {        +
@@ -685,7 +687,7 @@ SELECT * FROM explaintest;
                  "workmemused": 0,            +
                  "workmemwanted": 0,          +
                  "workfileCreated": false,    +
-                 "firststart": XXXXXX,        +
+                 "firststart": XXXXXX, +
                  "numPartScanned": 0,         +
                  "bnotes": 0,                 +
                  "enotes": 0,                 +
@@ -708,7 +710,7 @@ SELECT * FROM explaintest;
                  "workmemused": 0,            +
                  "workmemwanted": 0,          +
                  "workfileCreated": false,    +
-                 "firststart": XXXXXX,        +
+                 "firststart": XXXXXX, +
                  "numPartScanned": 0,         +
                  "bnotes": 0,                 +
                  "enotes": 0,                 +
@@ -731,7 +733,7 @@ SELECT * FROM explaintest;
                  "workmemused": 0,            +
                  "workmemwanted": 0,          +
                  "workfileCreated": false,    +
-                 "firststart": XXXXXX,        +
+                 "firststart": XXXXXX, +
                  "numPartScanned": 0,         +
                  "bnotes": 0,                 +
                  "enotes": 0,                 +

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -459,11 +459,24 @@ explain analyze SELECT * FROM explaintest;
 
 set gp_enable_explain_allstat=DEFAULT;
 -- Test explain node summary.
+-- start_matchsubs
+-- m/\(seg-?\d+\) \d+ \d+ \d+ \d+.\d+ \d+.\d+ \d+.\d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+/
+-- s/\(seg-?\d+\) \d+ \d+ \d+ \d+.\d+ \d+.\d+ \d+.\d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+/(segX) X X X X.X X.X X.X X X X X X X X X X X X X X X/
+-- m/\(cost=\d+.\d+..\d+.\d+ rows=\d+ width=\d+\)/
+-- s/\(cost=\d+.\d+..\d+.\d+ /(cost=X.X..X.X /
+-- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+.\d+..\d+.\d+ /(actual time=X.X..X.X /
+-- m/"firststart": \d+,/
+-- s/"firststart": \d+,/"firststart": XXXXXX,/
+-- m/"Actual Total Time": \d+,/
+-- s/"Actual Total Time": \d+,/"Actual Total Time": X.XXX,/
+-- end_matchsubs
 set gp_enable_explain_node_summary=on;
-explain analyze SELECT * FROM explaintest;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.17 rows=10 width=4) (actual time=1.000..1.000 rows=10 loops=1)
+explain (analyze, summary off)
+SELECT * FROM explaintest;
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.17 rows=10 width=4) (actual time=0.000..0.000 rows=10 loops=1)
    Node Summary:                  vmax       vsum       vcnt       imax
      ntuples:                       10         10          1         -1
      nloops:                         1          1          1         -1
@@ -475,8 +488,8 @@ explain analyze SELECT * FROM explaintest;
      segindex0: -1
      ninst: 1
      StatInsts:
-       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
-       (seg-1) 138 0 0 0.00 0.00 0.00 10 0 1 0 0 0 0 0 0 1798475 0 0 0 0
+       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes nworkers_launched
+       (seg-1) 138 0 0 0.00 0.00 0.00 10 0 1 0 0 0 0 0 0 686899 0 0 0 0
    ->  Seq Scan on explaintest  (cost=0.00..1.03 rows=3 width=4) (actual time=0.000..0.000 rows=5 loops=1)
          Node Summary:                  vmax       vsum       vcnt       imax
            ntuples:                        5         10          3          0
@@ -489,17 +502,254 @@ explain analyze SELECT * FROM explaintest;
            segindex0: 0
            ninst: 3
            StatInsts:
-             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes, nworkers_launched
-             (seg0) 95 0 0 0.00 0.00 0.00 5 0 1 0 0 0 0 0 0 1798475 0 0 0 0
-             (seg1) 95 0 0 0.00 0.00 0.00 1 0 1 0 0 0 0 0 0 1798475 0 0 0 0
-             (seg2) 95 0 0 0.00 0.00 0.00 4 0 1 0 0 0 0 0 0 1798475 0 0 0 0
- Planning Time: 0.079 ms
-   (slice0)    Executor memory: 111K bytes.
-   (slice1)    Executor memory: 110K bytes avg x 3x(0) workers, 110K bytes max (seg0).
- Memory used:  128000kB
+             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreated firststart numPartScanned bnotes enotes nworkers_launched
+             (seg0) 95 0 0 0.00 0.00 0.00 5 0 1 0 0 0 0 0 0 686899 0 0 0 0
+             (seg1) 95 0 0 0.00 0.00 0.00 1 0 1 0 0 0 0 0 0 686899 0 0 0 0
+             (seg2) 95 0 0 0.00 0.00 0.00 4 0 1 0 0 0 0 0 0 686899 0 0 0 0
  Optimizer: Postgres query optimizer
- Execution Time: 0.496 ms
-(36 rows)
+(31 rows)
+
+explain (analyze, summary off, format json)
+SELECT * FROM explaintest;
+                  QUERY PLAN                   
+-----------------------------------------------
+ [                                            +
+   {                                          +
+     "Plan": {                                +
+       "Node Type": "Gather Motion",          +
+       "Senders": 3,                          +
+       "Receivers": 1,                        +
+       "Slice": 1,                            +
+       "Segments": 3,                         +
+       "Gang Type": "primary reader",         +
+       "Parallel Aware": false,               +
+       "Async Capable": false,                +
+       "Startup Cost": 0.00,                  +
+       "Total Cost": 1.17,                    +
+       "Plan Rows": 10,                       +
+       "Plan Width": 4,                       +
+       "Actual Startup Time": 0.000,          +
+       "Actual Total Time": 0.000,            +
+       "Actual Rows": 10,                     +
+       "Actual Loops": 1,                     +
+       "CdbExplain_NodeSummary": {            +
+         "ntuples": {                         +
+           "vmax": 10,                        +
+           "vsum": 10,                        +
+           "vcnt": 1,                         +
+           "imax": -1                         +
+         },                                   +
+         "nloops": {                          +
+           "vmax": 1,                         +
+           "vsum": 1,                         +
+           "vcnt": 1,                         +
+           "imax": -1                         +
+         },                                   +
+         "execmemused": {                     +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "workmemused": {                     +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "workmemwanted": {                   +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "totalWorkfileCreated": {            +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "totalPartTableScanned": {           +
+           "vmax": 0,                         +
+           "vsum": 0,                         +
+           "vcnt": 0,                         +
+           "imax": 0                          +
+         },                                   +
+         "segindex0": -1,                     +
+         "ninst": 1,                          +
+         "CdbExplain_StatInsts": [            +
+           {                                  +
+             "Segment": -1,                   +
+             "pstype": 138,                   +
+             "starttime": 0,                  +
+             "counter": 0,                    +
+             "firsttuple": 0.00,              +
+             "startup": 0.00,                 +
+             "total": 0.00,                   +
+             "ntuples": 10,                   +
+             "ntuples2": 0,                   +
+             "nloops": 1,                     +
+             "nfiltered1": 0,                 +
+             "nfiltered2": 0,                 +
+             "execmemused": 0,                +
+             "workmemused": 0,                +
+             "workmemwanted": 0,              +
+             "workfileCreated": false,        +
+             "firststart": XXXXXX,            +
+             "numPartScanned": 0,             +
+             "bnotes": 0,                     +
+             "enotes": 0,                     +
+             "nworkers_launched": 0           +
+           }                                  +
+         ]                                    +
+       },                                     +
+       "Plans": [                             +
+         {                                    +
+           "Node Type": "Seq Scan",           +
+           "Parent Relationship": "Outer",    +
+           "Slice": 1,                        +
+           "Segments": 3,                     +
+           "Gang Type": "primary reader",     +
+           "Parallel Aware": false,           +
+           "Async Capable": false,            +
+           "Relation Name": "explaintest",    +
+           "Alias": "explaintest",            +
+           "Startup Cost": 0.00,              +
+           "Total Cost": 1.03,                +
+           "Plan Rows": 3,                    +
+           "Plan Width": 4,                   +
+           "Actual Startup Time": 0.000,      +
+           "Actual Total Time": 0.000,        +
+           "Actual Rows": 5,                  +
+           "Actual Loops": 1,                 +
+           "CdbExplain_NodeSummary": {        +
+             "ntuples": {                     +
+               "vmax": 5,                     +
+               "vsum": 10,                    +
+               "vcnt": 3,                     +
+               "imax": 0                      +
+             },                               +
+             "nloops": {                      +
+               "vmax": 1,                     +
+               "vsum": 3,                     +
+               "vcnt": 3,                     +
+               "imax": 0                      +
+             },                               +
+             "execmemused": {                 +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "workmemused": {                 +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "workmemwanted": {               +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "totalWorkfileCreated": {        +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "totalPartTableScanned": {       +
+               "vmax": 0,                     +
+               "vsum": 0,                     +
+               "vcnt": 0,                     +
+               "imax": 0                      +
+             },                               +
+             "segindex0": 0,                  +
+             "ninst": 3,                      +
+             "CdbExplain_StatInsts": [        +
+               {                              +
+                 "Segment": 0,                +
+                 "pstype": 95,                +
+                 "starttime": 0,              +
+                 "counter": 0,                +
+                 "firsttuple": 0.00,          +
+                 "startup": 0.00,             +
+                 "total": 0.00,               +
+                 "ntuples": 5,                +
+                 "ntuples2": 0,               +
+                 "nloops": 1,                 +
+                 "nfiltered1": 0,             +
+                 "nfiltered2": 0,             +
+                 "execmemused": 0,            +
+                 "workmemused": 0,            +
+                 "workmemwanted": 0,          +
+                 "workfileCreated": false,    +
+                 "firststart": XXXXXX,        +
+                 "numPartScanned": 0,         +
+                 "bnotes": 0,                 +
+                 "enotes": 0,                 +
+                 "nworkers_launched": 0       +
+               },                             +
+               {                              +
+                 "Segment": 1,                +
+                 "pstype": 95,                +
+                 "starttime": 0,              +
+                 "counter": 0,                +
+                 "firsttuple": 0.00,          +
+                 "startup": 0.00,             +
+                 "total": 0.00,               +
+                 "ntuples": 1,                +
+                 "ntuples2": 0,               +
+                 "nloops": 1,                 +
+                 "nfiltered1": 0,             +
+                 "nfiltered2": 0,             +
+                 "execmemused": 0,            +
+                 "workmemused": 0,            +
+                 "workmemwanted": 0,          +
+                 "workfileCreated": false,    +
+                 "firststart": XXXXXX,        +
+                 "numPartScanned": 0,         +
+                 "bnotes": 0,                 +
+                 "enotes": 0,                 +
+                 "nworkers_launched": 0       +
+               },                             +
+               {                              +
+                 "Segment": 2,                +
+                 "pstype": 95,                +
+                 "starttime": 0,              +
+                 "counter": 0,                +
+                 "firsttuple": 0.00,          +
+                 "startup": 0.00,             +
+                 "total": 0.00,               +
+                 "ntuples": 4,                +
+                 "ntuples2": 0,               +
+                 "nloops": 1,                 +
+                 "nfiltered1": 0,             +
+                 "nfiltered2": 0,             +
+                 "execmemused": 0,            +
+                 "workmemused": 0,            +
+                 "workmemwanted": 0,          +
+                 "workfileCreated": false,    +
+                 "firststart": XXXXXX,        +
+                 "numPartScanned": 0,         +
+                 "bnotes": 0,                 +
+                 "enotes": 0,                 +
+                 "nworkers_launched": 0       +
+               }                              +
+             ]                                +
+           }                                  +
+         }                                    +
+       ]                                      +
+     },                                       +
+     "Settings": {                            +
+       "Optimizer": "Postgres query optimizer"+
+     },                                       +
+     "Triggers": [                            +
+     ]                                        +
+   }                                          +
+ ]
+(1 row)
 
 set gp_enable_explain_node_summary=DEFAULT;
 --

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -230,8 +230,23 @@ set gp_enable_explain_allstat=DEFAULT;
 
 
 -- Test explain node summary.
+-- start_matchsubs
+-- m/\(seg-?\d+\) \d+ \d+ \d+ \d+.\d+ \d+.\d+ \d+.\d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+/
+-- s/\(seg-?\d+\) \d+ \d+ \d+ \d+.\d+ \d+.\d+ \d+.\d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+ \d+/(segX) X X X X.X X.X X.X X X X X X X X X X X X X X X/
+-- m/\(cost=\d+.\d+..\d+.\d+ rows=\d+ width=\d+\)/
+-- s/\(cost=\d+.\d+..\d+.\d+ /(cost=X.X..X.X /
+-- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
+-- s/\(actual time=\d+.\d+..\d+.\d+ /(actual time=X.X..X.X /
+-- m/"firststart": \d+,/
+-- s/"firststart": \d+,/"firststart": XXXXXX,/
+-- m/"Actual Total Time": \d+,/
+-- s/"Actual Total Time": \d+,/"Actual Total Time": X.XXX,/
+-- end_matchsubs
 set gp_enable_explain_node_summary=on;
-explain analyze SELECT * FROM explaintest;
+explain (analyze, summary off)
+SELECT * FROM explaintest;
+explain (analyze, summary off, format json)
+SELECT * FROM explaintest;
 set gp_enable_explain_node_summary=DEFAULT;
 
 --

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -237,10 +237,12 @@ set gp_enable_explain_allstat=DEFAULT;
 -- s/\(cost=\d+.\d+..\d+.\d+ /(cost=X.X..X.X /
 -- m/\(actual time=\d+.\d+..\d+.\d+ rows=\d+ loops=\d+\)/
 -- s/\(actual time=\d+.\d+..\d+.\d+ /(actual time=X.X..X.X /
--- m/"firststart": \d+,/
--- s/"firststart": \d+,/"firststart": XXXXXX,/
--- m/"Actual Total Time": \d+,/
--- s/"Actual Total Time": \d+,/"Actual Total Time": X.XXX,/
+-- m/"firststart": \d+,\s*/
+-- s/"firststart": \d+,\s*/"firststart": XXXXXX, /
+-- m/"Actual Total Time": \d+\.\d+\s*/
+-- s/"Actual Total Time": \d+\.\d+,\s*/"Actual Total Time": X.XXX, /
+-- m/"Actual Startup Time": \d+\.\d+,\s*/
+-- s/"Actual Startup Time": \d+\.\d+,\s*/"Actual Startup Time": X.XXX, /
 -- end_matchsubs
 set gp_enable_explain_node_summary=on;
 explain (analyze, summary off)

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -229,6 +229,11 @@ explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_allstat=DEFAULT;
 
 
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+set gp_enable_explain_node_summary=DEFAULT;
+
 --
 -- Test GPDB-specific EXPLAIN (SLICETABLE) option.
 --


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Cherry pick of https://github.com/robozmey/gpdb/commit/4b05cbf796eac2d40f6f8233c3a6e6f1144458ee

Dumps content of CdbExplain_NodeSummary into Node descriprion in EXPLAIN ANALYZE

`drop table if exists tt; create table tt (a int, b int) with(parallel_workers=2) distributed by (a);`

`insert into tt select * from generate_series(1,1000)a,generate_series(1,1000)b;`

`set enable_parallel = on;`

`set max_parallel_workers_per_gather = 2;`

`set gp_enable_explain_node_summary=on;`

`explain (analyze) select * from tt where a > b;`

```
                                                                                                             QUERY PLAN                                           
                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)  (cost=0.00..548.21 rows=28700 width=8) (actual time=1.000..53.000 rows=499500 loops=1)
   Node Summary:                  vmax       vsum       vcnt       imax
     ntuples:                   499500     499500          1         -1
     nloops:                         1          1          1         -1
     execmemused:                    0          0          0          0
     workmemused:                    0          0          0          0
     workmemwanted:                  0          0          0          0
     totalWorkfileCreated:           0          0          0          0
     totalPartTableScanned:          0          0          0          0
     segindex0: -1
     ninst: 1
     StatInsts:
       (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfileCreate
d firststart numPartScanned bnotes enotes, nworkers_launched
       (seg-1) 138 0 0 0.00 0.00 0.05 499500 0 1 0 0 0 0 0 0 1798033 0 0 0 0
   ->  Parallel Seq Scan on tt  (cost=0.00..213.38 rows=4783 width=8) (actual time=0.000..15.000 rows=85736 loops=1)
         Filter: (a < b)
         Rows Removed by Filter: 82281
         Node Summary:                  vmax       vsum       vcnt       imax
           ntuples:                    85736     499500          6          0
           nloops:                         1          6          6          0
           execmemused:                    0          0          0          0
           workmemused:                    0          0          0          0
           workmemwanted:                  0          0          0          0
           totalWorkfileCreated:           0          0          0          0
           totalPartTableScanned:          0          0          0          0
           segindex0: 0
           ninst: 3
           StatInsts:
             (segN) pstype starttime counter firsttuple startup total ntuples ntuples2 nloops nfiltered1 nfiltered2 execmemused workmemused workmemwanted workfile
Created firststart numPartScanned bnotes enotes, nworkers_launched
             (seg0) 95 0 0 0.00 0.00 0.01 85736 0 1 82281 0 0 0 0 0 1798033 0 0 0 0
             (seg1) 95 0 0 0.00 0.00 0.01 80303 0 1 79895 0 0 0 0 0 1798033 0 0 0 0
             (seg2) 95 0 0 0.00 0.00 0.02 83655 0 1 86362 0 0 0 0 0 1798033 0 0 0 0
 Planning Time: 0.313 ms
   (slice0)    Executor memory: 111K bytes.
   (slice1)    Executor memory: 111K bytes avg x 6x(0) workers, 112K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution Time: 62.953 ms
(38 rows)
```

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
