### PR TITLE
Extending gpfdist in Cloudberry Database to Support SFTP Protocol for…

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -67,6 +67,7 @@ LIBS := $(filter-out -lreadline -ledit -ltermcap -lncurses -lcurses, $(LIBS))
 
 # Cloudberry uses threads in the backend
 LIBS := $(LIBS) -lpthread
+LIBS := $(LIBS) -lssh2
 
 ifeq ($(with_systemd),yes)
 LIBS += -lsystemd

--- a/src/backend/utils/misc/fstream/Makefile
+++ b/src/backend/utils/misc/fstream/Makefile
@@ -10,6 +10,7 @@ top_builddir = ../../../../..
 include $(top_builddir)/src/Makefile.global
 
 override CPPFLAGS := -I$(srcdir) $(CPPFLAGS)
+override CPPFLAGS := -I$(srcdir) $(CPPFLAGS) -lssh2 -I/usr/local
 
 OBJS = fstream.o gfile.o
 

--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -30,6 +30,8 @@
 #include <gpfxdist.h>
 #endif
 
+#include <arpa/inet.h>
+
 char* format_error(char* c1, char* c2);
 
 
@@ -144,6 +146,36 @@ static void glob_and_copyfree(glob_and_copy_t *pglob)
 		gfile_free(pglob->gl_pathv);
 		pglob->gl_pathc = 0;
 		pglob->gl_pathv = 0;
+	}
+}
+
+static void glob_and_copyfree_sftp(glob_and_copy_t *pglob)
+{
+	if (pglob->gl_pathc)
+	{
+		int i;
+
+		for (i = 0; i < pglob->gl_pathc; i++)
+		{
+			gfile_free(pglob->gl_pathv[i]);
+			gfile_free(pglob->gl_username[i]);
+			gfile_free(pglob->gl_passwd[i]);
+			gfile_free(pglob->gl_hostaddr[i]);
+			gfile_free(pglob->gl_port[i]);
+		}
+
+		gfile_free(pglob->gl_pathv);
+		gfile_free(pglob->gl_username);
+		gfile_free(pglob->gl_passwd);
+		gfile_free(pglob->gl_hostaddr);
+		gfile_free(pglob->gl_port);
+
+		pglob->gl_pathc = 0;
+		pglob->gl_pathv = 0;
+		pglob->gl_username = 0;
+		pglob->gl_passwd = 0;
+		pglob->gl_hostaddr = 0;
+		pglob->gl_port = 0;
 	}
 }
 
@@ -315,7 +347,12 @@ int fstream_close_with_error(fstream_t* fs, char* error)
 	if(fs->buffer)
 		gfile_free(fs->buffer);
 
