### PR TITLE
Parallel DISTINCT plan of multi-stage.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -151,6 +151,7 @@ bool		enable_parallel = false;
 bool		enable_parallel_semi_join = true;
 bool		enable_parallel_dedup_semi_join = true;
 bool		enable_parallel_dedup_semi_reverse_join = true;
+bool		parallel_query_use_streaming_hashagg = false;
 int			gp_appendonly_insert_files = 0;
 int			gp_appendonly_insert_files_tuples_range = 0;
 int			gp_random_insert_segments = 0;
@@ -3224,6 +3225,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_EXPLAIN
 		},
 		&enable_parallel_dedup_semi_reverse_join,
+		true,
+		NULL, NULL, NULL
+	},
+	{
+		{"parallel_query_use_streaming_hashagg", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("allow to use of streaming hashagg in parallel query for DISTINCT."),
+			NULL,
+			GUC_EXPLAIN
+		},
+		&parallel_query_use_streaming_hashagg,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -293,6 +293,7 @@ extern bool enable_parallel;
 extern bool enable_parallel_semi_join;
 extern bool enable_parallel_dedup_semi_join;
 extern bool enable_parallel_dedup_semi_reverse_join;
+extern bool	parallel_query_use_streaming_hashagg;
 extern int  gp_appendonly_insert_files;
 extern int  gp_appendonly_insert_files_tuples_range;
 extern int  gp_random_insert_segments;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -498,6 +498,7 @@
 		"optimizer_use_gpdb_allocators",
 		"optimizer_xform_bind_threshold",
 		"parallel_leader_participation",
+		"parallel_query_use_streaming_hashagg",
 		"parallel_setup_cost",
 		"parallel_tuple_cost",
 		"password_encryption",

--- a/src/test/regress/expected/cbdb_parallel.out
+++ b/src/test/regress/expected/cbdb_parallel.out
@@ -3069,6 +3069,201 @@ select t1_anti.a, t1_anti.b from t1_anti left join t2_anti on t1_anti.a = t2_ant
 (4 rows)
 
 abort;
+--
+-- Test Parallel DISTINCT
+--
+drop table if exists t_distinct_0;
+NOTICE:  table "t_distinct_0" does not exist, skipping
+create table t_distinct_0(a int, b int) using ao_column distributed randomly;
+insert into t_distinct_0 select i, i+1 from generate_series(1, 1000) i;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+insert into t_distinct_0 select * from t_distinct_0;
+analyze t_distinct_0;
+explain(costs off)
+select distinct a from t_distinct_0;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: a
+               ->  HashAggregate
+                     Group Key: a
+                     ->  Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+set enable_parallel = on;
+-- first stage HashAgg, second stage GroupAgg
+explain(costs off)
+select distinct a from t_distinct_0;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   Merge Key: a
+   ->  GroupAggregate
+         Group Key: a
+         ->  Sort
+               Sort Key: a
+               ->  Redistribute Motion 6:6  (slice2; segments: 6)
+                     Hash Key: a
+                     Hash Module: 3
+                     ->  Streaming HashAggregate
+                           Group Key: a
+                           ->  Parallel Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+set parallel_query_use_streaming_hashagg = off;
+explain(costs off)
+select distinct a from t_distinct_0;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   Merge Key: a
+   ->  GroupAggregate
+         Group Key: a
+         ->  Sort
+               Sort Key: a
+               ->  Redistribute Motion 6:6  (slice2; segments: 6)
+                     Hash Key: a
+                     Hash Module: 3
+                     ->  HashAggregate
+                           Group Key: a
+                           ->  Parallel Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+-- GroupAgg
+set enable_hashagg = off;
+explain(costs off)
+select distinct a from t_distinct_0;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   Merge Key: a
+   ->  GroupAggregate
+         Group Key: a
+         ->  Sort
+               Sort Key: a
+               ->  Redistribute Motion 6:6  (slice2; segments: 6)
+                     Hash Key: a
+                     Hash Module: 3
+                     ->  GroupAggregate
+                           Group Key: a
+                           ->  Sort
+                                 Sort Key: a
+                                 ->  Parallel Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+-- HashAgg
+set enable_hashagg = on;
+set enable_groupagg = off;
+explain(costs off)
+select distinct a from t_distinct_0;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   ->  HashAggregate
+         Group Key: a
+         ->  Redistribute Motion 6:6  (slice2; segments: 6)
+               Hash Key: a
+               Hash Module: 3
+               ->  HashAggregate
+                     Group Key: a
+                     ->  Parallel Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+set parallel_query_use_streaming_hashagg = on;
+explain(costs off)
+select distinct a from t_distinct_0;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   ->  HashAggregate
+         Group Key: a
+         ->  Redistribute Motion 6:6  (slice2; segments: 6)
+               Hash Key: a
+               Hash Module: 3
+               ->  Streaming HashAggregate
+                     Group Key: a
+                     ->  Parallel Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- multi DISTINCT tlist
+explain(costs off)
+select distinct a, b from t_distinct_0;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   ->  HashAggregate
+         Group Key: a, b
+         ->  Redistribute Motion 6:6  (slice2; segments: 6)
+               Hash Key: a, b
+               Hash Module: 3
+               ->  Streaming HashAggregate
+                     Group Key: a, b
+                     ->  Parallel Seq Scan on t_distinct_0
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- DISTINCT on distribution key 
+drop table if exists t_distinct_1;
+NOTICE:  table "t_distinct_1" does not exist, skipping
+create table t_distinct_1(a int, b int) using ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_distinct_1 select * from t_distinct_0;
+analyze t_distinct_1;
+set enable_parallel = off;
+explain(costs off)
+select distinct a from t_distinct_1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a
+         ->  Seq Scan on t_distinct_1
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+set enable_parallel = on;
+explain(costs off)
+select distinct a from t_distinct_1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)
+   ->  HashAggregate
+         Group Key: a
+         ->  Redistribute Motion 6:6  (slice2; segments: 6)
+               Hash Key: a
+               Hash Module: 3
+               ->  Streaming HashAggregate
+                     Group Key: a
+                     ->  Parallel Seq Scan on t_distinct_1
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+--
+-- End of test Parallel DISTINCT
+--
 -- start_ignore
 drop schema test_parallel cascade;
 -- end_ignore


