### PR TITLE
Fix potential use-after-free of viewQuery in ExecRefreshMatView

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -463,7 +463,8 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	if (!stmt->skipData && RelationIsIVM(matviewRel))
 		dataQuery = rewriteQueryForIMMV(viewQuery,NIL);
 	else
-		dataQuery = viewQuery;
+		/* viewQuery maybe released in make_new_heap_with_colname. */
+		dataQuery = copyObject(viewQuery);
 
 	/*
 	 * Check that there is a unique index with no WHERE clause on one or more


### PR DESCRIPTION
```sql
(gdb) bt
#0  0x00007fb89d119387 in raise () from /lib64/libc.so.6
#1  0x00007fb89d11aa78 in abort () from /lib64/libc.so.6
#2  0x00007fb89dc45850 in ExceptionalCondition (conditionName=conditionName@entry=0x7fb89ea39371 "0", errorType=errorType@entry=0x7fb89e83a007 "FailedAssertion", 
    fileName=fileName@entry=0x7fb89e992ba3 "copyfuncs.c", lineNumber=lineNumber@entry=7881) at assert.c:44
#3  0x00007fb89dfafc39 in copyObjectImpl (from=0xef5560) at copyfuncs.c:7881
#4  0x00007fb89dea45ba in refresh_matview_datafill (dest=0xe9a820, query=0xef5560, queryString=0xdb9860 "REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;", 
    refreshClause=0xf2e6c0) at matview.c:741
#5  0x00007fb89dea52b3 in ExecRefreshMatView (stmt=stmt@entry=0xdba330, queryString=queryString@entry=0xdb9860 "REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;", 
    params=params@entry=0x0, qc=qc@entry=0x7ffd162afc60) at matview.c:627
#6  0x00007fb89e17b75a in ProcessUtilitySlow (pstate=0xe90ad8, pstmt=0xdba3f8, queryString=0xdb9860 "REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;", 
    context=PROCESS_UTILITY_TOPLEVEL, params=0x0, queryEnv=0x0, qc=0x7ffd162afc60, dest=<optimized out>) at utility.c:2347
#7  0x00007fb89e179e41 in standard_ProcessUtility (pstmt=0xdba3f8, queryString=0xdb9860 "REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;", readOnlyTree=<optimized out>, 
    context=PROCESS_UTILITY_TOPLEVEL, params=0x0, queryEnv=0x0, dest=0xdba7d8, qc=0x7ffd162afc60) at utility.c:1414
#8  0x00007fb89e17aac3 in ProcessUtility (pstmt=pstmt@entry=0xdba3f8, queryString=0xdb9860 "REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;", readOnlyTree=<optimized out>, 
    context=context@entry=PROCESS_UTILITY_TOPLEVEL, params=0x0, queryEnv=0x0, dest=0xdba7d8, qc=0x7ffd162afc60) at utility.c:621
#9  0x00007fb89e178373 in PortalRunUtility (portal=portal@entry=0xe32a70, pstmt=pstmt@entry=0xdba3f8, isTopLevel=isTopLevel@entry=true, 
    setHoldSnapshot=setHoldSnapshot@entry=false, dest=0xdba7d8, qc=0x7ffd162afc60) at pquery.c:1370
#10 0x00007fb89e1784c4 in PortalRunMulti (portal=portal@entry=0xe32a70, isTopLevel=isTopLevel@entry=true, setHoldSnapshot=setHoldSnapshot@entry=false, 
    dest=dest@entry=0xdba7d8, altdest=altdest@entry=0xdba7d8, qc=qc@entry=0x7ffd162afc60) at pquery.c:1527
#11 0x00007fb89e178c33 in PortalRun (portal=portal@entry=0xe32a70, count=count@entry=9223372036854775807, isTopLevel=isTopLevel@entry=true, run_once=run_once@entry=true, 
    dest=dest@entry=0xdba7d8, altdest=altdest@entry=0xdba7d8, qc=0x7ffd162afc60) at pquery.c:995
#12 0x00007fb89e171de8 in exec_simple_query (query_string=0xdb9860 "REFRESH MATERIALIZED VIEW m_aocs WITH NO DATA;") at postgres.c:1952
#13 0x00007fb89e175c69 in PostgresMain (argc=argc@entry=1, argv=argv@entry=0x7ffd162b00b0, dbname=<optimized out>, username=<optimized out>) at postgres.c:5633
#14 0x00007fb89e0bb25d in BackendRun (port=<optimized out>, port=<optimized out>) at postmaster.c:5134
#15 BackendStartup (port=<optimized out>) at postmaster.c:4838
#16 ServerLoop () at postmaster.c:2062
#17 0x00007fb89e0bc3de in PostmasterMain (argc=argc@entry=7, argv=argv@entry=0xdb40d0) at postmaster.c:1687
#18 0x00000000004017ce in main (argc=7, argv=0xdb40d0) at main/main.c:269
(gdb) 
```


In ExecRefreshMatView(), the pointer viewQuery may be invalidated when make_new_heap_with_colname() closes the old heap via table_close(OldHeap, NoLock). This happens because table_close() can release relcache entries and associated rules, including rd_rules, which stores the viewQuery.

To avoid accessing a possibly freed memory region, make a deep copy of viewQuery before invoking make_new_heap_with_colname(), and use this copy as dataQuery for further processing.

Fix: ERROR:  unrecognized node type: 2139062143 (copyfuncs.c:7663)




Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
