### PR TITLE
PAX: Use const reference to avoid constructor/destructor of shared pointer

### DIFF
--- a/contrib/pax_storage/src/api/python3/paxfilereader_type.cc
+++ b/contrib/pax_storage/src/api/python3/paxfilereader_type.cc
@@ -323,7 +323,6 @@ static PyObject *paxfilereader_readgroup(PaxFileReaderObject *self,
   try {
     for (; column_index < col_nums; column_index++) {
       const auto &column = (*columns)[column_index];
-      std::shared_ptr<pax::Bitmap8> bm;
       auto null_counts = 0;
       PyObject *schema_item = nullptr;
       long col_oid;
@@ -351,7 +350,7 @@ static PyObject *paxfilereader_readgroup(PaxFileReaderObject *self,
         continue;
       }
 
-      bm = column->GetBitmap();
+      const auto &bm = column->GetBitmap();
 
       py_rows = PyList_New(0);
       if (!py_rows) {
@@ -381,7 +380,7 @@ static PyObject *paxfilereader_readgroup(PaxFileReaderObject *self,
           if (column->IsToast(row_index)) {
             // safe to no keep the ref, because paxbuffer_to_pyobj will copy the
             // detoast datum
-            std::shared_ptr<pax::MemoryObject> ref = nullptr;
+            std::unique_ptr<pax::MemoryObject> ref = nullptr;
 
             auto datum = PointerGetDatum(buff);
             auto external_buffer = column->GetExternalToastDataBuffer();

--- a/contrib/pax_storage/src/cpp/storage/columns/pax_column.cc
+++ b/contrib/pax_storage/src/cpp/storage/columns/pax_column.cc
@@ -83,7 +83,7 @@ size_t PaxColumn::GetRangeNonNullRows(size_t start_pos, size_t len) {
 
 void PaxColumn::CreateNulls(size_t cap) {
   Assert(!null_bitmap_);
-  null_bitmap_ = std::make_shared<Bitmap8>(cap);
+  null_bitmap_ = std::make_unique<Bitmap8>(cap);
   null_bitmap_->SetN(total_rows_);
 }
 

--- a/contrib/pax_storage/src/cpp/storage/columns/pax_column.h
+++ b/contrib/pax_storage/src/cpp/storage/columns/pax_column.h
@@ -233,13 +233,13 @@ class PaxColumn {
   inline bool AllNull() const { return null_bitmap_ && null_bitmap_->Empty(); }
 
   // Set the null bitmap
-  inline void SetBitmap(std::shared_ptr<Bitmap8> null_bitmap) {
+  inline void SetBitmap(std::unique_ptr<Bitmap8> null_bitmap) {
     Assert(!null_bitmap_);
     null_bitmap_ = std::move(null_bitmap);
   }
 
   // Get the null bitmap
-  inline std::shared_ptr<Bitmap8> GetBitmap() const { return null_bitmap_; }
+  inline const std::unique_ptr<Bitmap8>& GetBitmap() const { return null_bitmap_; }
 
   // Set the column kv attributes
   void SetAttributes(const std::map<std::string, std::string> &attrs);
@@ -354,7 +354,7 @@ class PaxColumn {
 
  protected:
   // null field bit map
-  std::shared_ptr<Bitmap8> null_bitmap_;
+  std::unique_ptr<Bitmap8> null_bitmap_;
 
   // Writer: write pointer
   // Reader: total rows

--- a/contrib/pax_storage/src/cpp/storage/columns/pax_columns.cc
+++ b/contrib/pax_storage/src/cpp/storage/columns/pax_columns.cc
@@ -377,7 +377,7 @@ size_t PaxColumns::MeasureVecDataBuffer(
 
     // has null will generate a bitmap in current stripe
     if (column->HasNull()) {
-      auto bm = column->GetBitmap();
+      const auto &bm = column->GetBitmap();
       Assert(bm);
       size_t bm_length = bm->MinimalStoredBytes(total_rows);
 
@@ -483,7 +483,7 @@ size_t PaxColumns::MeasureOrcDataBuffer(
     auto column = p_column.get();
     // has null will generate a bitmap in current stripe
     if (column->HasNull()) {
-      auto bm = column->GetBitmap();
+      const auto &bm = column->GetBitmap();
       Assert(bm);
       size_t bm_length = bm->MinimalStoredBytes(column->GetRows());
       buffer_len += bm_length;
@@ -592,7 +592,7 @@ void PaxColumns::CombineVecDataBuffer() {
 
     auto column = p_column.get();
     if (column->HasNull()) {
-      auto bm = column->GetBitmap();
+      const auto &bm = column->GetBitmap();
       Assert(bm);
       auto nbytes = bm->MinimalStoredBytes(column->GetRows());
       Assert(nbytes <= bm->Raw().size);
@@ -680,7 +680,7 @@ void PaxColumns::CombineOrcDataBuffer() {
 
     auto column = p_column.get();
     if (column->HasNull()) {
-      auto bm = column->GetBitmap();
+      const auto &bm = column->GetBitmap();
       Assert(bm);
       auto nbytes = bm->MinimalStoredBytes(column->GetRows());
       Assert(nbytes <= bm->Raw().size);

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.cc
@@ -899,7 +899,7 @@ std::unique_ptr<PaxColumns> OrcFormatReader::ReadStripe(
       continue;
     }
 
-    std::shared_ptr<Bitmap8> non_null_bitmap;
+    std::unique_ptr<Bitmap8> non_null_bitmap;
     bool has_null = stripe_info.colstats(index).hasnull();
     if (has_null) {
       const pax::porc::proto::Stream &non_null_stream =
@@ -909,9 +909,8 @@ std::unique_ptr<PaxColumns> OrcFormatReader::ReadStripe(
           reinterpret_cast<uint8 *>(data_buffer->GetAvailableBuffer());
 
       Assert(non_null_stream.kind() == pax::porc::proto::Stream_Kind_PRESENT);
-      non_null_bitmap =
-          std::make_shared<Bitmap8>(BitmapRaw<uint8>(bm_bytes, bm_nbytes),
-                                    BitmapTpl<uint8>::ReadOnlyRefBitmap);
+      non_null_bitmap = std::make_unique<Bitmap8>(BitmapRaw<uint8>(bm_bytes, bm_nbytes),
+                                         BitmapTpl<uint8>::ReadOnlyRefBitmap);
       data_buffer->Brush(bm_nbytes);
     }
 
@@ -1023,7 +1022,7 @@ std::unique_ptr<PaxColumns> OrcFormatReader::ReadStripe(
     last_column->SetRows(stripe_info.numberofrows());
     if (has_null) {
       Assert(non_null_bitmap);
-      last_column->SetBitmap(non_null_bitmap);
+      last_column->SetBitmap(std::move(non_null_bitmap));
     }
 
     if (!column_attrs_[index].empty()) {

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_group.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_group.cc
@@ -49,7 +49,7 @@ inline static std::pair<Datum, bool> GetColumnDatum(PaxColumn *column,
   Datum rc;
 
   if (column->HasNull()) {
-    auto bm = column->GetBitmap();
+    const auto &bm = column->GetBitmap();
     Assert(bm);
     if (!bm->Test(row_index)) {
       *null_counts += 1;
@@ -123,7 +123,7 @@ std::pair<bool, size_t> OrcGroup::ReadTuple(TupleTableSlot *slot) {
         }
 
         if (column->HasNull()) {
-          auto bm = column->GetBitmap();
+          const auto &bm = column->GetBitmap();
           Assert(bm);
           if (!bm->Test(current_row_index_)) {
             current_nulls_[index]++;
@@ -307,7 +307,7 @@ std::pair<Datum, bool> OrcGroup::GetColumnValueNoMissing(size_t column_index,
 void OrcGroup::CalcNullShuffle(PaxColumn *column, size_t column_index) {
   auto rows = column->GetRows();
   uint32 n_counts = 0;
-  auto bm = column->GetBitmap();
+  const auto &bm = column->GetBitmap();
 
   Assert(bm);
   Assert(column->HasNull() && !nulls_shuffle_[column_index]);

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_reader.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_reader.cc
@@ -129,7 +129,7 @@ std::unique_ptr<MicroPartitionReader::Group> OrcReader::ReadGroup(
   for (size_t i = 0; i < pax_columns->GetColumns(); i++) {
     auto column = (*pax_columns)[i].get();
     if (column && !column->GetBuffer().first) {
-      auto bm = column->GetBitmap();
+      const auto &bm = column->GetBitmap();
       // Assert(bm);
       if (bm) {
         for (size_t n = 0; n < column->GetRows(); n++) {

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_vec_group.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_vec_group.cc
@@ -32,7 +32,7 @@ namespace pax {
 inline static std::pair<Datum, bool> GetColumnDatum(PaxColumn *column,
                                                     size_t row_index) {
   if (column->HasNull()) {
-    auto bm = column->GetBitmap();
+    const auto &bm = column->GetBitmap();
     Assert(bm);
     if (!bm->Test(row_index)) {
       return {0, true};

--- a/contrib/pax_storage/src/cpp/storage/toast/pax_toast.h
+++ b/contrib/pax_storage/src/cpp/storage/toast/pax_toast.h
@@ -145,7 +145,7 @@ size_t pax_toast_hdr_size(Datum d);
 // detoast pax toast
 size_t pax_detoast_raw(Datum d, char *dst_buff, size_t dst_size,
                        char *ext_buff = nullptr, size_t ext_buff_size = 0);
-std::pair<Datum, std::shared_ptr<MemoryObject>> pax_detoast(
+std::pair<Datum, std::unique_ptr<MemoryObject>> pax_detoast(
     Datum d, char *ext_buff = nullptr, size_t ext_buff_size = 0);
 
 // free pax toast

--- a/contrib/pax_storage/src/cpp/storage/vec/pax_porc_adpater.cc
+++ b/contrib/pax_storage/src/cpp/storage/vec/pax_porc_adpater.cc
@@ -49,7 +49,7 @@ static void CopyFixedRawBufferWithNull(
   std::tie(buffer, buffer_len) =
       column->GetRangeBuffer(data_index_begin, data_range_lens);
 
-  auto null_bitmap = column->GetBitmap();
+  const auto &null_bitmap = column->GetBitmap();
   size_t non_null_offset = 0;
   size_t type_len = column->GetTypeLength();
   for (size_t i = range_begin; i < (range_begin + range_lens); i++) {
@@ -121,9 +121,9 @@ static void CopyNonFixedBuffer(PaxColumn *column,
   size_t dst_offset = out_data_buffer->Used();
   char *buffer = nullptr;
   size_t buffer_len = 0;
-
-  auto null_bitmap = column->GetBitmap();
   size_t non_null_offset = 0;
+
+  const auto &null_bitmap = column->GetBitmap();
 
   for (size_t i = range_begin; i < (range_begin + range_lens); i++) {
     if (visibility_map_bitset &&
@@ -219,7 +219,7 @@ static void CopyDecimalBuffer(PaxColumn *column,
   size_t buffer_len = 0;
   int32 type_len;
 
-  auto null_bitmap = column->GetBitmap();
+  const auto &null_bitmap = column->GetBitmap();
   type_len = VEC_SHORT_NUMERIC_STORE_BYTES;
 
   for (size_t i = range_begin; i < (range_begin + range_lens); i++) {
@@ -279,11 +279,11 @@ void CopyBitPackedBuffer(PaxColumn *column,
   std::tie(buffer, buffer_len) =
       column->GetRangeBuffer(data_index_begin, data_range_lens);
 
-  auto null_bitmap = column->GetBitmap();
   size_t bit_index = 0;
   size_t non_null_offset = 0;
   size_t type_len = column->GetTypeLength();
   size_t tuple_offset = group_base_offset + range_begin;
+  const auto &null_bitmap = column->GetBitmap();
 
   for (size_t i = 0; i < range_lens; i++) {
     bool is_visible = !visibility_map_bitset ||
@@ -431,7 +431,7 @@ std::pair<size_t, size_t> VecAdapter::AppendPorcFormat(PaxColumns *columns,
 
       vec_cache_buffer_[index].is_dict = true;
       if (column->HasNull()) {
-        auto null_bitmap = column->GetBitmap();
+        const auto &null_bitmap = column->GetBitmap();
         size_t non_null_offset = 0;
 
         for (size_t i = 0; i < range_lens; i++) {

--- a/contrib/pax_storage/src/cpp/storage/vec/pax_vec_comm.cc
+++ b/contrib/pax_storage/src/cpp/storage/vec/pax_vec_comm.cc
@@ -88,12 +88,12 @@ void CopyBitmapBuffer(PaxColumn *column,
       Assert(!null_bits_buffer->GetBuffer());
       null_bits_buffer->Set(BlockBuffer::Alloc<char>(null_align_bytes),
                             null_align_bytes);
-      auto bitmap = column->GetBitmap();
+      const auto &bitmap = column->GetBitmap();
       Assert(bitmap);
       CopyBitmap(bitmap.get(), range_begin, range_lens, null_bits_buffer);
       *out_visable_null_counts = range_lens - data_range_lens;
     } else {
-      auto bitmap = column->GetBitmap();
+      const auto &bitmap = column->GetBitmap();
       Assert(bitmap);
 
       Bitmap8 null_bitmap(out_range_lens);


### PR DESCRIPTION
Accessing the visibility bitmap of a column is temporary. Frequently building the shared pointer of the bitmap and destroy it will hurt performance.

Note: The returned left reference should not hold long time, its lifetime must be shorter than the corresponding column.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
