### PR TITLE
Reject zero-column table creation with AO column storage

### DIFF
--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -113,3 +113,13 @@ from gp_dist_random('gp_distribution_policy') where localoid = 't2_17271'::regcl
 drop table t_17271;
 drop table t1_17271;
 drop table t2_17271;
+-- Github Issue 1055
+-- AO column storage not supported for zero-column tables
+create table t_1055() using ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+ERROR:  AO column storage is not supported for zero-column tables
+-- This should fail because the table is empty and AO column storage is not supported for zero-column
+create table t1_1055() using ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+alter table t1_1055 set access method ao_column;
+ERROR:  cannot rewrite empty table "t1_1055" as an AO columnar table

--- a/src/test/regress/sql/misc_jiras.sql
+++ b/src/test/regress/sql/misc_jiras.sql
@@ -70,3 +70,12 @@ from gp_dist_random('gp_distribution_policy') where localoid = 't2_17271'::regcl
 drop table t_17271;
 drop table t1_17271;
 drop table t2_17271;
+
+-- Github Issue 1055
+-- AO column storage not supported for zero-column tables
+create table t_1055() using ao_column;
+
+-- This should fail because the table is empty and AO column storage is not supported for zero-column
+create table t1_1055() using ao_row;
+alter table t1_1055 set access method ao_column;
+


### PR DESCRIPTION
Creating a table with AO columnar storage and no columns is not supported. This patch adds an explicit check in DefineRelation() to throw an error when such a case is encountered. This ensures users receive a clear error message rather than encountering undefined behavior.

Also adds a regression test under misc_jiras to verify the behavior.

Fixes #1055

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