-	glob_and_copyfree(&fs->glob);
+	if (fs->fd.is_sftp)
+	{
+		glob_and_copyfree_sftp(&fs->glob);
+	}
+	else 
+		glob_and_copyfree(&fs->glob);
 	gfile_close(&fs->fd);
 #ifdef GPFXDIST
 		/* 
@@ -453,6 +490,310 @@ static int glob_path(fstream_t *fs, const char *path)
 	return 0;
 }
 
+int get_sftp_counts(const char *sftp_request)
+{
+	const char *start;
+	const char *end;
+	int count1 = 0;
+	int count2 = 0;
+
+	start = (char *)sftp_request;
+	end = (char *)sftp_request;
+
+	while (*start || *end)
+	{
+		if (*start == '<')
+			count1++;
+		start++;
+		if (*end == '>')
+			count2++;
+		end++;
+	}
+
+	if (count1 != count2)
+		return -1;
+
+	return count1;
+}
+
+int ParseFilePathUri(char *uri_str, sftp_info_t *info)
+{
+
+	int protocol_len = 0;
+	int len = 0;
+	char *start, *end;
+
+	if (strncmp(uri_str, "sftp://", 7) == 0)
+	{
+		protocol_len = 7;
+	}
+	else
+	{
+		return -2;
+	}
+
+	start = (char *)uri_str + protocol_len;
+	end = strchr(start, ':');
+	if (end == NULL)
+	{
+
+		return -2;
+	}
+	else
+	{
+		len = end - start;
+
+		char *username = NULL;
+		username = (char *)gfile_malloc(len + 1);
+		if (username == NULL)
+		{
+			gfile_printf_then_putc_newline("out of memory");
+			return -1;
+		}
+		strncpy(username, start, len);
+		username[len] = '\0';
+		strcpy(info->username, username);
+		gfile_free(username);
+	}
+	start = end + 1;
+	end = strchr(start, '@');
+
+	if (end == NULL)
+	{
+		return -2;
+	}
+	else
+	{
+		len = end - start;
+
+		char *passwd = NULL;
+		passwd = (char *)gfile_malloc(len + 1);
+		if (passwd == NULL)
+		{
+			gfile_printf_then_putc_newline("out of memory");
+			return -1;
+		}
+		strncpy(passwd, start, len);
+		passwd[len] = '\0';
+		strcpy(info->password, passwd);
+		gfile_free(passwd);
+	}
+
+	start = end + 1;
+	if (strncmp(start, "[", 1) == 0)
+	{
+		end = strchr(start, ']');
+		if (end == NULL)
+			return -2;
+
+		len = end - start;
+		char *hostaddr6 = NULL;
+		hostaddr6 = (char *)gfile_malloc(len);
+		if (hostaddr6 == NULL)
+		{
+			gfile_printf_then_putc_newline("out of memory");
+			return -1;
+		}
+		strncpy(hostaddr6, start + 1, len - 1);
+		hostaddr6[len - 1] = '\0';
+		strcpy(info->hostaddr, hostaddr6);
+		gfile_free(hostaddr6);
+
+		end++;
+	}
+
+	else
+	{
+		end = strchr(start, ':');
+		if (end == NULL)
+		{
+			return -2;
+		}
+		else
+		{
+			len = end - start;
+
+			char *hostaddr4 = NULL;
+			hostaddr4 = (char *)gfile_malloc(len + 1);
+			if (hostaddr4 == NULL)
+			{
+				gfile_printf_then_putc_newline("out of memory");
+				return -1;
+			}
+			strncpy(hostaddr4, start, len);
+			hostaddr4[len] = '\0';
+			strcpy(info->hostaddr, hostaddr4);
+			gfile_free(hostaddr4);
+		}
+	}
+
+	start = end + 1;
+	end = strchr(start, '/');
+	if (end == NULL)
+	{
+		return -2;
+	}
+	else
+	{
+		len = end - start;
+
+		char *port = NULL;
+		port = (char *)gfile_malloc(len + 1);
+		if (port == NULL)
+		{
+			gfile_printf_then_putc_newline("out of memory");
+			return -1;
+		}
+		strncpy(port, start, len);
+		port[len] = '\0';
+		strcpy(info->port, port);
+		gfile_free(port);
+	}
+
+	start = end;
+	strcpy(info->fpath, start);
+
+	return 0;
+}
+
+static int order_by_hostaddr(const void *e1, const void *e2)
+{
+	struct in_addr ip1;
+	struct in_addr ip2;
+	int result = 0;
+
+	inet_pton(AF_INET, ((struct sftp_info_t *)e1)->hostaddr, &ip1);
+	inet_pton(AF_INET, ((struct sftp_info_t *)e2)->hostaddr, &ip2);
+
+	result = memcmp(&ip1, &ip2, sizeof(struct in_addr));
+
+	if (result > 0)
+		return 1;
+	else if (result < 0)
+		return -1;
+	else
+		return 0;
+}
+
+static int fetch_sftp_paths(fstream_t *fs, const char *path)
+{
+	int counts = get_sftp_counts(path);
+	if(counts == -1)
+	{
+		gfile_printf_then_putc_newline("sftp path is Non-conforming, please check ");
+		return 1;
+	}
+
+	if(counts == 0)
+	{
+		gfile_printf_then_putc_newline("sftp path is empty");
+		return 1;
+	}
+	char **res = (char **)malloc(sizeof(char *) * counts);
+
+	char **unames = (char **)gfile_malloc(sizeof(char *) * counts);
+	char **passwds = (char **)gfile_malloc(sizeof(char *) * counts);
+	char **hostaddrs = (char **)gfile_malloc(sizeof(char *) * counts);
+	char **ports = (char **)gfile_malloc(sizeof(char *) * counts);
+	char **fpaths = (char **)gfile_malloc(sizeof(char *) * counts);
+
+	if (!unames || !passwds || !hostaddrs || !ports || !fpaths)
+	{
+		gfile_printf_then_putc_newline("out of memory");
+		return 1;
+	}
+
+	sftp_info_t sftp_info_lists[64];
+
+	fs->glob.gl_pathc = 0;
+	fs->glob.gl_username = unames;
+	fs->glob.gl_passwd = passwds;
+	fs->glob.gl_hostaddr = hostaddrs;
+	fs->glob.gl_port = ports;
+	fs->glob.gl_pathv = fpaths;
+
+	{
+		const char *start;
+		const char *end;
+		start = (char *)path;
+		end = (char *)path;
+
+		for (int i = 0; i < counts; i++)
+		{
+			while (*start != '<')
+				start++;
+			while (*end != '>')
+				end++;
+			int len = end - start - 1;
+			char *req = (char *)gfile_malloc(len + 1);
+			if (!req)
+			{
+				gfile_printf_then_putc_newline("out of memory");
+				return 1;
+			}
+			strncpy(req, start + 1, len);
+			req[len] = '\0';
+			res[i] = strdup(req);
+			gfile_free(req);
+			start++;
+			end++;
+		}
+	}
+
+	for (int i = 0; i < counts; i++)
+	{
+		int parse_result = ParseFilePathUri(res[i], &sftp_info_lists[i]);
+		if(parse_result == 0)
+			continue;
+		else
+		{
+			for (int j = 0; j < counts; j++)
+			{
+				if(res[i])
+					free(res[i]);
+			}
+			free(res);
+		}
+	}
+
+	qsort(sftp_info_lists, counts, sizeof(sftp_info_t), order_by_hostaddr);
+
+	for (int j = 0; j < counts; j++)
+	{
+		char *tmp_uname = sftp_info_lists[j].username;
+		char *tmp_passwd = sftp_info_lists[j].password;
+		char *tmp_hostaddr = sftp_info_lists[j].hostaddr;
+		char *tmp_port = sftp_info_lists[j].port;
+		char *tmp_fpath = sftp_info_lists[j].fpath;
+
+		*unames = (char *)gfile_malloc(strlen(tmp_uname) + 1);
+		*passwds = (char *)gfile_malloc(strlen(tmp_passwd) + 1);
+		*hostaddrs = (char *)gfile_malloc(strlen(tmp_hostaddr) + 1);
+		*ports = (char *)gfile_malloc(strlen(tmp_port) + 1);
+		*fpaths = (char *)gfile_malloc(strlen(tmp_fpath) + 1);
+
+		if (!(*unames) || !(*passwds) || !(*hostaddrs) || !(*ports) || !(*fpaths))
+		{
+			gfile_printf_then_putc_newline("out of memory!!!");
+			return 1;
+		}
+
+		strcpy(*unames++, tmp_uname);
+		strcpy(*passwds++, tmp_passwd);
+		strcpy(*hostaddrs++, tmp_hostaddr);
+		strcpy(*ports++, tmp_port);
+		strcpy(*fpaths++, tmp_fpath);
+
+		fs->glob.gl_pathc++;
+	}
+
+	for (int i = 0; i < counts; i++)
+	{
+		free(res[i]);
+	}
+	free(res);
+	return 0;
+}
 
 #ifdef GPFXDIST
 /*
@@ -501,6 +842,7 @@ fstream_open(const char *path, const struct fstream_options *options,
 {
 	int i;
 	fstream_t* fs;
+	bool_t is_sftp = FALSE;
 
 	*response_code = 500;
 	*response_string = "Internal Server Error";
@@ -515,26 +857,43 @@ fstream_open(const char *path, const struct fstream_options *options,
 	fs->options = *options;
 	fs->buffer = gfile_malloc(options->bufsize);
 	
+	if (strncmp(path, "/<sftp://", 9) == 0)
+	{
+		is_sftp = TRUE;
+	}
+
 	/*
 	 * get a list of all files that were requested to be read and include them
 	 * in our fstream. This includes any wildcard pattern matching.
 	 */
