### PR TITLE
initdb: Reject empty string for -U/--username option

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -3391,6 +3391,11 @@ main(int argc, char *argv[])
 				pwprompt = true;
 				break;
 			case 'U':
+				if (optarg[0] == '\0')
+				{
+					pg_log_error("superuser name must not be empty.");
+					exit(1);
+				}
 				username = pg_strdup(optarg);
 				break;
 			case 'd':

--- a/src/bin/initdb/t/001_initdb.pl
+++ b/src/bin/initdb/t/001_initdb.pl
@@ -38,6 +38,11 @@ command_fails(
 	[ 'initdb', '-U', 'pg_test', $datadir ],
 	'role names cannot begin with "pg_"');
 
+command_fails_like(
+	[ 'initdb', '--username' => '', $datadir ],
+	qr/superuser name must not be empty./,
+	'empty username not allowed');
+
 mkdir $datadir;
 
 # make sure we run one successful test without a TZ setting so we test


### PR DESCRIPTION
```sql
performing post-bootstrap initialization ... 2025-07-01 19:48:42.006 PDT [14888] FATAL:  role """ does not exist at character 72

2025-07-01 19:48:42.006 PDT [14888] STATEMENT:  

	UPDATE pg_class   SET relacl = (SELECT array_agg(a.acl) FROM  (SELECT E'=r/""' as acl   UNION SELECT unnest(pg_catalog.acldefault(    CASE WHEN relkind = 'S' THEN 's'          ELSE 'r' END::"char",10::oid)) ) as a)   WHERE relkind IN ('r', 'v', 'm', 'S')  AND relacl IS NULL;
````
Previously, passing an empty string to the -U or --username option (e.g., `initdb -U ''`) would cause confusing errors during bootstrap, as initdb attempted to create a role with an empty name.

This patch adds an explicit check for empty usernames and exits immediately with a clear error message.

A test case is added to verify that initdb fails when -U is given an empty string.


Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
