### PR TITLE
[gpfdist] Use event_base with libevent 2.0+ to avoid thread-unsafe event_init

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -233,6 +233,9 @@ static struct
 	SSL_CTX 		*server_ctx;/* for SSL */
 #endif
 	int 			wdtimer; /* Kill gpfdist after k seconds of inactivity. 0 to disable. */
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	struct event_base *event_base; /* for libevent 2.0+ */
+#endif
 } gcb;
 
 /*  A session */
@@ -1600,7 +1603,11 @@ static void session_detach(request_t* r)
 			}
 
 			event_del(&session->ev);
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+			evtimer_assign(&session->ev, gcb.event_base, free_session_cb, session);
+#else
 			evtimer_set(&session->ev, free_session_cb, session);
+#endif
 			session->tm.tv_sec  = opt.w;
 			session->tm.tv_usec = 0;
 			(void)evtimer_add(&session->ev, &session->tm);
@@ -1811,7 +1818,11 @@ static int session_attach(request_t* r)
 		session->active_segids[r->segid] = 1; /* mark this segid as active */
 		session->maxsegs = r->totalsegs;
 		session->requests = apr_hash_make(pool);
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+		event_assign(&session->ev, gcb.event_base, -1, 0, NULL, NULL);
+#else
 		event_set(&session->ev, 0, 0, 0, 0);
+#endif
 
 		if (session->tid == 0 || session->path == 0 || session->key == 0)
 			gfatal(r, "out of memory in session_attach");
@@ -2352,7 +2363,11 @@ static void do_accept(int fd, short event, void* arg)
 	r->pool = pool;
 	r->sock = sock;
 
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	event_assign(&r->ev, gcb.event_base, -1, 0, NULL, NULL);
+#else
 	event_set(&r->ev, 0, 0, 0, 0);
+#endif
 
 	/* use the block size specified by -m option */
 	r->outblock.data = palloc_safe(r, pool, opt.m, "out of memory when allocating buffer: %d bytes", opt.m);
@@ -2405,7 +2420,11 @@ static int setup_write(request_t* r)
 	if (r->sock < 0)
 		gwarning(r, "internal error in setup_write - no socket to use");
 	event_del(&r->ev);
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	event_assign(&r->ev, gcb.event_base, r->sock, EV_WRITE, do_write, r);
+#else
 	event_set(&r->ev, r->sock, EV_WRITE, do_write, r);
+#endif
 	return (event_add(&r->ev, 0));
 }
 
@@ -2429,7 +2448,11 @@ static int setup_read(request_t* r)
 		gwarning(r, "internal error in setup_read - no socket to use");
 
 	event_del(&r->ev);
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	event_assign(&r->ev, gcb.event_base, r->sock, EV_READ, do_read_request, r);
+#else
 	event_set(&r->ev, r->sock, EV_READ, do_read_request, r);