-	if (glob_path(fs, path))
+	if (is_sftp)
 	{
-		fstream_close(fs);
-		return 0;
-	}
-
-	/*
-	 * If the list of files in our filestrem includes a directory name, expand
-	 * the directory and add all the files inside of it.
-	 */
-	if (fpath_all_directories(&fs->glob))
-	{
-		if (expand_directories(fs))
+		if (fetch_sftp_paths(fs, path))
 		{
 			fstream_close(fs);
 			return 0;
+		}
+	}
+
+	else
+	{
+		if (glob_path(fs, path))
+		{
+			fstream_close(fs);
+			return 0;
+		}
+
+		/*
+	 * If the list of files in our filestrem includes a directory name, expand
+	 * the directory and add all the files inside of it.
+	 */
+		if (fpath_all_directories(&fs->glob))
+		{
+			if (expand_directories(fs))
+			{
+				fstream_close(fs);
+				return 0;
+			}
 		}
 	}
 
@@ -543,11 +902,14 @@ fstream_open(const char *path, const struct fstream_options *options,
 	 */
 	if (fs->glob.gl_pathc == 0)
 	{
-		gfile_printf_then_putc_newline("fstream bad path: %s", path);
-		fstream_close(fs);
-		*response_code = 404;
-		*response_string = "No matching file(s) found";
-		return 0;
+		if(!is_sftp)
+		{
+			gfile_printf_then_putc_newline("fstream bad path: %s", path);
+			fstream_close(fs);
+			*response_code = 404;
+			*response_string = "No matching file(s) found";
+			return 0;
+		}
 	}
 
 	if (fs->glob.gl_pathc != 1 && options->forwrite)
@@ -650,13 +1012,26 @@ fstream_open(const char *path, const struct fstream_options *options,
 
 		gfile_close(&fs->fd);
 
-		if (gfile_open(&fs->fd, fs->glob.gl_pathv[i], gfile_open_flags(options->forwrite, options->usesync),
-					   response_code, response_string, transform))
+		if (is_sftp)
 		{
-			gfile_printf_then_putc_newline("fstream unable to open file %s",
-					fs->glob.gl_pathv[i]);
-			fstream_close(fs);
-			return 0;
+			if (gfile_open_sftp(&fs->fd, fs->glob.gl_pathv[i], fs->glob.gl_username[i], fs->glob.gl_passwd[i],
+								fs->glob.gl_hostaddr[i], fs->glob.gl_port[i], gfile_open_flags(options->forwrite, options->usesync), response_code, response_string, transform))
+			{
+				gfile_printf_then_putc_newline("fstream unable to open file %s", fs->glob.gl_pathv[i]);
+				fstream_close(fs);
+				return 0;
+			}
+		}
+		else
+		{
+			if (gfile_open(&fs->fd, fs->glob.gl_pathv[i], gfile_open_flags(options->forwrite, options->usesync),
+						   response_code, response_string, transform))
+			{
+				gfile_printf_then_putc_newline("fstream unable to open file %s",
+											   fs->glob.gl_pathv[i]);
+				fstream_close(fs);
+				return 0;
+			}
 		}
 
 		fs->compressed_size += gfile_get_compressed_size(&fs->fd);
@@ -708,13 +1083,28 @@ static int nextFile(fstream_t*fs)
 	{
 		fs->skip_header_line = fs->options.header;
 
-		if (gfile_open(&fs->fd, fs->glob.gl_pathv[fs->fidx], GFILE_OPEN_FOR_READ, 
-					   &response_code, &response_string, transform))
+		if (fs->fd.is_sftp)
 		{
-			gfile_printf_then_putc_newline("fstream unable to open file %s",
-											fs->glob.gl_pathv[fs->fidx]);
-			fs->ferror = "unable to open file";
-			return 1;
+			if (gfile_open_sftp(&fs->fd, fs->glob.gl_pathv[fs->fidx], fs->glob.gl_username[fs->fidx], fs->glob.gl_passwd[fs->fidx],
+								fs->glob.gl_hostaddr[fs->fidx], fs->glob.gl_port[fs->fidx], GFILE_OPEN_FOR_READ, &response_code, &response_string, transform))
+			{
+				gfile_printf_then_putc_newline("fstream unable to open file %s",
+											   fs->glob.gl_pathv[fs->fidx]);
+				fs->ferror = "unable to open file";
+				return 1;
+			}
+		}
+
+		else
+		{
+			if (gfile_open(&fs->fd, fs->glob.gl_pathv[fs->fidx], GFILE_OPEN_FOR_READ,
+						   &response_code, &response_string, transform))
+			{
+				gfile_printf_then_putc_newline("fstream unable to open file %s",
+											   fs->glob.gl_pathv[fs->fidx]);
+				fs->ferror = "unable to open file";
+				return 1;
+			}
 		}
 	}
 

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -40,6 +40,11 @@
 #include <sys/file.h>   /* for flock */
 #include <unistd.h>
 
+#include <libssh2.h>
+#include <libssh2_sftp.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+
 #ifdef WIN32
 #include <io.h>
 #define snprintf _snprintf
@@ -144,6 +149,45 @@ writewinpipe(gfile_t* fd, void* ptr, size_t size)
 		fd->compressed_position += i;
 
 	return i;
+}
+
+static ssize_t
+sftp_read(gfile_t *fd, void *ptr, size_t size)
+{
+	ssize_t i = 0;
+	do
+		i = libssh2_sftp_read(fd->sftp_handle, ptr, size);
+	while (i < 0 && errno == EINTR);
+
+	if (i < 0)
+		gfile_printf_then_putc_newline("i is %ld", i);
+
+	if (i > 0)
+		fd->compressed_position += i;
+	return i;
+}
+
+static int
+sftp_close(gfile_t *fd)
+{
+	if (fd->sftp_handle)
+		libssh2_sftp_close(fd->sftp_handle);
+	if (fd->sftp_session)
+		libssh2_sftp_shutdown(fd->sftp_session);
+	if (fd->session)
+	{
+		libssh2_session_disconnect(fd->session, "Normal Shutdown");
+		libssh2_session_free(fd->session);
+	}
+	
+#ifdef WIN32
+	closesocket(fd->sock);
+#else
+	close(fd->sock);
+#endif
+	fd->sock = -1;
+	libssh2_exit();
+	return 0;
 }
 
 #ifdef HAVE_LIBBZ2
@@ -1335,27 +1379,123 @@ gfile_close(gfile_t*fd)
 				fd->close(fd);
 			}
 
