### PR TITLE
Fix CTAS crash.

### DIFF
--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2622,7 +2622,15 @@ create_motion_path_for_insert(PlannerInfo *root, GpPolicy *policy,
 			}
 
 		}
-		subpath = cdbpath_create_broadcast_motion_path(root, subpath, policy->numsegments);
+
+		/*
+		 * planner may have add a top Motion eariler.
+		 * Create table t1(id int) distributed randomly;
+		 * Create table t2 as select random() from t1 distributed replicated;
+		 * Avoid Motion if there was already one.
+		 */
+		if (!CdbPathLocus_IsReplicated(subpath->locus))
+			subpath = cdbpath_create_broadcast_motion_path(root, subpath, policy->numsegments);
 	}
 	else
 		elog(ERROR, "unrecognized policy type %u", policyType);

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -663,6 +663,8 @@ select count(distinct nextval) from gp_dist_random('t_rep4');
 (1 row)
 
 drop table rep_tbl, t_rep4;
+create table t_issue_1218_random(id int) distributed randomly;
+create table t_issue_1218_replicated as select random() from t_issue_1218_random distributed replicated;
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -681,6 +681,8 @@ select count(distinct nextval) from gp_dist_random('t_rep4');
 (1 row)
 
 drop table rep_tbl, t_rep4;
+create table t_issue_1218_random(id int) distributed randomly;
+create table t_issue_1218_replicated as select random() from t_issue_1218_random distributed replicated;
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146

--- a/src/test/regress/sql/bfv_planner.sql
+++ b/src/test/regress/sql/bfv_planner.sql
@@ -345,6 +345,9 @@ select count(*) from gp_dist_random('t_rep4');
 select count(distinct nextval) from gp_dist_random('t_rep4');
 drop table rep_tbl, t_rep4;
 
+create table t_issue_1218_random(id int) distributed randomly;
+create table t_issue_1218_replicated as select random() from t_issue_1218_random distributed replicated;
+
 --
 -- Test append different numsegments tables work well
 -- See Github issue: https://github.com/greenplum-db/gpdb/issues/12146


### PR DESCRIPTION
Fix #1218 

If we create a replicated table when selecting project volatile functions from a randomly distributed table, we will try to add a Motion on a Motion node that will cause a crash. 

```sql
Create table t1(id int) distributed randomly;
Create table t2 as select random() from t1 distributed replicated;
```

planner may have add a top Motion earlier if we know the query's final locus. 
Some codes handle volatile functions lead us to create_motion_path_for_insert(), and we should consider the case to avoid Assertion failure when create_plan().

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
