### PR TITLE
Fix: Core happend when calling pg_relation_size on root partitioned table with PAX AM

### DIFF
--- a/contrib/pax_storage/expected/ddl.out
+++ b/contrib/pax_storage/expected/ddl.out
@@ -71,3 +71,21 @@ drop table pax_test.t3;
 create table pax_test.t4 (v1 text) with(compresstype=zstd, compresslevel=1);
 alter table pax_test.t4 add column v2 text;
 drop table pax_test.t4;
+-- test pg_relation_size
+CREATE TABLE pt_pax (id int, date date) using pax DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( PARTITION subpt1 START (date '2016-01-01') INCLUSIVE ,
+  PARTITION subpt2 START (date '2016-02-01') INCLUSIVE);
+SELECT pg_catalog.pg_relation_size('pt_pax'::regclass);
+ pg_relation_size 
+------------------
+                0
+(1 row)
+
+select 1 from (select count(*) from gp_toolkit.gp_size_of_schema_disk) empty_out;
+ ?column? 
+----------
+        1
+(1 row)
+
+drop table pt_pax;

--- a/contrib/pax_storage/sql/ddl.sql
+++ b/contrib/pax_storage/sql/ddl.sql
@@ -48,3 +48,13 @@ drop table pax_test.t3;
 create table pax_test.t4 (v1 text) with(compresstype=zstd, compresslevel=1);
 alter table pax_test.t4 add column v2 text;
 drop table pax_test.t4;
+
+-- test pg_relation_size
+CREATE TABLE pt_pax (id int, date date) using pax DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( PARTITION subpt1 START (date '2016-01-01') INCLUSIVE ,
+  PARTITION subpt2 START (date '2016-02-01') INCLUSIVE);
+
+SELECT pg_catalog.pg_relation_size('pt_pax'::regclass);
+select 1 from (select count(*) from gp_toolkit.gp_size_of_schema_disk) empty_out;
+drop table pt_pax;

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -563,8 +563,9 @@ typedef struct ViewOptions
  *      True iff relation(table) should run the code path as AO/CO
  */
 #define RelationIsNonblockRelation(relation) \
+	((relation)->rd_tableam && \
 	(RelationIsAppendOptimized(relation) || \
-	 RelationIsPax(relation))
+	 RelationIsPax(relation)))
 
 /*
  * RelationIsBitmapIndex


### PR DESCRIPTION

In the `calculate_relation_size` method, whether to directly callback the table AM(access method) is determined by `RelationIsNonblockRelation`. However, for root partitioned tables, the table AM is always be NULL.

When the AM of a root partitioned table is PAX, `RelationIsNonblockRelation` always returns TRUE. But for AO tables, `RelationIsNonblockRelation` will returns FALSE. It because AO table are determined directly through `rel->rd_amhandler` (PAX as a plugin, cannot register its `amhandler` in the CBDB kernel).

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
