### PR TITLE
Fix row estimation for parallel subquery paths.

### DIFF
--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -1540,10 +1540,10 @@ cost_subqueryscan(SubqueryScanPath *path, PlannerInfo *root,
 	Assert(baserel->relid > 0);
 	Assert(baserel->rtekind == RTE_SUBQUERY);
 
-	/* Adjust row count if this runs in multiple segments and parallel model */
 	if (CdbPathLocus_IsPartitioned(path->path.locus))
 	{
-		numsegments = CdbPathLocus_NumSegments(path->path.locus);
+		/* Adjust row count if this runs in multiple segments and parallel model */
+		numsegments = CdbPathLocus_NumSegmentsPlusParallelWorkers(path->path.locus);
 	}
 	else
 		numsegments = 1;

--- a/src/test/regress/expected/cbdb_parallel.out
+++ b/src/test/regress/expected/cbdb_parallel.out
@@ -3415,6 +3415,110 @@ reset enable_parallel;
 --
 -- End of test Parallel UNION
 --
+--
+-- Test Parallel Subquery.
+--
+CREATE TABLE departments (
+    department_id INT PRIMARY KEY,
+    department_name VARCHAR(100)
+);
+CREATE TABLE employees (
+    employee_id INT PRIMARY KEY,
+    name VARCHAR(100),
+    salary NUMERIC,
+    department_id INT
+);
+INSERT INTO departments VALUES 
+(1, 'Sales'),
+(2, 'IT'),
+(3, 'HR');
+INSERT INTO employees VALUES
+(1, 'Alice', 5000, 1),
+(2, 'Bob', 6000, 1),
+(3, 'Charlie', 7000, 2),
+(4, 'David', 8000, 2),
+(5, 'Eve', 9000, 3);
+set enable_parallel = off;
+explain SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=163.42..307.76 rows=3767 width=218)
+   ->  Hash Join  (cost=163.42..257.54 rows=1256 width=218)
+         Hash Cond: (e.department_id = "Expr_SUBQUERY".csq_c0)
+         Join Filter: (e.salary > "Expr_SUBQUERY".csq_c1)
+         ->  Seq Scan on employees e  (cost=0.00..71.67 rows=3767 width=254)
+         ->  Hash  (cost=150.92..150.92 rows=1000 width=36)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=130.09..150.92 rows=1000 width=36)
+                     ->  Subquery Scan on "Expr_SUBQUERY"  (cost=130.09..137.59 rows=333 width=36)
+                           ->  Finalize HashAggregate  (cost=130.09..134.26 rows=333 width=36)
+                                 Group Key: employees.department_id
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=90.50..122.67 rows=990 width=36)
+                                       Hash Key: employees.department_id
+                                       ->  Partial HashAggregate  (cost=90.50..102.87 rows=990 width=36)
+                                             Group Key: employees.department_id
+                                             ->  Seq Scan on employees  (cost=0.00..71.67 rows=3767 width=36)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+ name  
+-------
+ Bob
+ David
+(2 rows)
+
+set enable_parallel = on;
+set min_parallel_table_scan_size = 0;
+explain SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 6:1  (slice1; segments: 6)  (cost=116.58..230.86 rows=3767 width=218)
+   ->  Parallel Hash Join  (cost=116.58..186.92 rows=628 width=218)
+         Hash Cond: (e.department_id = "Expr_SUBQUERY".csq_c0)
+         Join Filter: (e.salary > "Expr_SUBQUERY".csq_c1)
+         ->  Parallel Seq Scan on employees e  (cost=0.00..52.83 rows=1883 width=254)
+         ->  Parallel Hash  (cost=110.33..110.33 rows=500 width=36)
+               ->  Broadcast Workers Motion 6:6  (slice2; segments: 6)  (cost=99.92..110.33 rows=500 width=36)
+                     ->  Subquery Scan on "Expr_SUBQUERY"  (cost=99.92..103.67 rows=167 width=36)
+                           ->  HashAggregate  (cost=99.92..102.00 rows=167 width=36)
+                                 Group Key: employees.department_id
+                                 ->  Redistribute Motion 6:6  (slice3; segments: 6)  (cost=0.00..90.50 rows=1883 width=36)
+                                       Hash Key: employees.department_id
+                                       Hash Module: 3
+                                       ->  Parallel Seq Scan on employees  (cost=0.00..52.83 rows=1883 width=36)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+ name  
+-------
+ Bob
+ David
+(2 rows)
+
+  
+reset enable_parallel;
+reset min_parallel_table_scan_size;
 -- start_ignore
 drop schema test_parallel cascade;
 -- end_ignore

--- a/src/test/regress/sql/cbdb_parallel.sql
+++ b/src/test/regress/sql/cbdb_parallel.sql
@@ -1074,6 +1074,68 @@ reset enable_parallel;
 -- End of test Parallel UNION
 --
 
