### PR TITLE
Remove Upstream Assertion in Cloudberry's Parallel UNION codes.

### DIFF
--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -710,7 +710,16 @@ generate_union_paths(SetOperationStmt *op, PlannerInfo *root,
 
 			parallel_workers = Max(parallel_workers, path->parallel_workers);
 		}
+#if 0
+		/*
+		 * CBDB_PARALLEL:
+		 * Unlike upstream, this scenario can occur when there are paths with
+		 * parallel_workers set to 0, but have subpaths with parallel_workers > 0.
+		 * This is a valid case that allows our Cloudberry
+		 * to maximize parallel execution where possible.
+		 */
 		Assert(parallel_workers > 0);
+#endif
 
 		/*
 		 * If the use of parallel append is permitted, always request at least
@@ -726,7 +735,12 @@ generate_union_paths(SetOperationStmt *op, PlannerInfo *root,
 			parallel_workers = Min(parallel_workers,
 								   max_parallel_workers_per_gather);
 		}
+#if 0
+		/*
+		 * See above comments.
+		 */
 		Assert(parallel_workers > 0);
+#endif
 
 		ppath = (Path *)
 			create_append_path(root, result_rel, NIL, partial_pathlist,


### PR DESCRIPTION
Fix #1229 

This commit addresses the scenario where paths have parallel_workers set to 0, but contain subpaths with parallel_workers greater than 0. This case is valid and enables our CBDB to maximize parallel execution where feasible, enhancing overall performance in query processing.
```sql
explain(costs off) SELECT * FROM (SELECT AVG(a) as a FROM dml_union_r UNION SELECT AVG(b) as a FROM dml_union_s) foo;
                           QUERY PLAN
-----------------------------------------------------------------------
 Unique
   Group Key: (avg(dml_union_r.a))
   ->  Sort
         Sort Key: (avg(dml_union_r.a))
         ->  Append
               ->  Finalize Aggregate
                     ->  Gather Motion 6:1  (slice1; segments: 6)
                           ->  Partial Aggregate
                                 ->  Parallel Seq Scan on dml_union_r
               ->  Finalize Aggregate
                     ->  Gather Motion 6:1  (slice2; segments: 6)
                           ->  Partial Aggregate
                                 ->  Parallel Append
                                       ->  Seq Scan on
dml_union_s_1_prt_3 dml_union_s_2
                                       ->  Seq Scan on
dml_union_s_1_prt_4 dml_union_s_3
                                       ->  Seq Scan on
dml_union_s_1_prt_5 dml_union_s_4
                                       ->  Seq Scan on
dml_union_s_1_prt_6 dml_union_s_5
                                       ->  Seq Scan on
dml_union_s_1_prt_7 dml_union_s_6
                                       ->  Seq Scan on
dml_union_s_1_prt_8 dml_union_s_7
                                       ->  Seq Scan on
dml_union_s_1_prt_9 dml_union_s_8
                                       ->  Seq Scan on
dml_union_s_1_prt_10 dml_union_s_9
                                       ->  Seq Scan on
dml_union_s_1_prt_11 dml_union_s_10
                                       ->  Parallel Seq Scan on
dml_union_s_1_prt_2 dml_union_s_1
                                       ->  Parallel Seq Scan on
dml_union_s_1_prt_def dml_union_s_11
 Optimizer: Postgres query optimizer
(25 rows)
```
Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->


### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
