### PR TITLE
FIX: core dump when exit(0) happend in postgres

### DIFF
--- a/src/backend/gporca/libnaucrates/src/md/CMDName.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDName.cpp
@@ -75,7 +75,9 @@ CMDName::CMDName(const CMDName &name)
 //---------------------------------------------------------------------------
 CMDName::~CMDName()
 {
-	GPOS_ASSERT(m_name->IsValid());
+	// Some of `m_name` is reference only, there is no guarantee
+	// that the referenced object lives longer than the CMDName
+	// object when running the destructor of a process.
 
 	if (m_deep_copy)
 	{


### PR DESCRIPTION
The core:

- 0  0x00007f7c24dee387 in raise () from /lib64/libc.so.6
- 1  0x00007f7c24defa78 in abort () from /lib64/libc.so.6
- 2  0x00007f7c252238e9 in __gnu_cxx::__verbose_terminate_handler() [clone .cold] () from /workspace/dist/database/lib/libstdc++.so.6
- 3  0x00007f7c2522f10a in __cxxabiv1::__terminate(void (*)()) () from /workspace/dist/database/lib/libstdc++.so.6
- 4  0x00007f7c2522f175 in std::terminate() () from /workspace/dist/database/lib/libstdc++.so.6
- 5  0x00007f7c2522fe93 in __cxa_pure_virtual () from /workspace/dist/database/lib/libstdc++.so.6
- 6  0x00005577fe3eb0b4 in gpos::CWStringBase::IsValid (this=0x5578034ff1c0 <gpmd::CMDTypeOidGPDB::m_str>) at CWStringBase.cpp:50
- 7  0x00005577fe41c23d in gpmd::CMDName::~CMDName (this=0x5578034ff1e0 <gpmd::CMDTypeOidGPDB::m_mdname>, __in_chrg=<optimized out>) at CMDName.cpp:78
- 8  0x00007f7c24df1ce9 in __run_exit_handlers () from /lib64/libc.so.6
- 9  0x00007f7c24df1d37 in exit () from /lib64/libc.so.6
- 10 0x00005577fe089979 in proc_exit (code=0) at ipc.c:157
- 11 0x00005577fe0d4b2d in PostgresMain (argc=14, argv=0x5578078d8480, dbname=0x55780793a930 "template1", username=0x5578078dd7b0 "gpadmin") at postgres.c:6152
- 12 0x00005577fde4eb05 in main (argc=14, argv=0x5578078d8480) at main.c:263

In the #6 the object(`class CWStringConst`) is a static variable in the `class CMDName`, and the core happend when we try to call the `~CMDName` to destory the global variable.

```
CWStringConst CMDTypeOidGPDB::m_str = CWStringConst(GPOS_WSZ_LIT("oid"));
CMDName CMDTypeOidGPDB::m_mdname(&m_str);
```

The reason for this core is that `m_name` has been destructed before its own class CMDName. I added a variable to prove:

```
CWStringConst::~CWStringConst()
{
	if (m_owns_memory && m_w_str_buffer != &m_empty_wcstr)
	{
		GPOS_DELETE_ARRAY(m_w_str_buffer);
	}
	is_invalid = true; // once ~CWStringConst() call, current is_invalid will be true, which default is false.
}
```

And gdb the core

```
(gdb) f 6
(gdb) p ((CWStringConst *)this)->is_invalid
$4 = true // m_name is invalid
```

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