### PR DESCRIPTION
Postgres UPSTREAM does not support parallel DISTINCT processing since DISTINCT across multiple workers cannot be guaranteed. In MPP databases, however, we can utilize Motion to redistribute tuples across multiple workers within a parallel query.

For a DISTINCT query like:
```sql
select distinct a from t_distinct_0;
```
we can create a parallel plan based on the underlying node's Parallel Scan on the table. The tuples are distributed randomly after the Parallel Scan, even when the distribution key matches the target expression.

The pre-distinct node uses Streaming HashAggregate or HashAggregate to deduplicate some tuples in parallel, which are then redistributed according to the DISTINCT expressions. Finally, a second-stage process handles the DISTINCT operation.
```sql
                         QUERY PLAN
------------------------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   ->  HashAggregate
         Group Key: a
         ->  Redistribute Motion 6:6  (slice2; segments: 6)
               Hash Key: a
               Hash Module: 3
               ->  Streaming HashAggregate
                     Group Key: a
                     ->  Parallel Seq Scan on t_distinct_0
 Optimizer: Postgres query optimizer
(10 rows)
```
Parallel Group Aggregation is also supported:
```sql
explain(costs off)
select distinct a, b from t_distinct_0;
                        QUERY PLAN
-----------------------------------------------------------
 GroupAggregate
   Group Key: a, b
   ->  Gather Motion 6:1  (slice1; segments: 6)
         Merge Key: a, b
         ->  GroupAggregate
               Group Key: a, b
               ->  Sort
                     Sort Key: a, b
                     ->  Parallel Seq Scan on t_distinct_0
 Optimizer: Postgres query optimizer
(10 rows)
```

## performance

For DISTINCT, the performance in parallel processing is closely tied to the tuples among each worker process, particularly in the case of streaming hash aggregates. 
Overall, the test cases indicate that a parallel execution plan with two workers achieves nearly half the runtime of a non-parallel plan.

The parallel plans(hashagg, streaming-hashagg, hashagg-groupagg) have 2 workers.


DISTINCT | 1 | 2 | 3 | avg
-- | -- | -- | -- | --
non-parallel | 8207.833 | 8416.01 | 8163.197 | 8262.346667
hashagg | 4550.331 | 4558.036 | 4219.485 | 4442.617333
streaming-hashagg | 4197.242 | 4200.889 | 4099.575 | 4165.902
hashagg-groupagg | 4336.934 | 4710.07 | 4352.795 | 4466.599667



![chart](https://github.com/user-attachments/assets/9a0d70b6-5419-4ae6-a1bc-ad8728fe0ef9)

### non-parallel
```sql
select distinct a from t_distinct_0;
                         QUERY PLAN
------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  HashAggregate
         Group Key: a
         ->  Redistribute Motion 3:3  (slice2; segments: 3)
               Hash Key: a
               ->  HashAggregate
                     Group Key: a
                     ->  Seq Scan on t_distinct_0
 Optimizer: Postgres query optimizer
(9 rows)
```

### hashagg 
```sql
select distinct a from t_distinct_0;
                         QUERY PLAN
------------------------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   ->  HashAggregate
         Group Key: a
         ->  Redistribute Motion 6:6  (slice2; segments: 6)
               Hash Key: a
               Hash Module: 3
               ->  HashAggregate
                     Group Key: a
                     ->  Parallel Seq Scan on t_distinct_0
 Optimizer: Postgres query optimizer
(10 rows)
```

### streaming-hashagg

```sql
select distinct a from t_distinct_0;
                         QUERY PLAN
------------------------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   ->  HashAggregate
         Group Key: a
         ->  Redistribute Motion 6:6  (slice2; segments: 6)
               Hash Key: a
               Hash Module: 3
               ->  Streaming HashAggregate
                     Group Key: a
                     ->  Parallel Seq Scan on t_distinct_0
 Optimizer: Postgres query optimizer
(10 rows)
```



### hashagg-groupagg 
```sql
select distinct a from t_distinct_0;
                            QUERY PLAN
------------------------------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)
   Merge Key: a
   ->  GroupAggregate
         Group Key: a
         ->  Sort
               Sort Key: a
               ->  Redistribute Motion 6:6  (slice2; segments: 6)
                     Hash Key: a
                     Hash Module: 3
                     ->  Streaming HashAggregate
                           Group Key: a
                           ->  Parallel Seq Scan on t_distinct_0
 Optimizer: Postgres query optimizer
(13 rows)
```

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