+--
+-- Test Parallel Subquery.
+--
+CREATE TABLE departments (
+    department_id INT PRIMARY KEY,
+    department_name VARCHAR(100)
+);
+
+CREATE TABLE employees (
+    employee_id INT PRIMARY KEY,
+    name VARCHAR(100),
+    salary NUMERIC,
+    department_id INT
+);
+
+INSERT INTO departments VALUES 
+(1, 'Sales'),
+(2, 'IT'),
+(3, 'HR');
+
+INSERT INTO employees VALUES
+(1, 'Alice', 5000, 1),
+(2, 'Bob', 6000, 1),
+(3, 'Charlie', 7000, 2),
+(4, 'David', 8000, 2),
+(5, 'Eve', 9000, 3);
+
+set enable_parallel = off;
+explain SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+
+SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+
+set enable_parallel = on;
+set min_parallel_table_scan_size = 0;
+
+explain SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+
+SELECT e.name
+FROM employees e
+WHERE e.salary > (
+    SELECT AVG(salary)
+    FROM employees
+    WHERE department_id = e.department_id);
+  
+reset enable_parallel;
+reset min_parallel_table_scan_size;
+
 -- start_ignore
 drop schema test_parallel cascade;
 -- end_ignore


### PR DESCRIPTION
In CBDB, row estimation is determined by the relation's rows and cluster segments.
However, when there is a parallel subquery scan path, each worker will process fewer rows (divided by parallel_workers).

```sql
set enable_parallel = off;
explain SELECT e.name
FROM employees e
WHERE e.salary > (
    SELECT AVG(salary)
    FROM employees
    WHERE department_id = e.department_id);
                                                         QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=163.42..307.76 rows=3767 width=218)
   ->  Hash Join  (cost=163.42..257.54 rows=1256 width=218)
         Hash Cond: (e.department_id = "Expr_SUBQUERY".csq_c0)
         Join Filter: (e.salary > "Expr_SUBQUERY".csq_c1)
         ->  Seq Scan on employees e  (cost=0.00..71.67 rows=3767 width=254)
         ->  Hash  (cost=150.92..150.92 rows=1000 width=36)
               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=130.09..150.92 rows=1000 width=36)
                     ->  Subquery Scan on "Expr_SUBQUERY"  (cost=130.09..137.59 rows=333 width=36)
                           ->  Finalize HashAggregate  (cost=130.09..134.26 rows=333 width=36)
                                 Group Key: employees.department_id
                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=90.50..122.67 rows=990 width=36)
                                       Hash Key: employees.department_id
                                       ->  Partial HashAggregate  (cost=90.50..102.87 rows=990 width=36)
                                             Group Key: employees.department_id
                                             ->  Seq Scan on employees  (cost=0.00..71.67 rows=3767 width=36)
 Optimizer: Postgres query optimizer
(16 rows)
```
Subquery Scan on "Expr_SUBQUERY"  (cost=130.09..137.59 **rows=333** width=36)
While, a parallel Subquery Scan has the same rows though cost is less than that.

```sql
set enable_parallel = on;
set min_parallel_table_scan_size = 0;
explain SELECT e.name
FROM employees e
WHERE e.salary > (
    SELECT AVG(salary)
    FROM employees
    WHERE department_id = e.department_id);
                                                        QUERY PLAN                                                         
---------------------------------------------------------------------------------------------------------------------------
 Gather Motion 6:1  (slice1; segments: 6)  (cost=131.17..245.45 rows=3767 width=218)
   ->  Parallel Hash Join  (cost=131.17..201.50 rows=628 width=218)
         Hash Cond: (e.department_id = "Expr_SUBQUERY".csq_c0)
         Join Filter: (e.salary > "Expr_SUBQUERY".csq_c1)
         ->  Parallel Seq Scan on employees e  (cost=0.00..52.83 rows=1883 width=254)
         ->  Parallel Hash  (cost=118.67..118.67 rows=1000 width=36)
               ->  Broadcast Workers Motion 6:6  (slice2; segments: 6)  (cost=99.92..118.67 rows=1000 width=36)
                     ->  Subquery Scan on "Expr_SUBQUERY"  (cost=99.92..105.33 rows=333 width=36)
                           ->  HashAggregate  (cost=99.92..102.00 rows=167 width=36)
                                 Group Key: employees.department_id
                                 ->  Redistribute Motion 6:6  (slice3; segments: 6)  (cost=0.00..90.50 rows=1883 width=36)
                                       Hash Key: employees.department_id
                                       Hash Module: 3
                                       ->  Parallel Seq Scan on employees  (cost=0.00..52.83 rows=1883 width=36)
 Optimizer: Postgres query optimizer
(15 rows)
```



This commit fixes that issue.

The correction not only makes parallel subquery estimation more accurate, but also enables the entire plan to be as parallel as possible, particularly for subqueries in complex queries.

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
