### PR TITLE
Fix case fail caused by change the default value of pax_enable_debug 

### DIFF
--- a/contrib/pax_storage/expected/filter_1.out
+++ b/contrib/pax_storage/expected/filter_1.out
@@ -1,3 +1,4 @@
+set pax_enable_debug to on;
 set pax_enable_sparse_filter = on;
 create table pax_test.null_test_t(a int, b int, c text) using pax;
 insert into pax_test.null_test_t(a) select null from generate_series(1,2)i;


### PR DESCRIPTION

filter_1.out is missed to change, make it answer right.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->


### What does this PR do?
Fix case answer file.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update


### Test Plan
<!-- How did you test these changes? -->
- [x] Passed `make installcheck`
- [x] Passed `make -C src/test installcheck-cbdb-parallel`


**Dependencies:**
<!-- New dependencies or version changes? -->
no

