### PR TITLE
Add ASF incubation DISCLAIMER file for release compliance

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,9 @@
+Apache Cloudberry is an effort undergoing incubation at The Apache
+Software Foundation (ASF), sponsored by the Apache
+Incubator. Incubation is required of all newly accepted projects until
+a further review indicates that the infrastructure, communications,
+and decision making process have stabilized in a manner consistent
+with other successful ASF projects. While incubation status is not
+necessarily a reflection of the completeness or stability of the code,
+it does indicate that the project has yet to be fully endorsed by the
+ASF.


### PR DESCRIPTION
Adds the standard ASF disclaimer required for podlings under incubation.  This file clarifies the project's status and is intended to be included alongside LICENSE and NOTICE in all official source release artifacts.

Reference: https://incubator.apache.org/policy/incubation.html#disclaimers