-			if (fd->is_win_pipe)
+			if (fd->is_sftp)
 			{
-				fd->close(fd);
+				sftp_close(fd);
 			}
 			else
 			{
-				if(fd->held_pipe_lock)
+				if (fd->is_win_pipe)
 				{
-#ifndef WIN32
-					flock (fd->fd.filefd, LOCK_UN);
-#endif
+					fd->close(fd);
 				}
-				ret = close_filefd(fd->fd.filefd);
-				if (ret == -1)
-					ret = 1;
+				else
+				{
+					if(fd->held_pipe_lock)
+					{
+#ifndef WIN32
+						flock (fd->fd.filefd, LOCK_UN);
+#endif
+					}
+					ret = close_filefd(fd->fd.filefd);
+					if (ret == -1)
+						ret = 1;
+				}
 			}
+			
 		} 
 		fd->read = 0;
 		fd->close = 0;
 	}
 	return ret;
+}
+
+int gfile_open_sftp(gfile_t *fd, const char *fpath, const char *sftp_uname, const char *sftp_passwd, const char *sftp_hostaddr,
+					const char *sftp_port, int flags, int *response_code, const char **response_string, struct gpfxdist_t *transform)
+{
+	const char *s = strrchr(fpath, '.');
+
+	//struct stat sta;
+	LIBSSH2_SFTP_ATTRIBUTES sta;
+	memset(&sta, 0, sizeof(sta));
+	memset(fd, 0, sizeof *fd);
+	fd->is_sftp = TRUE;
+
+	int ans = sftp_open(fd, fpath, sftp_uname, sftp_passwd, sftp_hostaddr, sftp_port);
+	if (ans == 0)
+	{
+		gfile_printf_then_putc_newline("looks like a ftp handle");
+		gfile_printf_then_putc_newline("path is %s", fpath);
+	}
+	else
+	{
+		gfile_printf_then_putc_newline("failed open a  ftp handle, please check sftp-information: ip, port, passwd and filename");
+		if (ans == -2)
+		{
+			sftp_free(fd);
+		}
+		return 1;
+	}
+
+	if (flags == GFILE_OPEN_FOR_READ)
+	{
+		if (0 != libssh2_sftp_stat(fd->sftp_session, fpath, &sta))
+		{
+			gfile_printf_then_putc_newline("libssh2 libssh2_sftp_stat failed");
+			return 1;
+		}
+	}
+
+	fd->compressed_size = sta.filesize;
+
+	fd->read = sftp_read;
+	fd->close = sftp_close;
+
+	/*
+	 * delegate remaining setup work to an appropriate open routine
+	 * or return an error if we can't handle the type
+	 */
+	if (s && strcasecmp(s, ".gz") == 0)
+	{
+#ifndef HAVE_LIBZ
+		gfile_printf_then_putc_newline(".gz not supported");
+#else
+		/*
+		 * flag used by function gfile close
+		 */
+		fd->compression = GZ_COMPRESSION;
+
+		if (flags != GFILE_OPEN_FOR_READ)
+		{
+			fd->is_write = TRUE;
+		}
+
+		return gz_file_open(fd);
+#endif
+	}
+	else if (s && strcasecmp(s, ".bz2") == 0)
+	{
+#ifndef HAVE_LIBBZ2
+		gfile_printf_then_putc_newline(".bz2 not supported");
+#else
+		fd->compression = BZ_COMPRESSION;
+		if (flags != GFILE_OPEN_FOR_READ)
+			gfile_printf_then_putc_newline(".bz2 not yet supported for writable tables");
+
+		return bz_file_open(fd);
+#endif
+	}
+	else if (s && strcasecmp(s, ".z") == 0)
+		gfile_printf_then_putc_newline("gfile compression .z file is not supported");
+	else if (s && strcasecmp(s, ".zip") == 0)
+		gfile_printf_then_putc_newline("gfile compression zip is not supported");
+	else
+		return 0;
+
+	*response_code = 415;
+	*response_string = "Unsupported File Type";
+
+	return 1;
 }
 
 ssize_t 
