### PR TITLE
CI: fix rat-check status reporting issue

### DIFF
--- a/.github/workflows/apache-rat-audit.yml
+++ b/.github/workflows/apache-rat-audit.yml
@@ -23,7 +23,7 @@
 # using the command: `mvn clean verify -Drat.consoleOutput=true`
 # --------------------------------------------------------------------
 
-name: Apache Rat Audit
+name: Apache Rat License Check
 
 on:
   push:
@@ -42,7 +42,6 @@ concurrency:
 
 jobs:
   rat-check:
-    name: Apache Rat License Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -60,7 +59,6 @@ jobs:
           cache: maven
 
       - name: Run Apache Rat check
-        id: rat-check
         run: |
           echo "Running Apache Rat license check..."
           mvn clean verify -Drat.consoleOutput=true | tee rat-output.log
@@ -147,3 +145,18 @@ jobs:
               echo "The rat-output.log file was not generated."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report Status
+        if: always()
+        shell: bash {0}
+        run: |
+          if [[ -f rat-output.log ]] && grep -q "\[INFO\] BUILD SUCCESS" rat-output.log; then
+            echo "✅ Apache Rat check completed successfully"
+            exit 0
+          elif [[ -f rat-output.log ]] && grep -q "\[INFO\] BUILD FAILURE" rat-output.log; then
+            echo "❌ Apache Rat check failed"
+            exit 1
+          else
+            echo "⚠️ Apache Rat check status unclear"
+            exit 1
+          fi


### PR DESCRIPTION
Fix the "Expected - Waiting for status to be reported" issue for the rat-check status in the CI workflow.

Changes made:
- Add explicit status reporting step

The rat-check job now properly reports its status to GitHub, allowing branch protection rules to correctly evaluate the Apache Rat license compliance check results.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
