### PR TITLE
Fix unstable scan rows caused by limit squelch.

### DIFF
--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -577,6 +577,10 @@ DROP USER regress_range_parted_user;
 -- Test if explain analyze will hang with materialize node
 CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
 INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
+-- start_matchsubs
+-- m/Seq Scan on recursive_table_ic \(actual rows=\d+ loops=1\)/
+-- s/Seq Scan on recursive_table_ic \(actual rows=\d+ loops=1\)/Seq Scan on recursive_table_ic (actual rows=#### loops=1)/
+-- end_matchsubs
 explain (analyze, costs off, timing off, summary off) WITH RECURSIVE
 r(i) AS (
 	SELECT 1
@@ -600,7 +604,7 @@ SELECT * FROM y LIMIT 10;
                      ->  WorkTable Scan on y (never executed)
                      ->  Materialize (never executed)
                            ->  Gather Motion 3:1  (slice1; segments: 3) (never executed)
-                                 ->  Seq Scan on recursive_table_ic (actual rows=4061 loops=1)
+                                 ->  Seq Scan on recursive_table_ic (actual rows=#### loops=1)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -599,6 +599,10 @@ DROP USER regress_range_parted_user;
 -- Test if explain analyze will hang with materialize node
 CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
 INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
+-- start_matchsubs
+-- m/Seq Scan on recursive_table_ic \(actual rows=\d+ loops=1\)/
+-- s/Seq Scan on recursive_table_ic \(actual rows=\d+ loops=1\)/Seq Scan on recursive_table_ic (actual rows=#### loops=1)/
+-- end_matchsubs
 explain (analyze, costs off, timing off, summary off) WITH RECURSIVE
 r(i) AS (
 	SELECT 1
@@ -622,7 +626,7 @@ SELECT * FROM y LIMIT 10;
                      ->  WorkTable Scan on y (never executed)
                      ->  Materialize (never executed)
                            ->  Gather Motion 3:1  (slice1; segments: 3) (never executed)
-                                 ->  Seq Scan on recursive_table_ic (actual rows=4061 loops=1)
+                                 ->  Seq Scan on recursive_table_ic (actual rows=#### loops=1)
  Optimizer: Postgres query optimizer
 (13 rows)
 

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -285,7 +285,10 @@ DROP USER regress_range_parted_user;
 -- Test if explain analyze will hang with materialize node
 CREATE TABLE recursive_table_ic (a INT) DISTRIBUTED BY (a);
 INSERT INTO recursive_table_ic SELECT * FROM generate_series(20, 30000);
-
+-- start_matchsubs
+-- m/Seq Scan on recursive_table_ic \(actual rows=\d+ loops=1\)/
+-- s/Seq Scan on recursive_table_ic \(actual rows=\d+ loops=1\)/Seq Scan on recursive_table_ic (actual rows=#### loops=1)/
+-- end_matchsubs
 explain (analyze, costs off, timing off, summary off) WITH RECURSIVE
 r(i) AS (
 	SELECT 1


### PR DESCRIPTION
Squelch in limit node may cause scan finish early, row count in scan may vary.

### What does this PR do?
Change gp_explain test case, ignore rows count to avoid case failure caused by unstable results.

### Type of Change
- [x] Bug fix (non-breaking change)


### Breaking Changes
no

### Test Plan
<!-- How did you test these changes? -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Passed `make installcheck`
- [x] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->
no

**User-facing changes:**
<!-- Any changes visible to users? -->
no

**Dependencies:**
<!-- New dependencies or version changes? -->
no

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