@@ -1406,4 +1546,108 @@ off_t gfile_get_compressed_size(gfile_t *fd)
 off_t gfile_get_compressed_position(gfile_t *fd)
 {
 	return fd->compressed_position;
+}
+
+
+int sftp_open(gfile_t *fd, const char *fpath, const char *sftp_uname, const char *sftp_passwd, const char *sftp_hostaddr,
+			 const char *sftp_port)
+{
+	int rc;
+	int auth_pw = 0;
+	char *userauthlist;
+	uint16_t port;
+	unsigned long hostaddr;
+	struct sockaddr_in sin;
+
+	hostaddr = inet_addr(sftp_hostaddr);
+
+	sscanf(sftp_port, "%hu", &port);
+
+	rc = libssh2_init(0);
+
+	if (rc != 0)
+	{
+		gfile_printf_then_putc_newline("libssh2 initialization failed (%d)\n", rc);
+		return -1;
+	}
+	
+	fd->sock = -1;
+
+	fd->sock = socket(AF_INET, SOCK_STREAM, 0);
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+	sin.sin_addr.s_addr = hostaddr;
+
+	if (connect(fd->sock, (struct sockaddr *)(&sin),
+				sizeof(struct sockaddr_in)) != 0)
+	{
+		gfile_printf_then_putc_newline("failed to connect!\n");
+		return -1;
+	}
+
+	fd->session = libssh2_session_init();
+	if (!fd->session)
+		return -1;
+
+	/* Since we have set non-blocking, tell libssh2 we are blocking */
+	libssh2_session_set_blocking(fd->session, 1);
+
+	/* ... start it up. This will trade welcome banners, exchange keys,
+     * and setup crypto, compression, and MAC layers
+     */
+	rc = libssh2_session_handshake(fd->session, fd->sock);
+	if (rc)
+	{
+		gfile_printf_then_putc_newline("Failure establishing SSH session: %d\n", rc);
+		return -1;
+	}
+
+	/* check what authentication methods are available */
+	userauthlist = libssh2_userauth_list(fd->session, sftp_uname, strlen(sftp_uname));
+	if (strstr(userauthlist, "password") != NULL)
+	{
+		auth_pw |= 1;
+	}
+
+	if (auth_pw & 1)
+	{
+		if (libssh2_userauth_password(fd->session, sftp_uname, sftp_passwd))
+		{
+			gfile_printf_then_putc_newline("Authentication by password failed.\n");
+			return -2;
+		}
+	}
+
+	gfile_printf_then_putc_newline("libssh2_sftp_init()!\n");
+	fd->sftp_session = libssh2_sftp_init(fd->session);
+
+	if (!(fd->sftp_session))
+	{
+		gfile_printf_then_putc_newline("Unable to init SFTP session\n");
+		return -2;
+	}
+
+	fd->sftp_handle =
+		libssh2_sftp_open(fd->sftp_session, fpath, LIBSSH2_FXF_READ, 0);
+	if (!(fd->sftp_handle))
+	{
+		gfile_printf_then_putc_newline("Unable to open file with SFTP: %ld\n",
+									   libssh2_sftp_last_error(fd->sftp_session));
+		return -2;
+	}
+
+	return 0;
+}
+void sftp_free(gfile_t *fd)
+{
+	libssh2_session_disconnect(fd->session, "Normal Shutdown");
+	libssh2_session_free(fd->session);
+
+#ifdef WIN32
+	closesocket(fd->sock);
+#else
+	close(fd->sock);
+#endif
+	fd->sock = -1;
+	libssh2_exit();
 }

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -25,7 +25,7 @@ ifeq ($(PORTNAME),win32)
   OBJS += $(top_builddir)/src/port/glob.o
 endif
 
-LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(apr_link_ld_libs)
+LDLIBS += $(LIBS) $(GPFDIST_LIBS) $(apr_link_ld_libs) -lssh2
 
 all: gpfdist$(X)
 

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -42,6 +42,7 @@ override CPPFLAGS += -DVAL_LIBS="\"$(LIBS)\""
 
 override CPPFLAGS := -DFRONTEND -I. -I$(top_srcdir)/src/common $(CPPFLAGS)
 LIBS += $(PTHREAD_LIBS)
+LIBS += -lssh2 
 
 # If you add objects here, see also src/tools/msvc/Mkvcbuild.pm
 

--- a/src/include/cdb/cdbsreh.h
+++ b/src/include/cdb/cdbsreh.h
@@ -100,5 +100,6 @@ extern Datum gp_truncate_error_log(PG_FUNCTION_ARGS);
 extern Datum gp_read_persistent_error_log(PG_FUNCTION_ARGS);
 extern Datum gp_truncate_persistent_error_log(PG_FUNCTION_ARGS);
 
+extern int get_sftpfile_numbers(const char *path);
 
 #endif /* CDBSREH_H */

--- a/src/include/fstream/fstream.h
+++ b/src/include/fstream/fstream.h
@@ -23,6 +23,12 @@ typedef struct
 {
 	int 	gl_pathc;
 	char**	gl_pathv;
+	char**  gl_username;
+	char**  gl_passwd;
+	char**  gl_keyfile1;
+	char**  gl_keyfile2;
+	char**  gl_hostaddr;
+	char**  gl_port;
 } glob_and_copy_t;
 
 struct fstream_options{
@@ -84,5 +90,8 @@ fstream_t* fstream_open(const char* path, const struct fstream_options* options,
 int fstream_close_with_error(fstream_t* fs, char* msg);
 void fstream_close(fstream_t* fs);
 bool_t fstream_is_win_pipe(fstream_t *fs);
+
+int ParseFilePathUri(char *uri_str, sftp_info_t *info);
+int get_sftp_counts(const char *sftp_request);
 
 #endif

--- a/src/include/fstream/gfile.h
+++ b/src/include/fstream/gfile.h
@@ -26,6 +26,9 @@ typedef _int64 ssize_t;
 
 #include "c.h"
 
+#include <libssh2.h>
+#include <libssh2_sftp.h>
+
 #ifdef WIN32
 typedef BOOL bool_t;
 #else
@@ -57,6 +60,7 @@ typedef struct gfile_t
 	off_t compressed_size,compressed_position;
 	bool_t is_win_pipe;
 	bool_t held_pipe_lock; /* Whether held flock on pipe file, used to restrict only one reader of pipe */
+	bool_t is_sftp;
 
 	union
 	{
@@ -65,6 +69,11 @@ typedef struct gfile_t
 		HANDLE pipefd;
 #endif
 	} fd;
+
+	LIBSSH2_SESSION *session;
+	LIBSSH2_SFTP *sftp_session;
+	LIBSSH2_SFTP_HANDLE *sftp_handle;
+	int sock;
 
 	union
 	{
@@ -85,6 +94,19 @@ typedef struct gfile_t
 	struct gpfxdist_t* transform;
 } gfile_t;
 
+/* Struct of sftp info */
+typedef struct sftp_info_t sftp_info_t;
+struct sftp_info_t
+{
+	char username[32];
+	char password[64];
+	char keyfile1[64];
+	char keyfile2[64];
+	char hostaddr[64];
+	char port[16];
+	char fpath[256];
+};
+
 /*
  * MPP-13817 (support opening files without O_SYNC)
  */
@@ -94,6 +116,8 @@ int gfile_open_flags(int writing, int usesync);
 #define GFILE_OPEN_FOR_WRITE_SYNC   2
 
 int gfile_open(gfile_t* fd, const char* fpath, int flags, int* response_code, const char** response_string, struct gpfxdist_t* transform);
+int gfile_open_sftp(gfile_t *fd, const char *fpath, const char *sftp_uname, const char *sftp_passwd, const char *sftp_hostaddr,
+					const char *sftp_port, int flags, int *response_code, const char **response_string, struct gpfxdist_t *transform);
 int gfile_close(gfile_t*fd);
 off_t gfile_get_compressed_size(gfile_t*fd);
 off_t gfile_get_compressed_position(gfile_t*fd);
@@ -103,4 +127,7 @@ void gfile_printf_then_putc_newline(const char*format,...) pg_attribute_printf(1
 void*gfile_malloc(size_t size);
 void gfile_free(void*a);
 
+extern int sftp_open(gfile_t *fd, const char *fpath, const char *sftp_uname, const char *sftp_passwd, const char *sftp_hostaddr,
+					const char *sftp_port);
+extern void sftp_free(gfile_t *fd);
 #endif


### PR DESCRIPTION
… Data Ingestion

gpfdist is a file distribution program in Cloudberry that can parallel load external data into the database. However, it has the drawback that data files must reside on the same machine as the tool. Therefore,extending it to support the SFTP protocol can address the above drawback and enable loading files from a remote server.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
By extending the `gpfdist` tool to support the SFTP protocol, remote data loading has been achieved, overcoming the challenge of having the tool and data files on the same machine.

### Type of Change
New feature (non-breaking change)

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
The ssh2 library needs to be introduced during compilation and placed under `/usr/local`.

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
Under this approach, the location template for the external table is:
```shell
CREATE EXTERNAL TABLE ext1 (d varchar(20)) location ('gpfdist://ip:port/<sftp://sftp-user:passwd@sftp-hostip:sftp-port/file.csv>') format 'csv' (DELIMITER '|');
``` 

Related Test Case:
1 Start gpfdist
```shell
[cdbberry@node196 ~]$ gpfdist -d /home/cdbberry/ -p 9876 -l gpfdist.log &
[1] 83161
[cdbberry@node196 ~]$ 2025-07-12 14:49:21 83161 INFO Before opening listening sockets - following listening sockets are available:
2025-07-12 14:49:21 83161 INFO IPV6 socket: [::]:9876
2025-07-12 14:49:21 83161 INFO IPV4 socket: 0.0.0.0:9876
2025-07-12 14:49:21 83161 INFO Trying to open listening socket:
2025-07-12 14:49:21 83161 INFO IPV6 socket: [::]:9876
2025-07-12 14:49:21 83161 INFO Opening listening socket succeeded
2025-07-12 14:49:21 83161 INFO Trying to open listening socket:
2025-07-12 14:49:21 83161 INFO IPV4 socket: 0.0.0.0:9876
2025-07-12 14:49:21 83161 INFO Opening listening socket succeeded
Serving HTTP on port 9876, directory /home/cdbberry
``` 

2 create  table (external)
```shell
CREATE table test(
id int,
name varchar(20)
);

CREATE external table testww(
id int,
name varchar(20)
)
location 
('gpfdist://10.229.89.196:9876/<sftp://xxx:xxxx@xxx:22/xx.csv>')
format 'csv' (delimiter as '|' NULL as '' FILL MISSING FIELDS) SEGMENT REJECT LIMIT 2 ROWS;
``` 

3  data load
```shell
insert into test select * from testww;
``` 

4  result 
```shell
postgres=# insert into test select * from test_ext;
INSERT 0 10
postgres=# select * from test;
 id |   name    
----+-----------
  2 | ZTE-EBASE
  3 | ZTE-EBASE
  4 | ZTE-EBASE
  6 | ZTE-EBASE
  7 | ZTE-EBASE
  8 | ZTE-EBASE
  9 | ZTE-EBASE
 10 | ZTE-EBASE
  1 | ZTE-EBASE
  5 | ZTE-EBASE
(10 rows)
``` 

cat test.csv 
1|ZTE-EBASE
2|ZTE-EBASE
3|ZTE-EBASE
4|ZTE-EBASE
5|ZTE-EBASE
6|ZTE-EBASE
7|ZTE-EBASE
8|ZTE-EBASE
9|ZTE-EBASE
10|ZTE-EBASE

The amount and content of the table data are consistent with the file.

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