+#endif
 
 	if(opt.t == 0)
 	{
@@ -2536,16 +2559,40 @@ static void
 signal_register()
 {
     /* when SIGTERM raised invoke process_term_signal */
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+    evsignal_assign(&gcb.signal_event, gcb.event_base, SIGTERM, process_term_signal, 0);
+#else
     signal_set(&gcb.signal_event,SIGTERM,process_term_signal,0);
+#endif
 
     /* high priority so we accept as fast as possible */
     if(event_priority_set(&gcb.signal_event, 0))
         gwarning(NULL,"signal event priority set failed");
 
     /* start watching this event */
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	if(evsignal_add(&gcb.signal_event, 0))
+#else
 	if(signal_add(&gcb.signal_event, 0))
+#endif
         gfatal(NULL,"cannot set up event on signal register");
 
+}
+
+/*
+ * gpfdist_cleanup
+ *
+ * Clean up all resources before exiting
+ */
+static void gpfdist_cleanup(void)
+{
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	/* Clean up event_base if initialized */
+	if (gcb.event_base) {
+		event_base_free(gcb.event_base);
+		gcb.event_base = NULL;
+	}
+#endif
 }
 
 static void clear_listen_sock(void)
@@ -2600,9 +2647,13 @@ http_setup(void)
 		hostaddr = opt.b;
 
 	/* setup event priority */
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	if (event_base_priority_init(gcb.event_base, 10))
+		gwarning(NULL, "event_base_priority_init failed");
+#else
 	if (event_priority_init(10))
 		gwarning(NULL, "event_priority_init failed");
-
+#endif
 
 	/* Try each possible port from opt.p to opt.last_port */
 	for (;;)
@@ -2795,8 +2846,13 @@ http_setup(void)
 	for (i = 0; i < gcb.listen_sock_count; i++)
 	{
 		/* when this socket is ready, do accept */
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+		event_assign(&gcb.listen_events[i], gcb.event_base, gcb.listen_socks[i], 
+		            EV_READ | EV_PERSIST, do_accept, 0);
+#else
 		event_set(&gcb.listen_events[i], gcb.listen_socks[i], EV_READ | EV_PERSIST,
 				  do_accept, 0);
+#endif
 
         /* only signal process function priority higher than socket handler */
 		if (event_priority_set(&gcb.listen_events[i], 1))
@@ -2822,6 +2878,9 @@ process_term_signal(int sig,short event,void* arg)
 			{
 				closesocket(gcb.listen_socks[i]);
 			}
+		
+		/* Clean up resources before exiting */
+		gpfdist_cleanup();
 		_exit(1);
 }
 
@@ -3897,7 +3956,15 @@ int gpfdist_init(int argc, const char* const argv[])
 		putenv("EVENT_SHOW_METHOD=1");
 	putenv("EVENT_NOKQUEUE=1");
 
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	/* libevent 2.0+ */
+	gcb.event_base = event_base_new();
+	if (!gcb.event_base)
+		gfatal(NULL, "event_base_new failed");
+#else
+	/* libevent 1.x */
 	event_init();
+#endif
 
     signal_register();
 	http_setup();
@@ -3975,16 +4042,23 @@ int gpfdist_init(int argc, const char* const argv[])
 
 int gpfdist_run()
 {
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	return event_base_dispatch(gcb.event_base);
+#else
 	return event_dispatch();
+#endif
 }
 
 #ifndef WIN32
 
 int main(int argc, const char* const argv[])
 {
+	int ret;
 	if (gpfdist_init(argc, argv) == -1)
 		gfatal(NULL, "Initialization failed");
-	return gpfdist_run();
+	ret = gpfdist_run();
+	gpfdist_cleanup();
+	return ret;
 }
 
 
@@ -4159,6 +4233,7 @@ int main(int argc, const char* const argv[])
 		if (gpfdist_init(argc, argv) == -1)
 			gfatal(NULL, "Initialization failed");
 		main_ret = gpfdist_run();
+		gpfdist_cleanup();
 	}
 
 
@@ -4248,6 +4323,7 @@ void ServiceMain(int argc, char** argv)
 	 * actual service work
 	 */
 	gpfdist_run();
+	gpfdist_cleanup();
 }
 
 void ControlHandler(DWORD request)
@@ -4550,7 +4626,11 @@ static void flush_ssl_buffer(int fd, short event, void* arg)
 static void setup_flush_ssl_buffer(request_t* r)
 {
 	event_del(&r->ev);
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	event_assign(&r->ev, gcb.event_base, r->sock, EV_WRITE, flush_ssl_buffer, r);
+#else
 	event_set(&r->ev, r->sock, EV_WRITE, flush_ssl_buffer, r);
+#endif
 	r->tm.tv_sec  = 5;
 	r->tm.tv_usec = 0;
 	(void)event_add(&r->ev, &r->tm);
@@ -4662,7 +4742,11 @@ static void request_cleanup(request_t *r)
 static void setup_do_close(request_t* r)
 {
 	event_del(&r->ev);
+#if defined(EVENT__VERSION) && EVENT__NUMERIC_VERSION >= 0x02000100
+	event_assign(&r->ev, gcb.event_base, r->sock, EV_READ, do_close, r);
+#else
 	event_set(&r->ev, r->sock, EV_READ, do_close, r);
+#endif
 
 	r->tm.tv_sec = 60;
 	r->tm.tv_usec = 0;


### PR DESCRIPTION

The legacy event_init() function is not thread-safe and can cause issues when gpfdist is run in multi-threaded environments. This patch updates gpfdist to use libevent 2.0+'s thread-safe APIs, specifically `event_base` along with `event_assign()` and `evtimer_assign()`.

A new global `gcb.event_base` is introduced and used when compiled with libevent ≥ 2.0.1. This avoids the need for the deprecated and non-thread-safe `event_set()` / `evtimer_set()` APIs, and prepares gpfdist for better thread safety.

This change maintains backward compatibility with older libevent versions via conditional compilation.


Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
