### PR TITLE
Align scan terminology: Shared Scan and ShareInputScan.

### DIFF
--- a/contrib/pax_storage/src/test/regress/expected/qp_with_clause.out
+++ b/contrib/pax_storage/src/test/regress/expected/qp_with_clause.out
@@ -11089,7 +11089,7 @@ ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
  35NAME        |              7 | 5NAME        |              1
 (25 rows)
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 -- start_ignore
 CREATE TABLE car (a int, b int);

--- a/contrib/pax_storage/src/test/regress/expected/query_finish_pending.out
+++ b/contrib/pax_storage/src/test/regress/expected/query_finish_pending.out
@@ -92,7 +92,7 @@ select gp_inject_fault('execsort_sort_bounded_heap', 'status', 2);
  
 (1 row)
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
 drop table if exists testsisc;
 NOTICE:  table "testsisc" does not exist, skipping
@@ -104,7 +104,7 @@ insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar; 
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
--- ORCA does not generate SharedInputScan with a Sort node underneath it. For
+-- ORCA does not generate ShareInputScan with a Sort node underneath it. For
 -- the following query, ORCA disregards the order by inside the cte definition;
 -- planner on the other hand does not.
 set optimizer=off;
@@ -114,8 +114,8 @@ select gp_inject_fault('execshare_input_next', 'reset', 2);
  Success:
 (1 row)
 
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
  gp_inject_fault 
 -----------------
@@ -137,7 +137,7 @@ select gp_inject_fault('execshare_input_next', 'status', 2);
  
 (1 row)
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 select gp_inject_fault('execshare_input_next', 'reset', 2);
  gp_inject_fault 
@@ -145,8 +145,8 @@ select gp_inject_fault('execshare_input_next', 'reset', 2);
  Success:
 (1 row)
 
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
  gp_inject_fault 
 -----------------

--- a/contrib/pax_storage/src/test/regress/input/temp_tablespaces.source
+++ b/contrib/pax_storage/src/test/regress/input/temp_tablespaces.source
@@ -45,7 +45,7 @@ CREATE TABLE tts_foo (i int, j int) distributed by(i);
 insert into tts_foo select i, i from generate_series(1,80000)i;
 ANALYZE tts_foo;
 set gp_cte_sharing=on;
--- CBDB_PARALLEL_FIXME: since we disabled shared input scan in parallel mode, sisc_xslice_temp_files
+-- CBDB_PARALLEL_FIXME: since we disabled Share Input Scan in parallel mode, sisc_xslice_temp_files
 -- will never be triggered. We need set max_parallel_workers_per_gather to 0 in this case.
 set max_parallel_workers_per_gather = 0;
 

--- a/contrib/pax_storage/src/test/regress/output/temp_tablespaces.source
+++ b/contrib/pax_storage/src/test/regress/output/temp_tablespaces.source
@@ -56,7 +56,7 @@ CREATE TABLE tts_foo (i int, j int) distributed by(i);
 insert into tts_foo select i, i from generate_series(1,80000)i;
 ANALYZE tts_foo;
 set gp_cte_sharing=on;
--- CBDB_PARALLEL_FIXME: since we disabled shared input scan in parallel mode, sisc_xslice_temp_files
+-- CBDB_PARALLEL_FIXME: since we disabled Share Input Scan in parallel mode, sisc_xslice_temp_files
 -- will never be triggered. We need set max_parallel_workers_per_gather to 0 in this case.
 set max_parallel_workers_per_gather = 0;
 -- CASE 1: when temp_tablespaces is set, hashagg and share-input-scan

--- a/contrib/pax_storage/src/test/regress/sql/qp_with_clause.sql
+++ b/contrib/pax_storage/src/test/regress/sql/qp_with_clause.sql
@@ -10329,7 +10329,7 @@ WHERE  e.deptno = dc1.deptno AND
        m.deptno = dmc1.dept_mgr_no
 ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 
 -- start_ignore

--- a/contrib/pax_storage/src/test/regress/sql/query_finish_pending.sql
+++ b/contrib/pax_storage/src/test/regress/sql/query_finish_pending.sql
@@ -38,7 +38,7 @@ reset enable_parallel;
 
 select gp_inject_fault('execsort_sort_bounded_heap', 'status', 2);
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
 drop table if exists testsisc;
 create table testsisc (i1 int, i2 int, i3 int, i4 int); 
@@ -48,13 +48,13 @@ insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
--- ORCA does not generate SharedInputScan with a Sort node underneath it. For
+-- ORCA does not generate ShareInputScan with a Sort node underneath it. For
 -- the following query, ORCA disregards the order by inside the cte definition;
 -- planner on the other hand does not.
 set optimizer=off;
 select gp_inject_fault('execshare_input_next', 'reset', 2);
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
 
 set enable_parallel = off;
