### PR TITLE
Don't export libpq.so symbols in the postgres binary. (#16234)

### DIFF
--- a/gpcontrib/gp_exttable_fdw/Makefile
+++ b/gpcontrib/gp_exttable_fdw/Makefile
@@ -3,6 +3,7 @@
 MODULE_big = gp_exttable_fdw
 OBJS = gp_exttable_fdw.o extaccess.o option.o
 
+SHLIB_LINK_INTERNAL = $(libpq)
 #SHLIB_LINK += -lcurl
 
 EXTENSION = gp_exttable_fdw

--- a/gpcontrib/gp_inject_fault/Makefile
+++ b/gpcontrib/gp_inject_fault/Makefile
@@ -1,4 +1,5 @@
-MODULES = gp_inject_fault
+MODULE_big = gp_inject_fault
+OBJS = gp_inject_fault.o
 
 EXTENSION = gp_inject_fault
 DATA = gp_inject_fault--1.0.sql
@@ -6,6 +7,7 @@ DATA = gp_inject_fault--1.0.sql
 REGRESS = inject_fault_test
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
+SHLIB_LINK_INTERNAL = $(libpq)
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -2,3 +2,5 @@
 /postgres.def
 /postgres.imp
 /catalog-extension/
+/postgres_symbols.map
+/hide_symbols.list

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -80,10 +80,36 @@ ifneq ($(PORTNAME), cygwin)
 ifneq ($(PORTNAME), win32)
 ifneq ($(PORTNAME), aix)
 
+# Due to Cloudberry's MPP architecture, the postgres process needs to connect to
+# databases, some symbols from frontend are compiled to the postgres binary.
+# Some extensions requires frontend symbols and are dynamically linked to libpq.so.
+# However, some symbols are not safe to be exported both in the postgres binary
+# and libpq.so. E.g., some of the functions are using palloc()/pfree() to allocate
+# and free memory in backend codes while using malloc()/free() to allocate and free
+# memory in frontend codes. We use linker version script to make these symbols exported
+# in libpq.so and private in the postgres binary.
+# FIXME: Can we teach the postgres binary to dynamically link against libpq.so? So that
+# we don't need this hack.
+SAFELY_EXPORTED_SYMBOLS_PATTERN = "(pqsignal|pg_*)"
+SYMBOL_MAPPING_FLAGS =
+ifeq ($(PORTNAME), darwin)
+SYMBOL_MAP_FILE = hide_symbols.list
+$(SYMBOL_MAP_FILE): $(top_builddir)/src/interfaces/libpq/exports.txt
+	$(AWK) '/^[^#]/ {printf "_%s\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN) >$@
+SYMBOL_MAPPING_FLAGS = -unexported_symbols_list $(SYMBOL_MAP_FILE)
+endif
+
+ifeq ($(PORTNAME), linux)
+SYMBOL_MAP_FILE = postgres_symbols.map
+$(SYMBOL_MAP_FILE): $(top_builddir)/src/interfaces/libpq/exports.txt
+	( echo '{ global: *; '; echo ' local:'; $(AWK) '/^[^#]/ {printf "%s;\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN); echo '};' ) >$@
+SYMBOL_MAPPING_FLAGS = -Wl,--version-script=$(SYMBOL_MAP_FILE)
+endif
+
 ifeq ($(enable_shared_postgres_backend),yes)
-libpostgres.so: $(OBJS)
+libpostgres.so: $(OBJS) $(SYMBOL_MAP_FILE)
 	$(CXX) -shared $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_SL) $(export_dynamic) \
-	  $(filter-out main/main.o, $(call expand_subsys,$^)) $(LIBS) -o $@
+	  $(filter-out main/main.o, $(call expand_subsys,${OBJS})) $(LIBS) $(SYMBOL_MAPPING_FLAGS) -o $@
 
 postgres: main/main.o libpostgres.so $(top_builddir)/src/port/libpgport_srv.a $(top_builddir)/src/common/libpgcommon_srv.a
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) \
@@ -91,8 +117,8 @@ postgres: main/main.o libpostgres.so $(top_builddir)/src/port/libpgport_srv.a $(
 	  $(top_builddir)/src/common/libpgcommon_srv.a $(LIBS) -o $@
 
 else
-postgres: $(OBJS)
-	$(CXX) $(CXXFLAGS) $(call expand_subsys,$^) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(LIBS) -o $@
+postgres: $(OBJS) $(SYMBOL_MAP_FILE)
+	$(CXX) $(CXXFLAGS) $(call expand_subsys,${OBJS}) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(LIBS) $(SYMBOL_MAPPING_FLAGS) -o $@
 endif
 
 endif
@@ -354,6 +380,10 @@ ifeq ($(PORTNAME), cygwin)
 endif
 ifeq ($(PORTNAME), win32)
 	rm -f postgres.dll libpostgres.a $(WIN32RES)
+endif
+ifeq (,$(filter cygwin win32 aix,$(PORTNAME)))
+	rm -f postgres_symbols.map
+	rm -f hide_symbols.list
 endif
 
 distclean: clean

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -99,6 +99,8 @@ OBJS = $(WIN32RES) regress.o
 
 OBJS += regress_gp.o
 
+SHLIB_LINK_INTERNAL = $(libpq)
+
 include $(top_srcdir)/src/Makefile.shlib
 
 all: all-lib


### PR DESCRIPTION
Due to Greenplum's MPP architecture, the postgres process needs to connect to databases, some symbols from libpq.so are compiled into the postgres binary as well. However, some symbols are not safe to be exported both in the postgres binary and the libpq.so library. E.g., some of the functions are using palloc()/pfree() to allocate/free memory in backend codes while using malloc()/free() in frontend codes. See issue #16219. This patch resolves the issue by hiding frontend symbols in the postgres binary, so that frontend symbols referenced in extensions will be resolved correctly.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