@@ -64,13 +64,13 @@ select * from cte c1, cte c2 limit 2;
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 
 
 select gp_inject_fault('execshare_input_next', 'reset', 2);
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
 
 with cte as (select i2 from testsisc order by i2)

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -825,8 +825,8 @@ shareinput_peekmot(ApplyShareInputContext *ctxt)
  * plan.
  *
  * To work around that issue, create a CTE for each shared input node, with
- * columns that match the target list of the SharedInputScan's subplan,
- * and replace the target list entries of the SharedInputScan with
+ * columns that match the target list of the ShareInputScan's subplan,
+ * and replace the target list entries of the ShareInputScan with
  * Vars that point to the CTE instead of the child plan.
  */
 Plan *
@@ -893,8 +893,8 @@ replace_shareinput_targetlists_walker(Node *node, PlannerInfo *root, bool fPop)
 		/*
 		 * Replace all the target list entries.
 		 *
-		 * SharedInputScan nodes are not projection-capable, so the target
-		 * list of the SharedInputScan matches the subplan's target list.
+		 * ShareInputScan nodes are not projection-capable, so the target
+		 * list of the ShareInputScan matches the subplan's target list.
 		 */
 		newtargetlist = NIL;
 		attno = 1;

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -76,7 +76,7 @@
 /*
  * In a cross-slice ShareinputScan, the producer and consumer processes
  * communicate using shared memory. There's a hash table containing one
- * 'shareinput_share_state' for each in-progress shared input scan.
+ * 'shareinput_share_state' for each in-progress Share Input Scan.
  *
  * The hash table itself,, and the fields within every entry, are protected
  * by ShareInputScanLock. (Although some operations get away without the
@@ -631,11 +631,11 @@ ExecSquelchShareInputScan(ShareInputScanState *node, bool force)
 	ExecClearTuple(node->ss.ps.ps_ResultTupleSlot);
 
 	/*
-	 * If this SharedInputScan is shared within the same slice then its
+	 * If this ShareInputScan is shared within the same slice then its
 	 * subtree may still need to be executed and the motions in the subtree
 	 * cannot yet be stopped. Thus, don't recurse in this case.
 	 *
-	 * In squelching a cross-slice SharedInputScan writer, we need to ensure
+	 * In squelching a cross-slice ShareInputScan writer, we need to ensure
 	 * we don't block any reader on other slices as a result of not
 	 * materializing the shared plan.
 	 *

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4445,7 +4445,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 		CDXLPhysicalCTEProducer::Cast(cte_producer_dxlnode->GetOperator());
 	ULONG cte_id = cte_prod_dxlop->Id();
 
-	// create the shared input scan representing the CTE Producer
+	// create the Share Input Scan representing the CTE Producer
 	ShareInputScan *shared_input_scan = MakeNode(ShareInputScan);
 	shared_input_scan->share_id = cte_id;
 	shared_input_scan->discard_output = true;

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -367,7 +367,7 @@ void CTranslatorDXLToExpr::PruneCTEs()
 			poper->RecalOutputColumns(umask, pprgpcrsz);
 
 			// Align consumer and producer output columns.
-			// In fact, we can support the column projection in consumer(SharedInputScan).
+			// In fact, we can support the column projection in consumer(ShareInputScan).
 			// However, non-requested columns in consumer(which from producer) may be added to the consumer, 
 			// which will make the plan for consumer(support projection) very complicated. 
 			//

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -158,7 +158,7 @@ public:
 	// register a newly CTE producer
 	void RegisterCTEProducerInfo(ULONG cte_id, ULongPtrArray *producer_output_colidx_map, ShareInputScan *siscan);
 
-	// return the shared input scan plans representing the CTE producer
+	// return the Share Input Scan plans representing the CTE producer
 	std::pair<ULongPtrArray *, ShareInputScan *> GetCTEProducerInfo(ULONG cte_id) const;
 
 	// return list of range table entries

--- a/src/include/optimizer/cost.h
+++ b/src/include/optimizer/cost.h
@@ -166,7 +166,7 @@ extern void cost_group(Path *path, PlannerInfo *root,
 					   List *quals,
 					   Cost input_startup_cost, Cost input_total_cost,
 					   double input_tuples);
-/* GPDB_92_MERGE_FIXME: parameterized path for shared input scan? */
+/* GPDB_92_MERGE_FIXME: parameterized path for Share Input Scan? */
 extern void cost_shareinputscan(Path *path, PlannerInfo *root, Cost sharecost, double ntuples, int width);
 extern void initial_cost_nestloop(PlannerInfo *root,
 								  JoinCostWorkspace *workspace,

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -11090,7 +11090,7 @@ ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
  35NAME        |              7 | 5NAME        |              1
 (25 rows)
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 -- start_ignore
 CREATE TABLE car (a int, b int);

--- a/src/test/regress/expected/qp_with_clause_optimizer.out
+++ b/src/test/regress/expected/qp_with_clause_optimizer.out
@@ -11139,7 +11139,7 @@ ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
  35NAME        |              7 | 5NAME        |              1
 (25 rows)
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 -- start_ignore
 CREATE TABLE car (a int, b int);

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -92,7 +92,7 @@ select gp_inject_fault('execsort_sort_bounded_heap', 'status', 2);
  
 (1 row)
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
 drop table if exists testsisc;
 NOTICE:  table "testsisc" does not exist, skipping
@@ -104,7 +104,7 @@ insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar; 
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
--- ORCA does not generate SharedInputScan with a Sort node underneath it. For
+-- ORCA does not generate ShareInputScan with a Sort node underneath it. For
 -- the following query, ORCA disregards the order by inside the cte definition;
 -- planner on the other hand does not.
 set optimizer=off;
@@ -114,8 +114,8 @@ select gp_inject_fault('execshare_input_next', 'reset', 2);
  Success:
 (1 row)
 
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
  gp_inject_fault 
 -----------------
@@ -137,7 +137,7 @@ select gp_inject_fault('execshare_input_next', 'status', 2);
  
 (1 row)
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 select gp_inject_fault('execshare_input_next', 'reset', 2);
  gp_inject_fault 
@@ -145,8 +145,8 @@ select gp_inject_fault('execshare_input_next', 'reset', 2);
  Success:
 (1 row)
 
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
  gp_inject_fault 
 -----------------

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -41,7 +41,7 @@ CREATE TABLE tts_foo (i int, j int) distributed by(i);
 insert into tts_foo select i, i from generate_series(1,80000)i;
 ANALYZE tts_foo;
 set gp_cte_sharing=on;
--- CBDB_PARALLEL_FIXME: since we disabled shared input scan in parallel mode, sisc_xslice_temp_files
+-- CBDB_PARALLEL_FIXME: since we disabled Share Input Scan in parallel mode, sisc_xslice_temp_files
 -- will never be triggered. We need set max_parallel_workers_per_gather to 0 in this case.
 set max_parallel_workers_per_gather = 0;
 

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -52,7 +52,7 @@ CREATE TABLE tts_foo (i int, j int) distributed by(i);
 insert into tts_foo select i, i from generate_series(1,80000)i;
 ANALYZE tts_foo;
 set gp_cte_sharing=on;
--- CBDB_PARALLEL_FIXME: since we disabled shared input scan in parallel mode, sisc_xslice_temp_files
+-- CBDB_PARALLEL_FIXME: since we disabled Share Input Scan in parallel mode, sisc_xslice_temp_files
 -- will never be triggered. We need set max_parallel_workers_per_gather to 0 in this case.
 set max_parallel_workers_per_gather = 0;
 -- CASE 1: when temp_tablespaces is set, hashagg and share-input-scan

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -10331,7 +10331,7 @@ WHERE  e.deptno = dc1.deptno AND
        m.deptno = dmc1.dept_mgr_no
 ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 
 -- start_ignore

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -38,7 +38,7 @@ reset enable_parallel;
 
 select gp_inject_fault('execsort_sort_bounded_heap', 'status', 2);
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
 drop table if exists testsisc;
 create table testsisc (i1 int, i2 int, i3 int, i4 int); 
@@ -48,13 +48,13 @@ insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
--- ORCA does not generate SharedInputScan with a Sort node underneath it. For
+-- ORCA does not generate ShareInputScan with a Sort node underneath it. For
 -- the following query, ORCA disregards the order by inside the cte definition;
 -- planner on the other hand does not.
 set optimizer=off;
 select gp_inject_fault('execshare_input_next', 'reset', 2);
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
 
 set enable_parallel = off;
@@ -64,13 +64,13 @@ select * from cte c1, cte c2 limit 2;
 
 select gp_inject_fault('execshare_input_next', 'status', 2);
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 
 
 select gp_inject_fault('execshare_input_next', 'reset', 2);
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 2);
 
 with cte as (select i2 from testsisc order by i2)

--- a/src/test/singlenode_regress/expected/qp_with_clause.out
+++ b/src/test/singlenode_regress/expected/qp_with_clause.out
@@ -11078,7 +11078,7 @@ ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
  35NAME        |              7 | 5NAME        |              1
 (25 rows)
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 -- start_ignore
 CREATE TABLE car (a int, b int);

--- a/src/test/singlenode_regress/expected/query_finish_pending.out
+++ b/src/test/singlenode_regress/expected/query_finish_pending.out
@@ -98,7 +98,7 @@ select gp_inject_fault('execsort_sort_bounded_heap', 'status', 1);
  
 (1 row)
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
 drop table if exists testsisc;
 NOTICE:  table "testsisc" does not exist, skipping
@@ -110,7 +110,7 @@ insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= -1) foo) bar; 
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
--- ORCA does not generate SharedInputScan with a Sort node underneath it. For
+-- ORCA does not generate ShareInputScan with a Sort node underneath it. For
 -- the following query, ORCA disregards the order by inside the cte definition;
 -- planner on the other hand does not.
 set optimizer=off;
@@ -120,8 +120,8 @@ select gp_inject_fault('execshare_input_next', 'reset', 1);
  Success:
 (1 row)
 
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 1);
  gp_inject_fault 
 -----------------
@@ -145,7 +145,7 @@ select gp_inject_fault('execshare_input_next', 'status', 1);
  
 (1 row)
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 select gp_inject_fault('execshare_input_next', 'reset', 1);
  gp_inject_fault 
@@ -153,8 +153,8 @@ select gp_inject_fault('execshare_input_next', 'reset', 1);
  Success:
 (1 row)
 
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 1);
  gp_inject_fault 
 -----------------

--- a/src/test/singlenode_regress/sql/qp_with_clause.sql
+++ b/src/test/singlenode_regress/sql/qp_with_clause.sql
@@ -10329,7 +10329,7 @@ WHERE  e.deptno = dc1.deptno AND
        m.deptno = dmc1.dept_mgr_no
 ORDER BY 1, 2, 3, 4 DESC LIMIT 25;
 
--- Test that SharedInputScan within the same slice is always executed 
+-- Test that ShareInputScan within the same slice is always executed 
 set gp_cte_sharing=on;
 
 -- start_ignore

--- a/src/test/singlenode_regress/sql/query_finish_pending.sql
+++ b/src/test/singlenode_regress/sql/query_finish_pending.sql
@@ -45,7 +45,7 @@ select i1 from _tmp_table order by i2 limit 3;
 
 select gp_inject_fault('execsort_sort_bounded_heap', 'status', 1);
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node
 drop table if exists testsisc;
 create table testsisc (i1 int, i2 int, i3 int, i4 int); 
@@ -55,13 +55,13 @@ insert into testsisc select i, i % 1000, i % 100000, i % 75 from
 
 set gp_resqueue_print_operator_memory_limits=on;
 set statement_mem='2MB';
--- ORCA does not generate SharedInputScan with a Sort node underneath it. For
+-- ORCA does not generate ShareInputScan with a Sort node underneath it. For
 -- the following query, ORCA disregards the order by inside the cte definition;
 -- planner on the other hand does not.
 set optimizer=off;
 select gp_inject_fault('execshare_input_next', 'reset', 1);
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 1);
 
 -- In cbdb single node, if we inject fault in the single node, no data should return. 
@@ -71,13 +71,13 @@ select * from cte c1, cte c2 limit 2;
 -- end_ignore
 select gp_inject_fault('execshare_input_next', 'status', 1);
 
--- test if shared input scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
+-- test if Share Input Scan deletes memory correctly when QueryFinishPending and its child has been eagerly freed,
 -- where the child is a Sort node and sort_mk algorithm is used
 
 
 select gp_inject_fault('execshare_input_next', 'reset', 1);
--- Set QueryFinishPending to true after SharedInputScan has retrieved the first tuple. 
--- This will eagerly free the memory context of shared input scan's child node.  
+-- Set QueryFinishPending to true after ShareInputScan has retrieved the first tuple. 
+-- This will eagerly free the memory context of Share Input Scan's child node.  
 select gp_inject_fault('execshare_input_next', 'finish_pending', 1);
 
 -- In cbdb single node, if we inject fault in the single node, no data should return. 


### PR DESCRIPTION
The plan node appears as 'Shared Scan' in user's EXPLAIN output, while internally it's represented as ShareInputScan type.

Most codes use the correct terms, but some places incorrectly mix:
- 'shared input scan' in codebase (should be 'ShareInputScan')
- 'Share Scan' in EXPLAIN (should be 'Shared Scan')

This change aligns all usage while preserving existing correct references.

Authored-by: Zhang Mingli avamingli@gmail.com

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
