### PR TITLE
Move deploy scripts from cloudberry-devops-release to main repo

### DIFF
--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -440,24 +440,6 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - name: Checkout CI Build/Test Scripts
-        if: needs.check-skip.outputs.should_skip != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: apache/cloudberry-devops-release
-          ref: main
-          path: cloudberry-devops-release
-          fetch-depth: 1
-
-      - name: Move cloudberry-devops-release directory
-        if: needs.check-skip.outputs.should_skip != 'true'
-        run: |
-          set -eo pipefail
-          if ! mv "${GITHUB_WORKSPACE}"/cloudberry-devops-release "${GITHUB_WORKSPACE}"/..; then
-            echo "::error::Container initialization failed"
-            exit 1
-          fi
-
       - name: Cloudberry Environment Initialization
         if: needs.check-skip.outputs.should_skip != 'true'
         env:
@@ -509,8 +491,8 @@ jobs:
           SRC_DIR: ${{ github.workspace }}
         run: |
           set -eo pipefail
-          chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/configure-cloudberry.sh
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ENABLE_DEBUG=${{ env.ENABLE_DEBUG }} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/configure-cloudberry.sh"; then
+          chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ENABLE_DEBUG=${{ env.ENABLE_DEBUG }} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh"; then
             echo "::error::Configure script failed"
             exit 1
           fi
@@ -522,8 +504,8 @@ jobs:
         run: |
           set -eo pipefail
 
-          chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh"; then
+          chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/build-cloudberry.sh
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/build-cloudberry.sh"; then
             echo "::error::Build script failed"
             exit 1
           fi
@@ -605,7 +587,7 @@ jobs:
             # Create RPM
             echo "Creating RPM package..."
             rpmdev-setuptree
-            ln -s "${SRC_DIR}"/../cloudberry-devops-release/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec "${HOME}"/rpmbuild/SPECS/apache-cloudberry-db-incubating.spec
+            ln -s "${SRC_DIR}"/deploy/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec "${HOME}"/rpmbuild/SPECS/apache-cloudberry-db-incubating.spec
             cp "${SRC_DIR}"/LICENSE /usr/local/cloudberry-db
 
             DEBUG_RPMBUILD_OPT=""
@@ -615,7 +597,7 @@ jobs:
                DEBUG_IDENTIFIER=".debug"
             fi
 
-            "${SRC_DIR}"/../cloudberry-devops-release/scripts/build-rpm.sh --version "${CBDB_VERSION}" --release "${BUILD_NUMBER}" "${DEBUG_RPMBUILD_OPT}"
+            "${SRC_DIR}"/deploy/scripts/build-rpm.sh --version "${CBDB_VERSION}" --release "${BUILD_NUMBER}" "${DEBUG_RPMBUILD_OPT}"
 
             # Get OS version and move RPM
             os_version=$(grep -oP '(?<=^VERSION_ID=")[0-9]' /etc/os-release)
@@ -652,8 +634,8 @@ jobs:
           SRC_DIR: ${{ github.workspace }}
         run: |
           set -eo pipefail
-          chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/unittest-cloudberry.sh
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/unittest-cloudberry.sh"; then
+          chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/unittest-cloudberry.sh
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/unittest-cloudberry.sh"; then
             echo "::error::Unittest script failed"
             exit 1
           fi
@@ -902,24 +884,6 @@ jobs:
         if: needs.check-skip.outputs.should_skip != 'true'
         run: |
           echo "Timestamp from output: ${{ needs.build.outputs.build_timestamp }}"
-
-      - name: Checkout CI Build/Test Scripts
-        if: needs.check-skip.outputs.should_skip != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: apache/cloudberry-devops-release
-          ref: main
-          path: cloudberry-devops-release
-          fetch-depth: 1
-
-      - name: Move cloudberry-devops-release directory
-        if: needs.check-skip.outputs.should_skip != 'true'
-        run: |
-          set -eo pipefail
-          if ! mv "${GITHUB_WORKSPACE}"/cloudberry-devops-release "${GITHUB_WORKSPACE}"/..; then
-            echo "::error::Container initialization failed"
-            exit 1
-          fi
 
       - name: Cloudberry Environment Initialization
         env:
@@ -1266,8 +1230,8 @@ jobs:
           set -eo pipefail
 
           {
-            chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
-            if ! time su - gpadmin -c "cd ${SRC_DIR} && NUM_PRIMARY_MIRROR_PAIRS='${{ matrix.num_primary_mirror_pairs }}' SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh"; then
+            chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
+            if ! time su - gpadmin -c "cd ${SRC_DIR} && NUM_PRIMARY_MIRROR_PAIRS='${{ matrix.num_primary_mirror_pairs }}' SRC_DIR=${SRC_DIR} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh"; then
               echo "::error::Demo cluster creation failed"
               exit 1
             fi
@@ -1342,7 +1306,7 @@ jobs:
                  MAKE_DIRECTORY='-C $dir' \
                  PGOPTIONS='${PG_OPTS}' \
                  SRC_DIR='${SRC_DIR}' \
-                 ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/test-cloudberry.sh" \
+                 ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/test-cloudberry.sh" \
                  2>&1 | tee "$config_log"; then
               echo "::warning::Test execution failed for configuration $((i+1)): make -C $dir $target"
               overall_status=1
@@ -1375,7 +1339,7 @@ jobs:
             ls -Rl "/tmp/cloudberry-cores"
             echo "-----------------------------------------"
 
-            "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/analyze_core_dumps.sh "$test_id"
+            "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/analyze_core_dumps.sh "$test_id"
             core_analysis_rc=$?
             case "$core_analysis_rc" in
               0) echo "No core dumps found for this configuration" ;;
@@ -1451,7 +1415,7 @@ jobs:
             # Parse this configuration's results
 
             MAKE_NAME="${{ matrix.test }}-config$i" \
-            "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/parse-test-results.sh "$config_log"
+            "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/parse-test-results.sh "$config_log"
             status_code=$?
 
             {

--- a/.github/workflows/build-dbg-cloudberry.yml
+++ b/.github/workflows/build-dbg-cloudberry.yml
@@ -343,24 +343,6 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - name: Checkout CI Build/Test Scripts
-        if: needs.check-skip.outputs.should_skip != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: apache/cloudberry-devops-release
-          ref: main
-          path: cloudberry-devops-release
-          fetch-depth: 1
-
-      - name: Move cloudberry-devops-release directory
-        if: needs.check-skip.outputs.should_skip != 'true'
-        run: |
-          set -eo pipefail
-          if ! mv "${GITHUB_WORKSPACE}"/cloudberry-devops-release "${GITHUB_WORKSPACE}"/..; then
-            echo "::error::Container initialization failed"
-            exit 1
-          fi
-
       - name: Cloudberry Environment Initialization
         if: needs.check-skip.outputs.should_skip != 'true'
         env:
@@ -412,8 +394,8 @@ jobs:
           SRC_DIR: ${{ github.workspace }}
         run: |
           set -eo pipefail
-          chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/configure-cloudberry.sh
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ENABLE_DEBUG=${{ env.ENABLE_DEBUG }} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/configure-cloudberry.sh"; then
+          chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ENABLE_DEBUG=${{ env.ENABLE_DEBUG }} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh"; then
             echo "::error::Configure script failed"
             exit 1
           fi
@@ -425,8 +407,8 @@ jobs:
         run: |
           set -eo pipefail
 
-          chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/build-cloudberry.sh"; then
+          chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/build-cloudberry.sh
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/build-cloudberry.sh"; then
             echo "::error::Build script failed"
             exit 1
           fi
@@ -508,7 +490,7 @@ jobs:
             # Create RPM
             echo "Creating RPM package..."
             rpmdev-setuptree
-            ln -s "${SRC_DIR}"/../cloudberry-devops-release/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec "${HOME}"/rpmbuild/SPECS/apache-cloudberry-db-incubating.spec
+            ln -s "${SRC_DIR}"/deploy/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec "${HOME}"/rpmbuild/SPECS/apache-cloudberry-db-incubating.spec
             cp "${SRC_DIR}"/LICENSE /usr/local/cloudberry-db
 
             DEBUG_RPMBUILD_OPT=""
@@ -518,7 +500,7 @@ jobs:
                DEBUG_IDENTIFIER=".debug"
             fi
 
-            "${SRC_DIR}"/../cloudberry-devops-release/scripts/build-rpm.sh --version "${CBDB_VERSION}" --release "${BUILD_NUMBER}" "${DEBUG_RPMBUILD_OPT}"
+            "${SRC_DIR}"/deploy/scripts/build-rpm.sh --version "${CBDB_VERSION}" --release "${BUILD_NUMBER}" "${DEBUG_RPMBUILD_OPT}"
 
             # Get OS version and move RPM
             os_version=$(grep -oP '(?<=^VERSION_ID=")[0-9]' /etc/os-release)
@@ -553,8 +535,8 @@ jobs:
           SRC_DIR: ${{ github.workspace }}
         run: |
           set -eo pipefail
-          chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/unittest-cloudberry.sh
-          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/unittest-cloudberry.sh"; then
+          chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/unittest-cloudberry.sh
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/unittest-cloudberry.sh"; then
             echo "::error::Unittest script failed"
             exit 1
           fi
@@ -803,24 +785,6 @@ jobs:
         if: needs.check-skip.outputs.should_skip != 'true'
         run: |
           echo "Timestamp from output: ${{ needs.build.outputs.build_timestamp }}"
-
-      - name: Checkout CI Build/Test Scripts
-        if: needs.check-skip.outputs.should_skip != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: apache/cloudberry-devops-release
-          ref: main
-          path: cloudberry-devops-release
-          fetch-depth: 1
-
-      - name: Move cloudberry-devops-release directory
-        if: needs.check-skip.outputs.should_skip != 'true'
-        run: |
-          set -eo pipefail
-          if ! mv "${GITHUB_WORKSPACE}"/cloudberry-devops-release "${GITHUB_WORKSPACE}"/..; then
-            echo "::error::Container initialization failed"
-            exit 1
-          fi
 
       - name: Cloudberry Environment Initialization
         env:
@@ -1167,8 +1131,8 @@ jobs:
           set -eo pipefail
 
           {
-            chmod +x "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
-            if ! time su - gpadmin -c "cd ${SRC_DIR} && NUM_PRIMARY_MIRROR_PAIRS='${{ matrix.num_primary_mirror_pairs }}' SRC_DIR=${SRC_DIR} ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh"; then
+            chmod +x "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
+            if ! time su - gpadmin -c "cd ${SRC_DIR} && NUM_PRIMARY_MIRROR_PAIRS='${{ matrix.num_primary_mirror_pairs }}' SRC_DIR=${SRC_DIR} ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh"; then
               echo "::error::Demo cluster creation failed"
               exit 1
             fi
@@ -1239,7 +1203,7 @@ jobs:
                  MAKE_DIRECTORY='-C $dir' \
                  PGOPTIONS='${PG_OPTS}' \
                  SRC_DIR='${SRC_DIR}' \
-                 ${SRC_DIR}/../cloudberry-devops-release/build_automation/cloudberry/scripts/test-cloudberry.sh" \
+                 ${SRC_DIR}/deploy/build_automation/cloudberry/scripts/test-cloudberry.sh" \
                  2>&1 | tee "$config_log"; then
               echo "::warning::Test execution failed for configuration $((i+1)): make -C $dir $target"
               overall_status=1
@@ -1272,7 +1236,7 @@ jobs:
             ls -Rl "/tmp/cloudberry-cores"
             echo "-----------------------------------------"
 
-            "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/analyze_core_dumps.sh "$test_id"
+            "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/analyze_core_dumps.sh "$test_id"
             core_analysis_rc=$?
             case "$core_analysis_rc" in
               0) echo "No core dumps found for this configuration" ;;
@@ -1348,7 +1312,7 @@ jobs:
             # Parse this configuration's results
 
             MAKE_NAME="${{ matrix.test }}-config$i" \
-            "${SRC_DIR}"/../cloudberry-devops-release/build_automation/cloudberry/scripts/parse-test-results.sh "$config_log"
+            "${SRC_DIR}"/deploy/build_automation/cloudberry/scripts/parse-test-results.sh "$config_log"
             status_code=$?
 
             {

--- a/.github/workflows/docker-cbdb-build-containers.yml
+++ b/.github/workflows/docker-cbdb-build-containers.yml
@@ -1,0 +1,208 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# GitHub Actions Workflow for Apache Cloudberry Build Environments
+# --------------------------------------------------------------------
+# Purpose:
+# Builds, tests, and publishes multi-architecture Docker images for
+# Apache Cloudberry DB build environments. Images are built for both
+# Rocky Linux 8 and 9, tested with TestInfra, and pushed to DockerHub.
+#
+# Multi-Architecture Support:
+# - Builds images for both AMD64 and ARM64 architectures
+# - Creates and pushes multi-arch manifests
+# - Uses QEMU for cross-platform builds
+# - Automated testing for all architectures
+#
+# Image Tags:
+# - Latest: cbdb-build-{platform}-latest
+# - Versioned: cbdb-build-{platform}-{YYYYMMDD}-{git-short-sha}
+#
+# Features:
+# - Matrix build for multiple platforms
+# - Parallel architecture builds
+# - Build caching strategy
+# - Path filtering to only build changed platforms
+# - Comprehensive build summary and metadata
+# - Container testing with TestInfra
+# - Multi-arch manifest creation
+#
+# Requirements:
+# - DockerHub credentials in GitHub secrets
+#   - DOCKERHUB_USER
+#   - DOCKERHUB_TOKEN
+# --------------------------------------------------------------------
+
+name: docker-cbdb-build-containers
+
+# Trigger workflow on pushes to main when relevant paths change
+# Also allows manual triggering via GitHub UI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'deploy/images/docker/cbdb/build/rocky8/**'
+      - 'deploy/images/docker/cbdb/build/rocky9/**'
+  workflow_dispatch:  # Manual trigger
+
+# Prevent multiple workflow runs from interfering with each other
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    # Set timeout to prevent hanging builds
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    # Matrix strategy to build for both Rocky Linux 8 and 9
+    strategy:
+      matrix:
+        platform: ['rocky8', 'rocky9']
+
+    steps:
+      # Checkout repository code with full history
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Generate version information for image tags
+      # - BUILD_DATE: Current date in YYYYMMDD format
+      # - SHA_SHORT: Short form of the git commit SHA
+      - name: Set version
+        id: version
+        run: |
+          echo "BUILD_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      # Determine if the current platform's files have changed
+      # This prevents unnecessary builds if only one platform was modified
+      - name: Determine if platform changed
+        id: platform-filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        with:
+          filters: |
+            rocky8:
+              - 'deploy/images/docker/cbdb/build/rocky8/**'
+            rocky9:
+              - 'deploy/images/docker/cbdb/build/rocky9/**'
+
+      # Set up QEMU for multi-architecture support
+      # This allows building ARM64 images on AMD64 infrastructure and vice versa
+      - name: Set up QEMU
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/setup-qemu-action@v3
+
+      # Login to DockerHub for pushing images
+      # Requires DOCKERHUB_USER and DOCKERHUB_TOKEN secrets to be set
+      - name: Login to Docker Hub
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Setup Docker Buildx for efficient builds
+      # Enable debug mode for better troubleshooting
+      - name: Set up Docker Buildx
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      # Build and test images for each architecture
+      # This ensures both AMD64 and ARM64 variants work correctly
+      - name: Build and test images
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        run: |
+          # Build for each platform
+          for arch in amd64 arm64; do
+            # Build the image for testing
+            docker buildx build \
+              --platform linux/$arch \
+              --load \
+              -t apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-$arch-test \
+              ./deploy/images/docker/cbdb/build/${{ matrix.platform }}
+
+            # Run tests in a container
+            docker run -d \
+              -h cdw \
+              --name cbdb-build-${{ matrix.platform }}-$arch-test \
+              apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-$arch-test \
+              bash -c "sleep 30"
+
+            # Execute TestInfra tests
+            docker exec cbdb-build-${{ matrix.platform }}-$arch-test pytest \
+              --cache-clear \
+              --disable-warnings \
+              -p no:warnings \
+              /tests/testinfra/test_cloudberry_db_env.py
+
+            # Cleanup test container
+            docker rm -f cbdb-build-${{ matrix.platform }}-$arch-test
+          done
+
+      # Build and push multi-architecture images
+      # This creates a manifest list that supports both architectures
+      - name: Build and Push Multi-arch Docker images
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./deploy/images/docker/cbdb/build/${{ matrix.platform }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          # Tag with both latest and version-specific tags
+          tags: |
+            apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-latest
+            apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+          # Add standard Open Container Initiative (OCI) labels
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+
+      # Generate a detailed build summary in GitHub Actions UI
+      # This provides quick access to build information and image usage instructions
+      - name: Build Summary
+        if: always()
+        run: |
+          echo "### Build Summary for ${{ matrix.platform }} 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### 🔍 Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Architectures**: amd64, arm64" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Date**: ${{ steps.version.outputs.BUILD_DATE }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### 🐳 Docker Images" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest tag: \`apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Version tag: \`apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### 📋 Quick Reference" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "# Pull the image (automatically selects correct architecture)" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Pull specific architecture if needed" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull --platform linux/amd64 apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull --platform linux/arm64 apache/incubator-cloudberry:cbdb-build-${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-cbdb-test-containers.yml
+++ b/.github/workflows/docker-cbdb-test-containers.yml
@@ -1,0 +1,182 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Purpose: Builds, tests and pushes multi-architecture Docker images for
+# Apache Cloudberry DB test environments. Images are built for both AMD64
+# and ARM64 architectures on Rocky Linux 8 and 9.
+#
+# Images are tagged with:
+# - cbdb-test-rocky8-latest
+# - cbdb-test-rocky8-{YYYYMMDD}-{git-short-sha}
+# - cbdb-test-rocky9-latest
+# - cbdb-test-rocky9-{YYYYMMDD}-{git-short-sha}
+#
+# Features:
+# - Multi-architecture support (AMD64 and ARM64)
+# - Matrix build for multiple platforms
+# - QEMU emulation for cross-platform builds
+# - Buildx for efficient multi-arch builds
+# - Path filtering to only build changed platforms
+# - Comprehensive build summary and metadata
+#
+# --------------------------------------------------------------------
+
+name: docker-cbdb-test-containers
+
+# Trigger on pushes to docker-images branch when relevant paths change
+# Also allows manual triggering via GitHub UI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'deploy/images/docker/cbdb/test/rocky8/**'
+      - 'deploy/images/docker/cbdb/test/rocky9/**'
+  workflow_dispatch:  # Manual trigger
+
+# Prevent multiple workflow runs from interfering with each other
+concurrency:
+  group: docker-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    timeout-minutes: 60  # Prevent hanging builds
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Build for both Rocky Linux 8 and 9
+        platform: ['rocky8', 'rocky9']
+
+    steps:
+      # Checkout repository code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Generate version information for image tags
+      - name: Set version
+        id: version
+        run: |
+          echo "BUILD_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      # Determine if the current platform's files have changed
+      - name: Determine if platform changed
+        id: platform-filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        with:
+          filters: |
+            rocky8:
+              - 'deploy/images/docker/cbdb/test/rocky8/**'
+            rocky9:
+              - 'deploy/images/docker/cbdb/test/rocky9/**'
+
+      # Skip if no changes for current platform
+      - name: Skip if not relevant
+        if: ${{ steps.platform-filter.outputs[matrix.platform] != 'true' }}
+        run: echo "Skipping because the changes do not affect this platform"
+
+      # Set up QEMU for multi-architecture support
+      # This allows building ARM64 images on AMD64 infrastructure and vice versa
+      - name: Set up QEMU
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/setup-qemu-action@v3
+
+      # Login to DockerHub for pushing images
+      - name: Login to Docker Hub
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Setup Docker Buildx for efficient multi-architecture builds
+      - name: Set up Docker Buildx
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      # Build and test images for each architecture
+      # This ensures both AMD64 and ARM64 variants work correctly
+      - name: Build and test images
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        run: |
+          # Build for each platform
+          for arch in amd64 arm64; do
+            echo "Building for $arch architecture..."
+            docker buildx build \
+              --platform linux/$arch \
+              --load \
+              -t apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-$arch-test \
+              ./deploy/images/docker/cbdb/test/${{ matrix.platform }}
+          done
+
+      # Build and push multi-architecture images
+      # Creates a manifest list that supports both architectures
+      - name: Build and Push Multi-arch Docker images
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./deploy/images/docker/cbdb/test/${{ matrix.platform }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          # Use caching for faster builds
+          cache-from: |
+            type=registry,ref=apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest
+            type=gha,scope=docker-cbdb-test-${{ matrix.platform }}
+          # Tag with both latest and version-specific tags
+          tags: |
+            apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest
+            apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+          # Add metadata labels for better image tracking
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+
+      # Generate a detailed build summary in GitHub Actions UI
+      # This provides quick access to build information and image usage instructions
+      - name: Build Summary
+        if: always()
+        run: |
+          echo "### Build Summary for ${{ matrix.platform }} 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### 🔍 Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Architectures**: AMD64, ARM64" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Date**: ${{ steps.version.outputs.BUILD_DATE }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### 🐳 Docker Images" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest tag: \`apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Version tag: \`apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### 📋 Quick Reference" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "# Pull the image (automatically selects correct architecture)" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Pull specific architecture if needed" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull --platform linux/amd64 apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull --platform linux/arm64 apache/incubator-cloudberry:cbdb-test-${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,5 +17,13 @@
   under the License.
 -->
 
-> [!WARNING]
-> The files are still in progress and will be revised in the following months.
+# Auto-Build Cloudberry Database from Source Code
+
+You can build Cloudberry Database from source code in two ways: manually or automatically.
+
+For the manual build, you need to manually set up many system configurations and download third-party dependencies, which is quite cumbersome and error-prone.
+
+To make the job easier, you are recommended to use the automated deployment method blessed by virtualization technology. The automation method simplifies the deployment process, reduces time costs, and allows developers to focus more on business code development.
+
+
+

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,66 @@ You can build Cloudberry Database from source code in two ways: manually or auto
 
 For the manual build, you need to manually set up many system configurations and download third-party dependencies, which is quite cumbersome and error-prone.
 
-To make the job easier, you are recommended to use the automated deployment method blessed by virtualization technology. The automation method simplifies the deployment process, reduces time costs, and allows developers to focus more on business code development.
+To make the job easier, it is recommended that you use the automated deployment method and scripts provided here. The automation method simplifies the deployment process, reduces time costs, and allows developers to focus more on business code development.
 
+## 1. Setup docker environment
 
+Nothing special, just follow the [official documentation](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
 
+## 2. Create docker build image
+
+Go to the supported OS directory, for example Rocky Linux 9
+
+`cd deploy/images/docker/cbdb/build/rocky9`
+
+And build image
+
+`docker build -t cloudberry-db-env . `
+
+The whole process usually takes about 5 minutes. You can use the created base image as many times as you want, just launch a new container for your specific task.
+
+## 3. Launch container
+
+Just run
+
+`docker run -h cdw -it cloudberry-db-env`
+
+## 4. Checkout git repo inside container
+
+The same way you did it on your laptop
+
+`docker exec <container ID> bash -c "cd /home/gpadmin && git clone --recurse-submodules https://github.com/apache/cloudberry.git"`
+
+## 5. Set envoronment and configure build container
+
+Create direcory for store logs
+
+`SRC_DIR=/home/gpadmin/cloudberry && docker exec <container ID>  bash -c "mkdir ${SRC_DIR}/build-logs"`
+
+Execute configure and check if system is ready for build
+
+`SRC_DIR=/home/gpadmin/cloudberry && docker exec <container ID> bash -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ./deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh"`
+
+## 6. Build binary
+
+The building consumes all available CPU resources and can take minutes to complete
+
+`SRC_DIR=/home/gpadmin/cloudberry && docker exec <container ID> bash -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ./deploy/build_automation/cloudberry/scripts/build-cloudberry.sh"`
+
+## 7. Install binary and create demo cluster
+
+By default `make install` copy compiled binary to  `/usr/local/cloudberry-db`
+
+`SRC_DIR=/home/gpadmin/cloudberry && docker exec <container ID> bash -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} make install"`
+
+To create demo cluster just launch `create-cloudberry-demo-cluster.sh`
+
+`SRC_DIR=/home/gpadmin/cloudberry && docker exec <container ID> bash -c "cd ${SRC_DIR} && SRC_DIR=${SRC_DIR} ./deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh"`
+
+## 8. Execute test query
+
+Now you could set environment and execute queries
+
+`docker exec 7197206b0645 bash -c "source /usr/local/cloudberry-db/cloudberry-env.sh && source /home/gpadmin/cloudberry/gpAux/gpdemo/gpdemo-env.sh && psql -U gpadmin -d postgres -c 'SELECT 42'"`
+
+All done!

--- a/deploy/build_automation/cloudberry/scripts/analyze_core_dumps.sh
+++ b/deploy/build_automation/cloudberry/scripts/analyze_core_dumps.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: analyze_core_dumps.sh
+# Description: Automated analysis tool for core dump files using GDB
+#
+# This script automatically analyzes core dump files found in a
+# specified directory, providing stack traces and register
+# information. It's particularly useful for analyzing crashes in
+# Postgres/Cloudberry executables and Python applications.
+#
+# Features:
+# - Automatic detection of core dump files
+# - Support for both compiled executables and interpreted languages
+# - Detailed stack traces with GDB
+# - Register state analysis
+# - Assembly code context at crash point
+# - Comprehensive logging of analysis results
+#
+# Usage: analyze_core_dumps.sh [test_id]
+#   test_id: Optional identifier for the test configuration that generated cores
+#
+# Dependencies:
+#   - GDB (GNU Debugger)
+#   - file command
+#
+# Environment Variables:
+#   SRC_DIR - Base directory for operations (defaults to /tmp)
+#
+# Return Codes:
+#   0 - No core files were found
+#   1 - Core files were found and all were processed successfully
+#   2 - Error conditions:
+#       - Missing required dependencies (gdb, file)
+#       - Issues processing some or all core files
+# --------------------------------------------------------------------
+
+set -u
+
+# Configuration
+#-----------------------------------------------------------------------------
+# Use SRC_DIR if defined, otherwise default to /tmp
+SRC_DIR="${SRC_DIR:-/tmp}"
+# Define log directory and files
+LOG_DIR="${SRC_DIR}/build-logs"
+# Create log directories if they don't exist
+mkdir -p "${LOG_DIR}"
+
+# Determine log file name based on test_id argument
+if [ $# -ge 1 ]; then
+    test_id="$1"
+    log_file="${LOG_DIR}/core_analysis_${test_id}_$(date +%Y%m%d_%H%M%S).log"
+else
+    log_file="${LOG_DIR}/core_analysis_$(date +%Y%m%d_%H%M%S).log"
+fi
+echo "log_file: ${log_file}"
+
+# Directory where core dumps are located
+core_dir="/tmp/cloudberry-cores/"
+
+# Pattern to match core dump files
+core_pattern="core-*"
+
+# Function Definitions
+#-----------------------------------------------------------------------------
+# Log messages to both console and log file
+# Args:
+#   $1 - Message to log
+log_message() {
+    local message="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+    echo "$message"
+    echo "$message" >> "$log_file"
+}
+
+# Analyze a single core file
+# Args:
+#   $1 - Path to core file
+# Returns:
+#   0 on success, 1 on failure
+analyze_core_file() {
+    local core_file="$1"
+    local file_info
+
+    log_message "Analyzing core file: $core_file"
+    file_info=$(file "$core_file")
+    log_message "Core file info: $file_info"
+
+    # Extract the original command from the core file info
+    if [[ "$file_info" =~ "from '([^']+)'" ]]; then
+        local original_cmd="${BASH_REMATCH[1]}"
+        log_message "Original command: $original_cmd"
+    fi
+
+    # Extract executable path from core file info
+    if [[ "$file_info" =~ execfn:\ \'([^\']+)\' ]]; then
+        local executable="${BASH_REMATCH[1]}"
+        log_message "Executable path: $executable"
+
+        # Convert relative path to absolute if needed
+        if [[ "$executable" == "./"* ]]; then
+            executable="$PWD/${executable:2}"
+            log_message "Converted to absolute path: $executable"
+        fi
+
+        # Run GDB analysis
+        log_message "Starting GDB analysis..."
+
+        gdb -quiet \
+            --batch \
+            -ex 'set pagination off' \
+            -ex 'info target' \
+            -ex 'thread apply all bt' \
+            -ex 'print $_siginfo' \
+            -ex quit \
+            "$executable" "$core_file" 2>&1 >> "$log_file"
+
+        local gdb_rc=$?
+        if [ $gdb_rc -eq 0 ] && [ -s "$log_file" ]; then
+            log_message "GDB analysis completed successfully"
+            return 0
+        else
+            log_message "Warning: GDB analysis failed or produced no output"
+            return 1
+        fi
+    else
+        log_message "Could not find executable path in core file"
+        return 1
+    fi
+}
+
+# Function to check required commands
+check_dependencies() {
+    local missing=0
+    local required_commands=("gdb" "file")
+
+    log_message "Checking required commands..."
+    for cmd in "${required_commands[@]}"; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            log_message "Error: Required command '$cmd' not found"
+            missing=1
+        fi
+    done
+
+    if [ $missing -eq 1 ]; then
+        log_message "Missing required dependencies. Please install them and try again."
+        return 1
+    fi
+
+    log_message "All required commands found"
+    return 0
+}
+
+# Main Execution
+#-----------------------------------------------------------------------------
+main() {
+    local core_count=0
+    local analyzed_count=0
+    local return_code=0
+
+    log_message "Starting core dump analysis"
+    log_message "Using source directory: $SRC_DIR"
+    log_message "Using log directory: $LOG_DIR"
+
+    # Check dependencies first
+    if ! check_dependencies; then
+        return 2
+    fi
+
+    # Process all core files
+    for core_file in "$core_dir"/$core_pattern; do
+        if [[ -f "$core_file" ]]; then
+            ((core_count++))
+            if analyze_core_file "$core_file"; then
+                ((analyzed_count++))
+            fi
+        fi
+    done
+
+    # Determine return code based on results
+    if ((core_count == 0)); then
+        log_message "No core files found matching pattern $core_pattern in $core_dir"
+        return_code=0  # No cores found
+    elif ((analyzed_count == core_count)); then
+        log_message "Analysis complete. Successfully processed $analyzed_count core(s) files"
+        return_code=1  # All cores processed successfully
+    else
+        log_message "Analysis complete with errors. Processed $analyzed_count of $core_count core files"
+        return_code=2  # Some cores failed to process
+    fi
+
+    log_message "Log file: $log_file"
+
+    return $return_code
+}
+
+# Script entry point
+main
+return_code=$?
+
+if ((return_code == 0)); then
+    rm -fv "${log_file}"
+fi
+
+exit $return_code

--- a/deploy/build_automation/cloudberry/scripts/build-cloudberry.sh
+++ b/deploy/build_automation/cloudberry/scripts/build-cloudberry.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: build-cloudberry.sh
+# Description: Builds Apache Cloudberry from source code and installs
+# it.
+#             Performs the following steps:
+#             1. Builds main Apache Cloudberry database components
+#             2. Builds contrib modules
+#             3. Installs both main and contrib components
+#             Uses parallel compilation based on available CPU cores.
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory containing Apache Cloudberry
+#   source code
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#   NPROC   - Number of parallel jobs (defaults to all available cores)
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./build-cloudberry.sh
+#
+# Prerequisites:
+#   - configure-cloudberry.sh must be run first
+#   - Required build dependencies must be installed
+#   - /usr/local/cloudberry-db/lib must exist and be writable
+#
+# Exit Codes:
+#   0 - Build and installation completed successfully
+#   1 - Environment setup failed (missing SRC_DIR, LOG_DIR creation failed)
+#   2 - Main component build failed
+#   3 - Contrib build failed
+#   4 - Installation failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="${SRC_DIR}/build-logs"
+BUILD_LOG="${LOG_DIR}/build.log"
+
+# Initialize environment
+init_environment "Cloudberry Build Script" "${BUILD_LOG}"
+
+# Set environment
+log_section "Environment Setup"
+export LD_LIBRARY_PATH=/usr/local/cloudberry-db/lib:LD_LIBRARY_PATH
+log_section_end "Environment Setup"
+
+# Build process
+log_section "Build Process"
+execute_cmd make -j$(nproc) --directory ${SRC_DIR} || exit 2
+execute_cmd make -j$(nproc) --directory ${SRC_DIR}/contrib || exit 3
+log_section_end "Build Process"
+
+# Installation
+log_section "Installation"
+execute_cmd make install --directory ${SRC_DIR} || exit 4
+execute_cmd make install --directory ${SRC_DIR}/contrib || exit 4
+log_section_end "Installation"
+
+# Log completion
+log_completion "Cloudberry Build Script" "${BUILD_LOG}"
+exit 0

--- a/deploy/build_automation/cloudberry/scripts/cloudberry-utils.sh
+++ b/deploy/build_automation/cloudberry/scripts/cloudberry-utils.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Library: cloudberry-utils.sh
+# Description: Common utility functions for Apache Cloudberry build
+# and test scripts
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Functions:
+#   init_environment "Script Name" "Log File"
+#     - Initialize logging and verify environment
+#     - Parameters:
+#       * script_name: Name of the calling script
+#       * log_file: Path to log file
+#     - Returns: 0 on success, 1 on failure
+#
+#   execute_cmd command [args...]
+#     - Execute command with logging
+#     - Parameters: Command and its arguments
+#     - Returns: Command's exit code
+#
+#   run_psql_cmd "sql_command"
+#     - Execute PostgreSQL command with logging
+#     - Parameters: SQL command string
+#     - Returns: psql command's exit code
+#
+#   source_cloudberry_env
+#     - Source Cloudberry environment files
+#     - Returns: 0 on success
+#
+#   log_section "section_name"
+#     - Log section start
+#     - Parameters: Name of the section
+#
+#   log_section_end "section_name"
+#     - Log section end
+#     - Parameters: Name of the section
+#
+#   log_completion "script_name" "log_file"
+#     - Log script completion
+#     - Parameters:
+#       * script_name: Name of the calling script
+#       * log_file: Path to log file
+#
+# Usage:
+#   source ./cloudberry-utils.sh
+#
+# Example:
+#   source ./cloudberry-utils.sh
+#   init_environment "My Script" "${LOG_FILE}"
+#   execute_cmd make clean
+#   log_section "Build Process"
+#   execute_cmd make -j$(nproc)
+#   log_section_end "Build Process"
+#   log_completion "My Script" "${LOG_FILE}"
+#
+# --------------------------------------------------------------------
+
+# Initialize logging and environment
+init_environment() {
+    local script_name=$1
+    local log_file=$2
+
+    echo "=== Initializing environment for ${script_name} ==="
+    echo "${script_name} executed at $(date)" | tee -a "${log_file}"
+    echo "Whoami: $(whoami)" | tee -a "${log_file}"
+    echo "Hostname: $(hostname)" | tee -a "${log_file}"
+    echo "Working directory: $(pwd)" | tee -a "${log_file}"
+    echo "Source directory: ${SRC_DIR}" | tee -a "${log_file}"
+    echo "Log directory: ${LOG_DIR}" | tee -a "${log_file}"
+
+    if [ -z "${SRC_DIR:-}" ]; then
+        echo "Error: SRC_DIR environment variable is not set" | tee -a "${log_file}"
+        exit 1
+    fi
+
+    mkdir -p "${LOG_DIR}"
+}
+
+# Function to echo and execute command with logging
+execute_cmd() {
+    local cmd_str="$*"
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "Executing at ${timestamp}: $cmd_str" | tee -a "${LOG_DIR}/commands.log"
+    "$@" 2>&1 | tee -a "${LOG_DIR}/commands.log"
+    return ${PIPESTATUS[0]}
+}
+
+# Function to run psql commands with logging
+run_psql_cmd() {
+    local cmd=$1
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "Executing psql at ${timestamp}: $cmd" | tee -a "${LOG_DIR}/psql-commands.log"
+    psql -P pager=off template1 -c "$cmd" 2>&1 | tee -a "${LOG_DIR}/psql-commands.log"
+    return ${PIPESTATUS[0]}
+}
+
+# Function to source Cloudberry environment
+source_cloudberry_env() {
+    echo "=== Sourcing Cloudberry environment ===" | tee -a "${LOG_DIR}/environment.log"
+    source /usr/local/cloudberry-db/cloudberry-env.sh
+    source ${SRC_DIR}/../cloudberry/gpAux/gpdemo/gpdemo-env.sh
+}
+
+# Function to log section start
+log_section() {
+    local section_name=$1
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "=== ${section_name} started at ${timestamp} ===" | tee -a "${LOG_DIR}/sections.log"
+}
+
+# Function to log section end
+log_section_end() {
+    local section_name=$1
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "=== ${section_name} completed at ${timestamp} ===" | tee -a "${LOG_DIR}/sections.log"
+}
+
+# Function to log script completion
+log_completion() {
+    local script_name=$1
+    local log_file=$2
+    local timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
+    echo "${script_name} execution completed successfully at ${timestamp}" | tee -a "${log_file}"
+}

--- a/deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh
+++ b/deploy/build_automation/cloudberry/scripts/configure-cloudberry.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: configure-cloudberry.sh
+# Description: Configures Apache Cloudberry build environment and runs
+#             ./configure with optimized settings. Performs the
+#             following:
+#             1. Prepares /usr/local/cloudberry-db directory
+#             2. Sets up library dependencies
+#             3. Configures build with required features enabled
+#
+# Configuration Features:
+#   - Cloud Storage Integration (gpcloud)
+#   - IC Proxy Support
+#   - MapReduce Processing
+#   - Oracle Compatibility (orafce)
+#   - ORCA Query Optimizer
+#   - PAX Access Method
+#   - PXF External Table Access
+#   - Test Automation Support (tap-tests)
+#
+# System Integration:
+#   - GSSAPI Authentication
+#   - LDAP Authentication
+#   - XML Processing
+#   - LZ4 Compression
+#   - OpenSSL Support
+#   - PAM Authentication
+#   - Perl Support
+#   - Python Support
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#   ENABLE_DEBUG - Enable debug build options (true/false, defaults to
+#                  false)
+#
+#                 When true, enables:
+#                   --enable-debug
+#                   --enable-profiling
+#                   --enable-cassert
+#                   --enable-debug-extensions
+#
+# Prerequisites:
+#   - System dependencies must be installed:
+#     * xerces-c development files
+#     * OpenSSL development files
+#     * Python development files
+#     * Perl development files
+#     * LDAP development files
+#   - /usr/local must be writable
+#   - User must have sudo privileges
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./configure-cloudberry.sh
+#
+# Exit Codes:
+#   0 - Configuration completed successfully
+#   1 - Environment setup failed
+#   2 - Directory preparation failed
+#   3 - Library setup failed
+#   4 - Configure command failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="${SRC_DIR}/build-logs"
+CONFIGURE_LOG="${LOG_DIR}/configure.log"
+
+# Initialize environment
+init_environment "Cloudberry Configure Script" "${CONFIGURE_LOG}"
+
+# Initial setup
+log_section "Initial Setup"
+execute_cmd sudo rm -rf /usr/local/cloudberry-db || exit 2
+execute_cmd sudo chmod a+w /usr/local || exit 2
+execute_cmd mkdir -p /usr/local/cloudberry-db/lib || exit 2
+execute_cmd sudo cp /usr/local/xerces-c/lib/libxerces-c.so \
+        /usr/local/xerces-c/lib/libxerces-c-3.3.so \
+        /usr/local/cloudberry-db/lib || exit 3
+execute_cmd sudo chown -R gpadmin:gpadmin /usr/local/cloudberry-db || exit 2
+log_section_end "Initial Setup"
+
+# Set environment
+log_section "Environment Setup"
+export LD_LIBRARY_PATH=/usr/local/cloudberry-db/lib:LD_LIBRARY_PATH
+log_section_end "Environment Setup"
+
+# Add debug options if ENABLE_DEBUG is set to "true"
+CONFIGURE_DEBUG_OPTS=""
+
+if [ "${ENABLE_DEBUG:-false}" = "true" ]; then
+    CONFIGURE_DEBUG_OPTS="--enable-debug \
+                          --enable-profiling \
+                          --enable-cassert \
+                          --enable-debug-extensions"
+fi
+
+# Configure build
+log_section "Configure"
+execute_cmd ./configure --prefix=/usr/local/cloudberry-db \
+            --disable-external-fts \
+            --enable-gpcloud \
+            --enable-ic-proxy \
+            --enable-mapreduce \
+            --enable-orafce \
+            --enable-orca \
+            --enable-pax \
+            --enable-pxf \
+            --enable-tap-tests \
+            ${CONFIGURE_DEBUG_OPTS} \
+            --with-gssapi \
+            --with-ldap \
+            --with-libxml \
+            --with-lz4 \
+            --with-openssl \
+            --with-pam \
+            --with-perl \
+            --with-pgport=5432 \
+            --with-python \
+            --with-pythonsrc-ext \
+            --with-ssl=openssl \
+            --with-openssl \
+            --with-uuid=e2fs \
+            --with-includes=/usr/local/xerces-c/include \
+            --with-libraries=/usr/local/cloudberry-db/lib || exit 4
+log_section_end "Configure"
+
+# Capture version information
+log_section "Version Information"
+execute_cmd ag "GP_VERSION | GP_VERSION_NUM | PG_VERSION | PG_VERSION_NUM | PG_VERSION_STR" src/include/pg_config.h
+log_section_end "Version Information"
+
+# Log completion
+log_completion "Cloudberry Configure Script" "${CONFIGURE_LOG}"
+exit 0

--- a/deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
+++ b/deploy/build_automation/cloudberry/scripts/create-cloudberry-demo-cluster.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: create-cloudberry-demo-cluster.sh
+# Description: Creates and configures a demo Apache Cloudbery cluster.
+#             Performs the following steps:
+#             1. Sets up required environment variables
+#             2. Verifies SSH connectivity
+#             3. Creates demo cluster using make
+#             4. Initializes and starts the cluster
+#             5. Performs comprehensive verification checks
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Prerequisites:
+#   - Apache Cloudberry must be installed (/usr/local/cloudberry-db)
+#   - SSH must be configured for passwordless access to localhost
+#   - User must have permissions to create cluster directories
+#   - PostgreSQL client tools (psql) must be available
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./create-cloudberry-demo-cluster.sh
+#
+# Verification Checks:
+#   - Apache Cloudberry version
+#   - Segment configuration
+#   - Available extensions
+#   - Active sessions
+#   - Configuration history
+#   - Replication status
+#
+# Exit Codes:
+#   0 - Cluster created and verified successfully
+#   1 - Environment setup failed
+#   2 - SSH verification failed
+#   3 - Cluster creation failed
+#   4 - Cluster startup failed
+#   5 - Verification checks failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory
+export LOG_DIR="${SRC_DIR}/build-logs"
+CLUSTER_LOG="${LOG_DIR}/cluster.log"
+
+# Initialize environment
+init_environment "Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+
+# Setup environment
+log_section "Environment Setup"
+source /usr/local/cloudberry-db/cloudberry-env.sh || exit 1
+log_section_end "Environment Setup"
+
+# Verify SSH access
+log_section "SSH Verification"
+execute_cmd ssh $(hostname) 'whoami; hostname' || exit 2
+log_section_end "SSH Verification"
+
+# Create demo cluster
+log_section "Demo Cluster Creation"
+execute_cmd make create-demo-cluster --directory ${SRC_DIR}/../cloudberry || exit 3
+log_section_end "Demo Cluster Creation"
+
+# Source demo environment
+log_section "Source Environment"
+source ${SRC_DIR}/../cloudberry/gpAux/gpdemo/gpdemo-env.sh || exit 1
+log_section_end "Source Environment"
+
+# Manage cluster state
+log_section "Cluster Management"
+execute_cmd gpstop -a || exit 4
+execute_cmd gpstart -a || exit 4
+execute_cmd gpstate || exit 4
+log_section_end "Cluster Management"
+
+# Verify installation
+log_section "Installation Verification"
+verification_failed=false
+run_psql_cmd "SELECT version()" || verification_failed=true
+run_psql_cmd "SELECT * from gp_segment_configuration" || verification_failed=true
+run_psql_cmd "SELECT * FROM pg_available_extensions" || verification_failed=true
+run_psql_cmd "SELECT * from pg_stat_activity" || verification_failed=true
+run_psql_cmd "SELECT * FROM gp_configuration_history" || verification_failed=true
+run_psql_cmd "SELECT * FROM gp_stat_replication" || verification_failed=true
+
+if [ "$verification_failed" = true ]; then
+    echo "One or more verification checks failed" | tee -a "${CLUSTER_LOG}"
+    exit 5
+fi
+log_section_end "Installation Verification"
+
+# Log completion
+log_completion "Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+exit 0

--- a/deploy/build_automation/cloudberry/scripts/destroy-cloudberry-demo-cluster.sh
+++ b/deploy/build_automation/cloudberry/scripts/destroy-cloudberry-demo-cluster.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: destroy-cloudberry-demo-cluster.sh
+# Description: Destroys and cleans up a demo Apache Cloudberry
+# cluster.
+#             Performs the following steps:
+#             1. Sources required environment variables
+#             2. Stops any running cluster processes
+#             3. Removes cluster data directories and configuration
+#             4. Cleans up any remaining cluster resources
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Prerequisites:
+#   - Apache Cloudberry environment must be available
+#   - User must have permissions to remove cluster directories
+#   - No active connections to the cluster
+#
+# Usage:
+#   Export required variables:
+#     export SRC_DIR=/path/to/cloudberry/source
+#   Then run:
+#     ./destroy-cloudberry-demo-cluster.sh
+#
+# Exit Codes:
+#   0 - Cluster destroyed successfully
+#   1 - Environment setup/sourcing failed
+#   2 - Cluster destruction failed
+#
+# Related Scripts:
+#   - create-cloudberry-demo-cluster.sh: Creates a new demo cluster
+#
+# Notes:
+#   - This script will forcefully terminate all cluster processes
+#   - All cluster data will be permanently deleted
+#   - Make sure to backup any important data before running
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory
+export LOG_DIR="${SRC_DIR}/build-logs"
+CLUSTER_LOG="${LOG_DIR}/destroy-cluster.log"
+
+# Initialize environment
+init_environment "Destroy Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+
+# Source Cloudberry environment
+log_section "Environment Setup"
+source_cloudberry_env || {
+    echo "Failed to source Cloudberry environment" | tee -a "${CLUSTER_LOG}"
+    exit 1
+}
+log_section_end "Environment Setup"
+
+# Destroy demo cluster
+log_section "Destroy Demo Cluster"
+execute_cmd make destroy-demo-cluster --directory ${SRC_DIR}/../cloudberry || {
+    echo "Failed to destroy demo cluster" | tee -a "${CLUSTER_LOG}"
+    exit 2
+}
+log_section_end "Destroy Demo Cluster"
+
+# Verify cleanup
+log_section "Cleanup Verification"
+if [ -d "${SRC_DIR}/../cloudberry/gpAux/gpdemo/data" ]; then
+    echo "Warning: Data directory still exists after cleanup" | tee -a "${CLUSTER_LOG}"
+fi
+log_section_end "Cleanup Verification"
+
+# Log completion
+log_completion "Destroy Cloudberry Demo Cluster Script" "${CLUSTER_LOG}"
+exit 0

--- a/deploy/build_automation/cloudberry/scripts/parse-results.pl
+++ b/deploy/build_automation/cloudberry/scripts/parse-results.pl
@@ -1,0 +1,215 @@
+#!/usr/bin/env perl
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: parse_results.pl
+# Description: Processes Cloudberry test output to extract statistics
+# and results.
+#             Analyzes test log files to determine:
+#             1. Overall test status (pass/fail)
+#             2. Total number of tests run
+#             3. Number of passed, failed, and ignored tests
+#             4. Names of failed and ignored tests
+#             5. Validates test counts for consistency
+#             Results are written to a file for shell script processing.
+#
+# Arguments:
+#   log-file    Path to test log file (required)
+#
+# Input File Format:
+#   Expects test log files containing one of the following summary formats:
+#   - "All X tests passed."
+#   - "Y of X tests failed."
+#   - "X of Y tests passed, Z failed test(s) ignored."
+#   - "X of Y tests failed, Z of these failures ignored."
+#
+#   And failed or ignored test entries in format:
+#   - "test_name ... FAILED"
+#   - "test_name ... failed (ignored)"
+#
+# Output File (test_results.txt):
+#   Environment variable format:
+#   STATUS=passed|failed
+#   TOTAL_TESTS=<number>
+#   FAILED_TESTS=<number>
+#   PASSED_TESTS=<number>
+#   IGNORED_TESTS=<number>
+#   FAILED_TEST_NAMES=<comma-separated-list>
+#   IGNORED_TEST_NAMES=<comma-separated-list>
+#
+# Prerequisites:
+#   - Read access to input log file
+#   - Write access to current directory
+#   - Perl 5.x or higher
+#
+# Exit Codes:
+#   0 - All tests passed, or only ignored failures occurred
+#   1 - Some non-ignored tests failed
+#   2 - Parse error or cannot access files
+#
+# Example Usage:
+#   ./parse_results.pl test_output.log
+#
+# Error Handling:
+#   - Validates input file existence and readability
+#   - Verifies failed and ignored test counts match found entries
+#   - Reports parsing errors with detailed messages
+#
+# --------------------------------------------------------------------
+
+use strict;
+use warnings;
+
+# Exit codes
+use constant {
+    SUCCESS => 0,
+    TEST_FAILURE => 1,
+    PARSE_ERROR => 2
+};
+
+# Get log file path from command line argument
+my $file = $ARGV[0] or die "Usage: $0 LOG_FILE\n";
+print "Parsing test results from: $file\n";
+
+# Check if file exists and is readable
+unless (-e $file) {
+    print "Error: File does not exist: $file\n";
+    exit PARSE_ERROR;
+}
+unless (-r $file) {
+    print "Error: File is not readable: $file\n";
+    exit PARSE_ERROR;
+}
+
+# Open and parse the log file
+open(my $fh, '<', $file) or do {
+    print "Cannot open log file: $! (looking in $file)\n";
+    exit PARSE_ERROR;
+};
+
+# Initialize variables
+my ($status, $total_tests, $failed_tests, $ignored_tests, $passed_tests) = ('', 0, 0, 0, 0);
+my @failed_test_list = ();
+my @ignored_test_list = ();
+
+while (<$fh>) {
+    # Match the summary lines
+    if (/All (\d+) tests passed\./) {
+        $status = 'passed';
+        $total_tests = $1;
+        $passed_tests = $1;
+    }
+    elsif (/(\d+) of (\d+) tests passed, (\d+) failed test\(s\) ignored\./) {
+        $status = 'passed';
+        $passed_tests = $1;
+        $total_tests = $2;
+        $ignored_tests = $3;
+    }
+    elsif (/(\d+) of (\d+) tests failed\./) {
+        $status = 'failed';
+        $failed_tests = $1;
+        $total_tests = $2;
+        $passed_tests = $2 - $1;
+    }
+    elsif (/(\d+) of (\d+) tests failed, (\d+) of these failures ignored\./) {
+        $status = 'failed';
+        $failed_tests = $1 - $3;
+        $ignored_tests = $3;
+        $total_tests = $2;
+        $passed_tests = $2 - $1;
+    }
+
+    # Capture failed tests
+    if (/^(?:\s+|test\s+)(\S+)\s+\.\.\.\s+FAILED\s+/) {
+        push @failed_test_list, $1;
+    }
+
+    # Capture ignored tests
+    if (/^(?:\s+|test\s+)(\S+)\s+\.\.\.\s+failed \(ignored\)/) {
+        push @ignored_test_list, $1;
+    }
+}
+
+# Close the log file
+close $fh;
+
+# Validate failed test count matches found test names
+if ($status eq 'failed' && scalar(@failed_test_list) != $failed_tests) {
+    print "Error: Found $failed_tests failed tests in summary but found " . scalar(@failed_test_list) . " failed test names\n";
+    print "Failed test names found:\n";
+    foreach my $test (@failed_test_list) {
+        print "  - $test\n";
+    }
+    exit PARSE_ERROR;
+}
+
+# Validate ignored test count matches found test names
+if ($ignored_tests != scalar(@ignored_test_list)) {
+    print "Error: Found $ignored_tests ignored tests in summary but found " . scalar(@ignored_test_list) . " ignored test names\n";
+    print "Ignored test names found:\n";
+    foreach my $test (@ignored_test_list) {
+        print "  - $test\n";
+    }
+    exit PARSE_ERROR;
+}
+
+# Write results to the results file
+open my $result_fh, '>', 'test_results.txt' or die "Cannot write to results file: $!\n";
+print $result_fh "STATUS=$status\n";
+print $result_fh "TOTAL_TESTS=$total_tests\n";
+print $result_fh "PASSED_TESTS=$passed_tests\n";
+print $result_fh "FAILED_TESTS=$failed_tests\n";
+print $result_fh "IGNORED_TESTS=$ignored_tests\n";
+if (@failed_test_list) {
+    print $result_fh "FAILED_TEST_NAMES=" . join(',', @failed_test_list) . "\n";
+}
+if (@ignored_test_list) {
+    print $result_fh "IGNORED_TEST_NAMES=" . join(',', @ignored_test_list) . "\n";
+}
+close $result_fh;
+
+# Print to stdout for logging
+print "Test Results:\n";
+print "Status: $status\n";
+print "Total Tests: $total_tests\n";
+print "Failed Tests: $failed_tests\n";
+print "Ignored Tests: $ignored_tests\n";
+print "Passed Tests: $passed_tests\n";
+if (@failed_test_list) {
+    print "Failed Test Names:\n";
+    foreach my $test (@failed_test_list) {
+        print "  - $test\n";
+    }
+}
+if (@ignored_test_list) {
+    print "Ignored Test Names:\n";
+    foreach my $test (@ignored_test_list) {
+        print "  - $test\n";
+    }
+}
+
+# Exit with appropriate code
+if ($status eq 'passed') {
+    exit SUCCESS;
+} elsif ($status eq 'failed') {
+    exit TEST_FAILURE;
+} else {
+    exit PARSE_ERROR;
+}

--- a/deploy/build_automation/cloudberry/scripts/parse-test-results.sh
+++ b/deploy/build_automation/cloudberry/scripts/parse-test-results.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: parse-test-results.sh
+# Description: Parses Apache Cloudberry test results and processes the
+# output.
+#             Provides GitHub Actions integration and environment
+#             variable export functionality. This script is a wrapper
+#             around parse_results.pl, adding the following features:
+#             1. Default log file path handling
+#             2. GitHub Actions output integration
+#             3. Environment variable management
+#             4. Result file cleanup
+#
+# Arguments:
+#   [log-file] - Path to test log file
+#                (defaults to build-logs/details/make-${MAKE_NAME}.log)
+#
+# Prerequisites:
+#   - parse_results.pl must be in the same directory
+#   - Perl must be installed and in PATH
+#   - Write access to current directory (for temporary files)
+#   - Read access to test log file
+#
+# Output Variables (in GitHub Actions):
+#   status           - Test status (passed/failed)
+#   total_tests      - Total number of tests
+#   failed_tests     - Number of failed tests
+#   passed_tests     - Number of passed tests
+#   ignored_tests    - Number of ignored tests
+#   failed_test_names - Names of failed tests (comma-separated)
+#   ignored_test_names - Names of ignored tests (comma-separated)
+#
+# Usage Examples:
+#   # Parse default log file:
+#   ./parse-test-results.sh
+#
+#   # Parse specific log file:
+#   ./parse-test-results.sh path/to/test.log
+#
+#   # Use with GitHub Actions:
+#   export GITHUB_OUTPUT=/path/to/output
+#   ./parse-test-results.sh
+#
+# Exit Codes:
+#   0 - All tests passed successfully
+#   1 - Tests failed but results were properly parsed
+#   2 - Parse error, missing files, or unknown status
+#
+# Files Created/Modified:
+#   - Temporary: test_results.txt (automatically cleaned up)
+#   - If GITHUB_OUTPUT set: Appends results to specified file
+#
+# --------------------------------------------------------------------
+
+set -uo pipefail
+
+# Default log file path
+DEFAULT_LOG_PATH="build-logs/details/make-${MAKE_NAME}.log"
+LOG_FILE=${1:-$DEFAULT_LOG_PATH}
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Check if log file exists
+if [ ! -f "$LOG_FILE" ]; then
+    echo "Error: Test log file not found: $LOG_FILE"
+    exit 2
+fi
+
+# Run the perl script and capture its exit code
+perl "${SCRIPT_DIR}/parse-results.pl" "$LOG_FILE"
+perl_exit_code=$?
+
+# Check if results file exists and source it if it does
+if [ ! -f test_results.txt ]; then
+    echo "Error: No results file generated"
+    exit 2
+fi
+
+# Return the perl script's exit code
+exit $perl_exit_code

--- a/deploy/build_automation/cloudberry/scripts/test-cloudberry.sh
+++ b/deploy/build_automation/cloudberry/scripts/test-cloudberry.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: test-cloudberry.sh
+# Description: Executes Apache Cloudberry test suite using specified
+#             make target.  Supports different test types through make
+#             target configuration.  Sources Cloudberry environment
+#             before running tests.
+#
+# Required Environment Variables:
+#   MAKE_TARGET    - Make target to execute (e.g., installcheck-world)
+#   MAKE_DIRECTORY - Directory where make command will be executed
+#   MAKE_NAME      - Name of the make operation (for logging)
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to build-logs)
+#   PGOPTIONS - PostgreSQL server options
+#
+# Usage:
+#   Export required variables:
+#     export MAKE_TARGET=installcheck-world
+#     export MAKE_DIRECTORY="/path/to/make/dir"
+#     export MAKE_NAME="Install Check"
+#   Then run:
+#     ./test-cloudberry.sh
+#
+# Exit Codes:
+#   0 - All tests passed successfully
+#   1 - Environment setup failed (missing required variables, environment sourcing failed)
+#   2 - Test execution failed (make command returned error)
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="build-logs"
+TEST_LOG="${LOG_DIR}/test.log"
+
+# Initialize environment
+init_environment "Cloudberry Test Script" "${TEST_LOG}"
+
+# Source Cloudberry environment
+log_section "Environment Setup"
+source_cloudberry_env || exit 1
+log_section_end "Environment Setup"
+
+echo "MAKE_TARGET: ${MAKE_TARGET}"
+echo "MAKE_DIRECTORY: ${MAKE_DIRECTORY}"
+echo "PGOPTIONS: ${PGOPTIONS}"
+
+# Execute specified target
+log_section "Install Check"
+execute_cmd make ${MAKE_TARGET} ${MAKE_DIRECTORY} || exit 2
+log_section_end "Install Check"
+
+# Log completion
+log_completion "Cloudberry Test Script" "${TEST_LOG}"
+exit 0

--- a/deploy/build_automation/cloudberry/scripts/unittest-cloudberry.sh
+++ b/deploy/build_automation/cloudberry/scripts/unittest-cloudberry.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Script: unittest-cloudberry.sh
+# Description: Executes unit tests for Apache Cloudberry from source
+#             code.  Runs the 'unittest-check' make target and logs
+#             results.  Tests are executed against the compiled source
+#             without requiring a full installation.
+#
+# Required Environment Variables:
+#   SRC_DIR - Root source directory
+#
+# Optional Environment Variables:
+#   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#
+# Usage:
+#   ./unittest-cloudberry.sh
+#
+# Exit Codes:
+#   0 - All unit tests passed successfully
+#   1 - Environment setup failed (missing SRC_DIR, LOG_DIR creation failed)
+#   2 - Unit test execution failed
+#
+# --------------------------------------------------------------------
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/cloudberry-utils.sh"
+
+# Define log directory and files
+export LOG_DIR="${SRC_DIR}/build-logs"
+UNITTEST_LOG="${LOG_DIR}/unittest.log"
+
+# Initialize environment
+init_environment "Cloudberry Unittest Script" "${UNITTEST_LOG}"
+
+# Set environment
+log_section "Environment Setup"
+export LD_LIBRARY_PATH=/usr/local/cloudberry-db/lib:LD_LIBRARY_PATH
+log_section_end "Environment Setup"
+
+# Unittest process
+log_section "Unittest Process"
+execute_cmd make --directory ${SRC_DIR}/../cloudberry unittest-check || exit 2
+log_section_end "Unittest Process"
+
+# Log completion
+log_completion "Cloudberry Unittest Script" "${UNITTEST_LOG}"
+exit 0

--- a/deploy/images/docker/cbdb/build/rocky8/Dockerfile
+++ b/deploy/images/docker/cbdb/build/rocky8/Dockerfile
@@ -1,0 +1,212 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Apache Cloudberry Build Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 9-based container for building
+# and developing Apache Cloudberry. It installs necessary system
+# utilities, development tools, and configures the environment for SSH
+# access and systemd support.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential development tools and libraries installation
+# - User configuration for 'gpadmin' with sudo privileges
+#
+# Usage:
+#   docker build -t cloudberry-db-env .
+#   docker run -h cdw -it cloudberry-db-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 8
+FROM rockylinux/rockylinux:8
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale and user
+ENV container=docker
+ENV LANG=en_US.UTF-8
+ENV USER=gpadmin
+
+# --------------------------------------------------------------------
+# Install Development Tools and Utilities
+# --------------------------------------------------------------------
+# Install various development tools, system utilities, and libraries
+# required for building and running Apache Cloudberry.
+# - EPEL repository is enabled for additional packages.
+# - Cleanup steps are added to reduce image size after installation.
+# --------------------------------------------------------------------
+RUN dnf makecache && \
+    dnf install -y \
+        epel-release \
+        git && \
+    dnf makecache && \
+    dnf config-manager --disable epel && \
+    dnf install -y -d0 --enablerepo=epel \
+        the_silver_searcher \
+        htop && \
+    dnf install -y -d0 \
+        apr-devel \
+        autoconf \
+        bison \
+        bzip2-devel \
+        cmake3 \
+        diffutils \
+        file \
+        flex \
+        gcc-toolset-11-gcc \
+        gcc-toolset-11-gcc-c++ \
+        gdb \
+        glibc-langpack-en \
+        glibc-locale-source \
+        iproute \
+        java-11-openjdk \
+        java-11-openjdk-devel \
+        krb5-devel \
+        libcurl-devel \
+        libevent-devel \
+        libuuid-devel \
+        libxml2-devel \
+        libzstd-devel \
+        lsof \
+        lz4 \
+        lz4-devel \
+        make \
+        m4 \
+        nc \
+        net-tools \
+        openldap-devel \
+        openssh-clients \
+        openssh-server \
+        openssl-devel \
+        pam-devel \
+        passwd \
+        perl-Env \
+        perl-ExtUtils-Embed \
+        perl-Test-Simple \
+        procps-ng \
+        python3 \
+        python3-devel \
+        readline-devel \
+        rsync \
+        sshpass \
+        sudo \
+        tar \
+        unzip \
+        util-linux-ng \
+        wget \
+        which \
+        zlib-devel && \
+    dnf install -y -d0 --enablerepo=devel \
+        libuv-devel \
+        libyaml-devel \
+        perl-IPC-Run \
+        protobuf-devel && \
+    dnf clean all && rm -rf /var/cache/dnf/* && \
+    echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/profile.d/gcc.sh && \
+    source /etc/profile.d/gcc.sh && \
+    cd && XERCES_LATEST_RELEASE=3.3.0 && \
+    wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    echo "$(curl -sL https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz.sha256)" | sha256sum -c - && \
+    tar xf "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz"; rm "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    cd xerces-c-${XERCES_LATEST_RELEASE} && \
+    ./configure --prefix=/usr/local/xerces-c && \
+    make -j$(nproc) && \
+    make install -C ~/xerces-c-${XERCES_LATEST_RELEASE} && \
+    rm -rf ~/xerces-c* && \
+    cd && GO_VERSION="go1.23.4" && \
+    ARCH=$(uname -m) && \
+    if [ "${ARCH}" = "aarch64" ]; then \
+        GO_ARCH="arm64" && \
+        GO_SHA256="16e5017863a7f6071363782b1b8042eb12c6ca4f4cd71528b2123f0a1275b13e"; \
+    elif [ "${ARCH}" = "x86_64" ]; then \
+        GO_ARCH="amd64" && \
+        GO_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971"; \
+    else \
+        echo "Unsupported architecture: ${ARCH}" && exit 1; \
+    fi && \
+    GO_URL="https://go.dev/dl/${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    wget -nv "${GO_URL}" && \
+    echo "${GO_SHA256}  ${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | sha256sum -c - && \
+    tar xf "${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    mv go "/usr/local/${GO_VERSION}" && \
+    ln -s "/usr/local/${GO_VERSION}" /usr/local/go && \
+    rm -f "${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    echo 'export PATH=$PATH:/usr/local/go/bin' | tee -a /etc/profile.d/go.sh > /dev/null
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Create and configure the 'gpadmin' user with sudo privileges.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cbdb/cloudberry-env.sh ]; then\n  source /usr/local/cbdb/cloudberry-env.sh\nfi' >> /home/gpadmin/.bashrc && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf && \
+    dnf clean all  # Final cleanup to remove unnecessary files
+
+# Install testinfra via pip
+RUN pip3 install pytest-testinfra
+
+# Example: Copying test files into the container
+COPY tests /tests
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. The container also mounts the
+# /sys/fs/cgroup volume for systemd compatibility.
+# --------------------------------------------------------------------
+USER gpadmin
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/deploy/images/docker/cbdb/build/rocky8/configs/90-cbdb-limits
+++ b/deploy/images/docker/cbdb/build/rocky8/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/deploy/images/docker/cbdb/build/rocky8/configs/gpinitsystem.conf
+++ b/deploy/images/docker/cbdb/build/rocky8/configs/gpinitsystem.conf
@@ -1,0 +1,87 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# gpinitsystem Configuration File for Apache Cloudberry
+# --------------------------------------------------------------------
+# This configuration file is used to initialize an Apache Cloudberry
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# --------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# --------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# --------------------------------------------------------------------

--- a/deploy/images/docker/cbdb/build/rocky8/configs/init_system.sh
+++ b/deploy/images/docker/cbdb/build/rocky8/configs/init_system.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# --------------------------------------------------------------------
+# Container Initialization Script
+# --------------------------------------------------------------------
+# This script sets up the environment inside the Docker container for
+# the Apache Cloudberry Build Environment. It performs the following
+# tasks:
+#
+# 1. Verifies that the container is running with the expected hostname.
+# 2. Starts the SSH daemon to allow SSH access to the container.
+# 3. Configures passwordless SSH access for the 'gpadmin' user.
+# 4. Displays a welcome banner and system information.
+# 5. Starts an interactive bash shell.
+#
+# This script is intended to be used as an entrypoint or initialization
+# script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+# First, create the CPU info detection function
+get_cpu_info() {
+   ARCH=$(uname -m)
+   if [ "$ARCH" = "x86_64" ]; then
+       lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}'
+   elif [ "$ARCH" = "aarch64" ]; then
+       VENDOR=$(lscpu | grep 'Vendor ID:' | awk '{print $3}')
+       if [ "$VENDOR" = "Apple" ] || [ "$VENDOR" = "0x61" ]; then
+           echo "Apple Silicon ($ARCH)"
+       else
+           if [ -f /proc/cpuinfo ]; then
+               IMPL=$(grep "CPU implementer" /proc/cpuinfo | head -1 | awk '{print $3}')
+               PART=$(grep "CPU part" /proc/cpuinfo | head -1 | awk '{print $3}')
+               if [ ! -z "$IMPL" ] && [ ! -z "$PART" ]; then
+                   echo "ARM $ARCH (Implementer: $IMPL, Part: $PART)"
+               else
+                   echo "ARM $ARCH"
+               fi
+           else
+               echo "ARM $ARCH"
+           fi
+       fi
+   else
+       echo "Unknown architecture: $ARCH"
+   fi
+}
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Build Environment!
+
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(get_cpu_info)
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/deploy/images/docker/cbdb/build/rocky8/tests/requirements.txt
+++ b/deploy/images/docker/cbdb/build/rocky8/tests/requirements.txt
@@ -1,0 +1,3 @@
+testinfra
+pytest-testinfra
+paramiko

--- a/deploy/images/docker/cbdb/build/rocky8/tests/testinfra/test_cloudberry_db_env.py
+++ b/deploy/images/docker/cbdb/build/rocky8/tests/testinfra/test_cloudberry_db_env.py
@@ -1,0 +1,126 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+import testinfra
+
+def test_installed_packages(host):
+    """
+    Test if the essential packages are installed.
+    """
+    packages = [
+        "epel-release",
+        "git",
+        "the_silver_searcher",
+        "htop",
+        "bison",
+        "gcc",
+        "gcc-c++",
+        "glibc-langpack-en",
+        "glibc-locale-source",
+        "openssh-clients",
+        "openssh-server",
+        "sudo",
+        "rsync",
+        "wget",
+        "openssl-devel",
+        "python36-devel",
+        "readline-devel",
+        "zlib-devel",
+        "libcurl-devel",
+        "libevent-devel",
+        "libxml2-devel",
+        "libuuid-devel",
+        "libzstd-devel",
+        "lz4",
+        "openldap-devel",
+        "libuv-devel",
+        "libyaml-devel"
+    ]
+    for package in packages:
+        pkg = host.package(package)
+        assert pkg.is_installed
+
+
+def test_user_gpadmin_exists(host):
+    """
+    Test if the gpadmin user exists and is configured properly.
+    """
+    user = host.user("gpadmin")
+    assert user.exists
+    assert "wheel" in user.groups
+
+
+def test_ssh_service(host):
+    """
+    Test if SSH service is configured correctly.
+    """
+    sshd_config = host.file("/etc/ssh/sshd_config")
+    assert sshd_config.exists
+
+
+def test_locale_configured(host):
+    """
+    Test if the locale is configured correctly.
+    """
+    locale_conf = host.file("/etc/locale.conf")
+    assert locale_conf.exists
+    assert locale_conf.contains("LANG=en_US.UTF-8")
+
+
+def test_timezone(host):
+    """
+    Test if the timezone is configured correctly.
+    """
+    localtime = host.file("/etc/localtime")
+    assert localtime.exists
+
+
+def test_system_limits_configured(host):
+    """
+    Test if the custom system limits are applied.
+    """
+    limits_file = host.file("/etc/security/limits.d/90-cbdb-limits")
+    assert limits_file.exists
+
+
+def test_init_system_script(host):
+    """
+    Test if the init_system.sh script is present and executable.
+    """
+    script = host.file("/tmp/init_system.sh")
+    assert script.exists
+    assert script.mode == 0o777
+
+
+def test_custom_configuration_files(host):
+    """
+    Test if custom configuration files are correctly copied.
+    """
+    config_file = host.file("/tmp/90-cbdb-limits")
+    assert config_file.exists
+
+
+def test_locale_generated(host):
+    """
+    Test if the en_US.UTF-8 locale is correctly generated.
+    """
+    locale = host.run("locale -a | grep en_US.utf8")
+    assert locale.exit_status == 0
+    assert "en_US.utf8" in locale.stdout

--- a/deploy/images/docker/cbdb/build/rocky9/Dockerfile
+++ b/deploy/images/docker/cbdb/build/rocky9/Dockerfile
@@ -1,0 +1,215 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Apache Cloudberry Build Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 9-based container for building
+# and developing Apache Cloudberry. It installs necessary system
+# utilities, development tools, and configures the environment for SSH
+# access and systemd support.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential development tools and libraries installation
+# - User configuration for 'gpadmin' with sudo privileges
+#
+# Usage:
+#   docker build -t cloudberry-db-env .
+#   docker run -h cdw -it cloudberry-db-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 9
+FROM rockylinux/rockylinux:9
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale and user
+ENV container=docker
+ENV LANG=en_US.UTF-8
+ENV USER=gpadmin
+
+# --------------------------------------------------------------------
+# Install Development Tools and Utilities
+# --------------------------------------------------------------------
+# Install various development tools, system utilities, and libraries
+# required for building and running Apache Cloudberry.
+# - EPEL repository is enabled for additional packages.
+# - Cleanup steps are added to reduce image size after installation.
+# --------------------------------------------------------------------
+RUN dnf makecache && \
+    dnf install -y \
+        epel-release \
+        git && \
+    dnf config-manager --disable epel-cisco-openh264 && \
+    dnf makecache && \
+    dnf config-manager --disable epel && \
+    dnf install -y --enablerepo=epel \
+        the_silver_searcher \
+        bat \
+        htop && \
+    dnf install -y \
+        bison \
+        cmake3 \
+        ed \
+        file \
+        flex \
+        gcc \
+        gcc-c++ \
+        gdb \
+        glibc-langpack-en \
+        glibc-locale-source \
+        initscripts \
+        iproute \
+        less \
+        lsof \
+        m4 \
+        net-tools \
+        openssh-clients \
+        openssh-server \
+        perl \
+        rpm-build \
+        rpmdevtools \
+        rsync \
+        sudo \
+        tar \
+        unzip \
+        util-linux-ng \
+        wget \
+        sshpass \
+        which && \
+    dnf install -y \
+        apr-devel \
+        bzip2-devel \
+        java-11-openjdk \
+        java-11-openjdk-devel \
+        krb5-devel \
+        libcurl-devel \
+        libevent-devel \
+        libxml2-devel \
+        libuuid-devel \
+        libzstd-devel \
+        lz4 \
+        lz4-devel \
+        openldap-devel \
+        openssl-devel \
+        pam-devel \
+        perl-ExtUtils-Embed \
+        perl-Test-Simple \
+        perl-core \
+        python3-devel \
+        python3-pytest \
+        readline-devel \
+        zlib-devel && \
+    dnf install -y --enablerepo=crb \
+        libuv-devel \
+        libyaml-devel \
+        perl-IPC-Run \
+        protobuf-devel && \
+    dnf clean all && \
+    cd && XERCES_LATEST_RELEASE=3.3.0 && \
+    wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    echo "$(curl -sL https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz.sha256)" | sha256sum -c - && \
+    tar xf "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz"; rm "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    cd xerces-c-${XERCES_LATEST_RELEASE} && \
+    ./configure --prefix=/usr/local/xerces-c && \
+    make -j$(nproc) && \
+    make install -C ~/xerces-c-${XERCES_LATEST_RELEASE} && \
+    rm -rf ~/xerces-c* && \
+    cd && GO_VERSION="go1.23.4" && \
+    ARCH=$(uname -m) && \
+    if [ "${ARCH}" = "aarch64" ]; then \
+        GO_ARCH="arm64" && \
+        GO_SHA256="16e5017863a7f6071363782b1b8042eb12c6ca4f4cd71528b2123f0a1275b13e"; \
+    elif [ "${ARCH}" = "x86_64" ]; then \
+        GO_ARCH="amd64" && \
+        GO_SHA256="6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971"; \
+    else \
+        echo "Unsupported architecture: ${ARCH}" && exit 1; \
+    fi && \
+    GO_URL="https://go.dev/dl/${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    wget -nv "${GO_URL}" && \
+    echo "${GO_SHA256}  ${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | sha256sum -c - && \
+    tar xf "${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    mv go "/usr/local/${GO_VERSION}" && \
+    ln -s "/usr/local/${GO_VERSION}" /usr/local/go && \
+    rm -f "${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    echo 'export PATH=$PATH:/usr/local/go/bin' | tee -a /etc/profile.d/go.sh > /dev/null
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Create and configure the 'gpadmin' user with sudo privileges.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+
+# Copy configuration files from their respective locations
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cbdb/cloudberry-env.sh ]; then\n  source /usr/local/cbdb/cloudberry-env.sh\nfi' >> /home/gpadmin/.bashrc && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf && \
+    dnf clean all  # Final cleanup to remove unnecessary files
+
+# Install testinfra via pip
+RUN pip3 install pytest-testinfra
+
+# Copying test files into the container
+COPY ./tests /tests
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. The container also mounts the
+# /sys/fs/cgroup volume for systemd compatibility.
+# --------------------------------------------------------------------
+USER gpadmin
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/deploy/images/docker/cbdb/build/rocky9/configs/90-cbdb-limits
+++ b/deploy/images/docker/cbdb/build/rocky9/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/deploy/images/docker/cbdb/build/rocky9/configs/gpinitsystem.conf
+++ b/deploy/images/docker/cbdb/build/rocky9/configs/gpinitsystem.conf
@@ -1,0 +1,89 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# gpinitsystem Configuration File for Apache Cloudberry
+# --------------------------------------------------------------------
+# This configuration file is used to initialize an Apache Cloudberry
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# --------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# --------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# --------------------------------------------------------------------

--- a/deploy/images/docker/cbdb/build/rocky9/configs/init_system.sh
+++ b/deploy/images/docker/cbdb/build/rocky9/configs/init_system.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+## Container Initialization Script
+# --------------------------------------------------------------------
+## This script sets up the environment inside the Docker container for
+## the Apache Cloudberry Build Environment. It performs the following
+## tasks:
+##
+## 1. Verifies that the container is running with the expected hostname.
+## 2. Starts the SSH daemon to allow SSH access to the container.
+## 3. Configures passwordless SSH access for the 'gpadmin' user.
+## 4. Displays a welcome banner and system information.
+## 5. Starts an interactive bash shell.
+##
+## This script is intended to be used as an entrypoint or initialization
+## script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+# First, create the CPU info detection function
+get_cpu_info() {
+   ARCH=$(uname -m)
+   if [ "$ARCH" = "x86_64" ]; then
+       lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}'
+   elif [ "$ARCH" = "aarch64" ]; then
+       VENDOR=$(lscpu | grep 'Vendor ID:' | awk '{print $3}')
+       if [ "$VENDOR" = "Apple" ] || [ "$VENDOR" = "0x61" ]; then
+           echo "Apple Silicon ($ARCH)"
+       else
+           if [ -f /proc/cpuinfo ]; then
+               IMPL=$(grep "CPU implementer" /proc/cpuinfo | head -1 | awk '{print $3}')
+               PART=$(grep "CPU part" /proc/cpuinfo | head -1 | awk '{print $3}')
+               if [ ! -z "$IMPL" ] && [ ! -z "$PART" ]; then
+                   echo "ARM $ARCH (Implementer: $IMPL, Part: $PART)"
+               else
+                   echo "ARM $ARCH"
+               fi
+           else
+               echo "ARM $ARCH"
+           fi
+       fi
+   else
+       echo "Unknown architecture: $ARCH"
+   fi
+}
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Build Environment!
+
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(get_cpu_info)
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/deploy/images/docker/cbdb/build/rocky9/tests/requirements.txt
+++ b/deploy/images/docker/cbdb/build/rocky9/tests/requirements.txt
@@ -1,0 +1,3 @@
+testinfra
+pytest-testinfra
+paramiko

--- a/deploy/images/docker/cbdb/build/rocky9/tests/testinfra/test_cloudberry_db_env.py
+++ b/deploy/images/docker/cbdb/build/rocky9/tests/testinfra/test_cloudberry_db_env.py
@@ -1,0 +1,129 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+import testinfra
+
+def test_installed_packages(host):
+    """
+    Test if the essential packages are installed.
+    """
+    packages = [
+        "epel-release",
+        "git",
+        "the_silver_searcher",
+        "bat",
+        "htop",
+        "bison",
+        "cmake",
+        "gcc",
+        "gcc-c++",
+        "glibc-langpack-en",
+        "glibc-locale-source",
+        "openssh-clients",
+        "openssh-server",
+        "sudo",
+        "rsync",
+        "wget",
+        "openssl-devel",
+        "python3-devel",
+        "python3-pytest",
+        "readline-devel",
+        "zlib-devel",
+        "libcurl-devel",
+        "libevent-devel",
+        "libxml2-devel",
+        "libuuid-devel",
+        "libzstd-devel",
+        "lz4",
+        "openldap-devel",
+        "libuv-devel",
+        "libyaml-devel"
+    ]
+    for package in packages:
+        pkg = host.package(package)
+        assert pkg.is_installed
+
+
+def test_user_gpadmin_exists(host):
+    """
+    Test if the gpadmin user exists and is configured properly.
+    """
+    user = host.user("gpadmin")
+    assert user.exists
+    assert "wheel" in user.groups
+
+
+def test_ssh_service(host):
+    """
+    Test if SSH service is configured correctly.
+    """
+    sshd_config = host.file("/etc/ssh/sshd_config")
+    assert sshd_config.exists
+
+
+def test_locale_configured(host):
+    """
+    Test if the locale is configured correctly.
+    """
+    locale_conf = host.file("/etc/locale.conf")
+    assert locale_conf.exists
+    assert locale_conf.contains("LANG=en_US.UTF-8")
+
+
+def test_timezone(host):
+    """
+    Test if the timezone is configured correctly.
+    """
+    localtime = host.file("/etc/localtime")
+    assert localtime.exists
+
+
+def test_system_limits_configured(host):
+    """
+    Test if the custom system limits are applied.
+    """
+    limits_file = host.file("/etc/security/limits.d/90-cbdb-limits")
+    assert limits_file.exists
+
+
+def test_init_system_script(host):
+    """
+    Test if the init_system.sh script is present and executable.
+    """
+    script = host.file("/tmp/init_system.sh")
+    assert script.exists
+    assert script.mode == 0o777
+
+
+def test_custom_configuration_files(host):
+    """
+    Test if custom configuration files are correctly copied.
+    """
+    config_file = host.file("/tmp/90-cbdb-limits")
+    assert config_file.exists
+
+
+def test_locale_generated(host):
+    """
+    Test if the en_US.UTF-8 locale is correctly generated.
+    """
+    locale = host.run("locale -a | grep en_US.utf8")
+    assert locale.exit_status == 0
+    assert "en_US.utf8" in locale.stdout

--- a/deploy/images/docker/cbdb/test/rocky8/Dockerfile
+++ b/deploy/images/docker/cbdb/test/rocky8/Dockerfile
@@ -1,0 +1,135 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Apache Cloudberry Base Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 8-based container to serve as
+# a base environment for evaluating Apache Cloudberry. It installs
+# necessary system utilities, configures the environment for SSH access,
+# and sets up a 'gpadmin' user with sudo privileges. The Apache
+# Cloudberry RPM can be installed into this container for testing and
+# functional verification.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential system utilities installation
+# - Separate user creation and configuration steps
+#
+# Security Considerations:
+# - This Dockerfile prioritizes ease of use for functional testing and
+#   evaluation. It includes configurations such as passwordless sudo access
+#   for the 'gpadmin' user and SSH access with password authentication.
+# - These configurations are suitable for testing and development but
+#   should NOT be used in a production environment due to potential security
+#   risks.
+#
+# Usage:
+#   docker build -t cloudberry-db-base-env .
+#   docker run -h cdw -it cloudberry-db-base-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 8
+FROM rockylinux/rockylinux:8
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale
+ENV LANG=en_US.UTF-8
+
+# --------------------------------------------------------------------
+# System Update and Installation
+# --------------------------------------------------------------------
+# Update the system and install essential system utilities required for
+# running and testing Apache Cloudberry. Cleanup the DNF cache afterward
+# to reduce the image size.
+# --------------------------------------------------------------------
+RUN dnf install -y \
+        file \
+        gdb \
+        glibc-locale-source \
+        make \
+        openssh \
+        openssh-clients \
+        openssh-server \
+        procps-ng \
+        sudo \
+        which \
+        && \
+    dnf clean all  # Clean up DNF cache after package installations
+
+# --------------------------------------------------------------------
+# User Creation and Configuration
+# --------------------------------------------------------------------
+# - Create the 'gpadmin' user and group.
+# - Configure the 'gpadmin' user with passwordless sudo privileges.
+# - Add Cloudberry-specific entries to the gpadmin's .bashrc.
+# --------------------------------------------------------------------
+RUN /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cloudberry/cloudberry-env.sh ]; then\n  source /usr/local/cloudberry/cloudberry-env.sh\n  export COORDINATOR_DATA_DIRECTORY=/data1/coordinator/gpseg-1\nfi' >> /home/gpadmin/.bashrc
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. This container serves as a base
+# environment, and the Apache Cloudberry RPM can be installed for
+# testing and functional verification.
+# --------------------------------------------------------------------
+USER gpadmin
+
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/deploy/images/docker/cbdb/test/rocky8/configs/90-cbdb-limits
+++ b/deploy/images/docker/cbdb/test/rocky8/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/deploy/images/docker/cbdb/test/rocky8/configs/gpinitsystem.conf
+++ b/deploy/images/docker/cbdb/test/rocky8/configs/gpinitsystem.conf
@@ -1,0 +1,87 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# gpinitsystem Configuration File for Cloudberry Database
+# --------------------------------------------------------------------
+# This configuration file is used to initialize a Cloudberry Database
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# --------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# --------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# --------------------------------------------------------------------

--- a/deploy/images/docker/cbdb/test/rocky8/configs/init_system.sh
+++ b/deploy/images/docker/cbdb/test/rocky8/configs/init_system.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# Container Initialization Script
+# --------------------------------------------------------------------
+# This script sets up the environment inside the Docker container for
+# the Apache Cloudberry Build Environment. It performs the following
+# tasks:
+#
+# 1. Verifies that the container is running with the expected hostname.
+# 2. Starts the SSH daemon to allow SSH access to the container.
+# 3. Configures passwordless SSH access for the 'gpadmin' user.
+# 4. Sets up the necessary directories and configuration files for
+#    Apache Cloudberry.
+# 5. Displays a welcome banner and system information.
+# 6. Starts an interactive bash shell.
+#
+# This script is intended to be used as an entrypoint or initialization
+# script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# --------------------------------------------------------------------
+# Cloudberry Data Directories Setup
+# --------------------------------------------------------------------
+# The script sets up the necessary directories for Apache Cloudberry,
+# including directories for the coordinator, standby coordinator, primary
+# segments, and mirror segments. It also sets up the configuration files
+# required for initializing the database.
+# --------------------------------------------------------------------
+sudo rm -rf /data1/*
+sudo mkdir -p /data1/coordinator /data1/standby_coordinator /data1/primary /data1/mirror
+sudo chown -R gpadmin.gpadmin /data1
+
+# Copy the gpinitsystem configuration file to the home directory
+cp /tmp/gpinitsystem.conf /home/gpadmin
+
+# Set up the hostfile for cluster initialization
+echo $(hostname) > /home/gpadmin/hostfile_gpinitsystem
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# - Cloudberry version (if installed)
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+# First, create the CPU info detection function
+get_cpu_info() {
+   ARCH=$(uname -m)
+   if [ "$ARCH" = "x86_64" ]; then
+       lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}'
+   elif [ "$ARCH" = "aarch64" ]; then
+       VENDOR=$(lscpu | grep 'Vendor ID:' | awk '{print $3}')
+       if [ "$VENDOR" = "Apple" ] || [ "$VENDOR" = "0x61" ]; then
+           echo "Apple Silicon ($ARCH)"
+       else
+           if [ -f /proc/cpuinfo ]; then
+               IMPL=$(grep "CPU implementer" /proc/cpuinfo | head -1 | awk '{print $3}')
+               PART=$(grep "CPU part" /proc/cpuinfo | head -1 | awk '{print $3}')
+               if [ ! -z "$IMPL" ] && [ ! -z "$PART" ]; then
+                   echo "ARM $ARCH (Implementer: $IMPL, Part: $PART)"
+               else
+                   echo "ARM $ARCH"
+               fi
+           else
+               echo "ARM $ARCH"
+           fi
+       fi
+   else
+       echo "Unknown architecture: $ARCH"
+   fi
+}
+
+# Check if Apache Cloudberry is installed and display its version
+if rpm -q apache-cloudberry-db-incubating > /dev/null 2>&1; then
+    CBDB_VERSION=$(/usr/local/cbdb/bin/postgres --gp-version)
+else
+    CBDB_VERSION="Not installed"
+fi
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Test Environment!
+
+Cloudberry version .. : $CBDB_VERSION
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(get_cpu_info)
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/deploy/images/docker/cbdb/test/rocky9/Dockerfile
+++ b/deploy/images/docker/cbdb/test/rocky9/Dockerfile
@@ -1,0 +1,135 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
+# Apache Cloudberry (incubating) is an effort undergoing incubation at
+# the Apache Software Foundation (ASF), sponsored by the Apache
+# Incubator PMC.
+#
+# Incubation is required of all newly accepted projects until a
+# further review indicates that the infrastructure, communications,
+# and decision making process have stabilized in a manner consistent
+# with other successful ASF projects.
+#
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the
+# project has yet to be fully endorsed by the ASF.
+#
+# --------------------------------------------------------------------
+# Dockerfile for Cloudberry Database Base Environment
+# --------------------------------------------------------------------
+# This Dockerfile sets up a Rocky Linux 9-based container to serve as
+# a base environment for evaluating the Cloudberry Database. It installs
+# necessary system utilities, configures the environment for SSH access,
+# and sets up a 'gpadmin' user with sudo privileges. The Cloudberry
+# Database RPM can be installed into this container for testing and
+# functional verification.
+#
+# Key Features:
+# - Locale setup for en_US.UTF-8
+# - SSH daemon setup for remote access
+# - Essential system utilities installation
+# - Separate user creation and configuration steps
+#
+# Security Considerations:
+# - This Dockerfile prioritizes ease of use for functional testing and
+#   evaluation. It includes configurations such as passwordless sudo access
+#   for the 'gpadmin' user and SSH access with password authentication.
+# - These configurations are suitable for testing and development but
+#   should NOT be used in a production environment due to potential security
+#   risks.
+#
+# Usage:
+#   docker build -t cloudberry-db-base-env .
+#   docker run -h cdw -it cloudberry-db-base-env
+# --------------------------------------------------------------------
+
+# Base image: Rocky Linux 9
+FROM rockylinux/rockylinux:9
+
+# Argument for configuring the timezone
+ARG TIMEZONE_VAR="America/Los_Angeles"
+
+# Environment variables for locale
+ENV LANG=en_US.UTF-8
+
+# --------------------------------------------------------------------
+# System Update and Installation
+# --------------------------------------------------------------------
+# Update the system and install essential system utilities required for
+# running and testing Cloudberry Database. Cleanup the DNF cache afterward
+# to reduce the image size.
+# --------------------------------------------------------------------
+RUN dnf install -y \
+        file \
+        gdb \
+        glibc-locale-source \
+        make \
+        openssh \
+        openssh-clients \
+        openssh-server \
+        procps-ng \
+        sudo \
+        which \
+        && \
+    dnf clean all  # Clean up DNF cache after package installations
+
+# --------------------------------------------------------------------
+# User Creation and Configuration
+# --------------------------------------------------------------------
+# - Create the 'gpadmin' user and group.
+# - Configure the 'gpadmin' user with passwordless sudo privileges.
+# - Add Cloudberry-specific entries to the gpadmin's .bashrc.
+# --------------------------------------------------------------------
+RUN /usr/sbin/groupadd gpadmin && \
+    /usr/sbin/useradd gpadmin -g gpadmin -G wheel && \
+    echo 'gpadmin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/90-gpadmin && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cloudberry/cloudberry-env.sh ]; then\n  source /usr/local/cloudberry/cloudberry-env.sh\n  export COORDINATOR_DATA_DIRECTORY=/data1/coordinator/gpseg-1\nfi' >> /home/gpadmin/.bashrc
+
+# --------------------------------------------------------------------
+# Copy Configuration Files and Setup the Environment
+# --------------------------------------------------------------------
+# - Copy custom configuration files from the build context to /tmp/.
+# - Apply custom system limits and timezone.
+# - Set up SSH for password-based authentication.
+# - Generate locale and set the default locale to en_US.UTF-8.
+# --------------------------------------------------------------------
+COPY ./configs/* /tmp/
+
+RUN cp /tmp/90-cbdb-limits /etc/security/limits.d/90-cbdb-limits && \
+    sed -i.bak -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/* && \
+    cat /usr/share/zoneinfo/${TIMEZONE_VAR} > /etc/localtime && \
+    chmod 777 /tmp/init_system.sh && \
+    setcap cap_net_raw+ep /usr/bin/ping && \
+    ssh-keygen -A && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    echo "LANG=en_US.UTF-8" | tee /etc/locale.conf
+
+# --------------------------------------------------------------------
+# Set the Default User and Command
+# --------------------------------------------------------------------
+# The default user is set to 'gpadmin', and the container starts by
+# running the init_system.sh script. This container serves as a base
+# environment, and the Cloudberry Database RPM can be installed for
+# testing and functional verification.
+# --------------------------------------------------------------------
+USER gpadmin
+
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/deploy/images/docker/cbdb/test/rocky9/configs/90-cbdb-limits
+++ b/deploy/images/docker/cbdb/test/rocky9/configs/90-cbdb-limits
@@ -1,0 +1,32 @@
+# /etc/security/limits.d/90-db-limits
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+# Core dump file size limits for gpadmin
+gpadmin soft core unlimited
+gpadmin hard core unlimited
+
+# Open file limits for gpadmin
+gpadmin soft nofile 524288
+gpadmin hard nofile 524288
+
+# Process limits for gpadmin
+gpadmin soft nproc 131072
+gpadmin hard nproc 131072

--- a/deploy/images/docker/cbdb/test/rocky9/configs/gpinitsystem.conf
+++ b/deploy/images/docker/cbdb/test/rocky9/configs/gpinitsystem.conf
@@ -1,0 +1,87 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# ----------------------------------------------------------------------
+# gpinitsystem Configuration File for Cloudberry Database
+# ----------------------------------------------------------------------
+# This configuration file is used to initialize a Cloudberry Database
+# cluster. It defines the settings for the coordinator, primary segments,
+# and mirrors, as well as other important configuration options.
+# ----------------------------------------------------------------------
+
+# Segment prefix - This prefix is used for naming the segment directories.
+# For example, the primary segment directories will be named gpseg0, gpseg1, etc.
+SEG_PREFIX=gpseg
+
+# Coordinator port - The port number where the coordinator will listen.
+# This is the port used by clients to connect to the database.
+COORDINATOR_PORT=5432
+
+# Coordinator hostname - The hostname of the machine where the coordinator
+# will be running. The $(hostname) command will automatically insert the
+# hostname of the current machine.
+COORDINATOR_HOSTNAME=$(hostname)
+
+# Coordinator data directory - The directory where the coordinator's data
+# will be stored. This directory should have enough space to store metadata
+# and system catalogs.
+COORDINATOR_DIRECTORY=/data1/coordinator
+
+# Base port for primary segments - The starting port number for the primary
+# segments. Each primary segment will use a unique port number starting from
+# this base.
+PORT_BASE=6000
+
+# Primary segment data directories - An array specifying the directories where
+# the primary segment data will be stored. Each directory corresponds to a
+# primary segment. In this case, two primary segments will be created in the
+# same directory.
+declare -a DATA_DIRECTORY=(/data1/primary /data1/primary)
+
+# Base port for mirror segments - The starting port number for the mirror
+# segments. Each mirror segment will use a unique port number starting from
+# this base.
+MIRROR_PORT_BASE=7000
+
+# Mirror segment data directories - An array specifying the directories where
+# the mirror segment data will be stored. Each directory corresponds to a
+# mirror segment. In this case, two mirror segments will be created in the
+# same directory.
+declare -a MIRROR_DATA_DIRECTORY=(/data1/mirror /data1/mirror)
+
+# Trusted shell - The shell program used for remote execution. Cloudberry uses
+# SSH to run commands on other machines in the cluster. 'ssh' is the default.
+TRUSTED_SHELL=ssh
+
+# Database encoding - The character set encoding to be used by the database.
+# 'UNICODE' is a common choice, especially for internationalization.
+ENCODING=UNICODE
+
+# Default database name - The name of the default database to be created during
+# initialization. This is also the default database that the gpadmin user will
+# connect to.
+DATABASE_NAME=gpadmin
+
+# Machine list file - A file containing the list of hostnames where the primary
+# segments will be created. Each line in the file represents a different machine.
+# This file is critical for setting up the cluster across multiple nodes.
+MACHINE_LIST_FILE=/home/gpadmin/hostfile_gpinitsystem
+
+# ----------------------------------------------------------------------
+# End of gpinitsystem Configuration File
+# ----------------------------------------------------------------------

--- a/deploy/images/docker/cbdb/test/rocky9/configs/init_system.sh
+++ b/deploy/images/docker/cbdb/test/rocky9/configs/init_system.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# Container Initialization Script
+# --------------------------------------------------------------------
+# This script sets up the environment inside the Docker container for
+# the Apache Cloudberry Build Environment. It performs the following
+# tasks:
+#
+# 1. Verifies that the container is running with the expected hostname.
+# 2. Starts the SSH daemon to allow SSH access to the container.
+# 3. Configures passwordless SSH access for the 'gpadmin' user.
+# 4. Sets up the necessary directories and configuration files for
+#    Apache Cloudberry.
+# 5. Displays a welcome banner and system information.
+# 6. Starts an interactive bash shell.
+#
+# This script is intended to be used as an entrypoint or initialization
+# script for the Docker container.
+# --------------------------------------------------------------------
+
+# --------------------------------------------------------------------
+# Check if the hostname is 'cdw'
+# --------------------------------------------------------------------
+# The script checks if the container's hostname is set to 'cdw'. This is
+# a requirement for this environment, and if the hostname does not match,
+# the script will exit with an error message. This ensures consistency
+# across different environments.
+# --------------------------------------------------------------------
+if [ "$(hostname)" != "cdw" ]; then
+    echo "Error: This container must be run with the hostname 'cdw'."
+    echo "Use the following command: docker run -h cdw ..."
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Start SSH daemon and setup for SSH access
+# --------------------------------------------------------------------
+# The SSH daemon is started to allow remote access to the container via
+# SSH. This is useful for development and debugging purposes. If the SSH
+# daemon fails to start, the script exits with an error.
+# --------------------------------------------------------------------
+if ! sudo /usr/sbin/sshd; then
+    echo "Failed to start SSH daemon" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------
+# Remove /run/nologin to allow logins
+# --------------------------------------------------------------------
+# The /run/nologin file, if present, prevents users from logging into
+# the system. This file is removed to ensure that users can log in via SSH.
+# --------------------------------------------------------------------
+sudo rm -rf /run/nologin
+
+# --------------------------------------------------------------------
+# Configure passwordless SSH access for 'gpadmin' user
+# --------------------------------------------------------------------
+# The script sets up SSH key-based authentication for the 'gpadmin' user,
+# allowing passwordless SSH access. It generates a new SSH key pair if one
+# does not already exist, and configures the necessary permissions.
+# --------------------------------------------------------------------
+mkdir -p /home/gpadmin/.ssh
+chmod 700 /home/gpadmin/.ssh
+
+if [ ! -f /home/gpadmin/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -b 4096 -C gpadmin -f /home/gpadmin/.ssh/id_rsa -P "" > /dev/null 2>&1
+fi
+
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+chmod 600 /home/gpadmin/.ssh/authorized_keys
+
+# Add the container's hostname to the known_hosts file to avoid SSH warnings
+ssh-keyscan -t rsa cdw > /home/gpadmin/.ssh/known_hosts 2>/dev/null
+
+# --------------------------------------------------------------------
+# Cloudberry Data Directories Setup
+# --------------------------------------------------------------------
+# The script sets up the necessary directories for Apache Cloudberry,
+# including directories for the coordinator, standby coordinator, primary
+# segments, and mirror segments. It also sets up the configuration files
+# required for initializing the database.
+# --------------------------------------------------------------------
+sudo rm -rf /data1/*
+sudo mkdir -p /data1/coordinator /data1/standby_coordinator /data1/primary /data1/mirror
+sudo chown -R gpadmin.gpadmin /data1
+
+# Copy the gpinitsystem configuration file to the home directory
+cp /tmp/gpinitsystem.conf /home/gpadmin
+
+# Set up the hostfile for cluster initialization
+echo $(hostname) > /home/gpadmin/hostfile_gpinitsystem
+
+# Change to the home directory of the current user
+cd $HOME
+
+# --------------------------------------------------------------------
+# Display a Welcome Banner
+# --------------------------------------------------------------------
+# The following ASCII art and welcome message are displayed when the
+# container starts. This banner provides a visual indication that the
+# container is running in the Apache Cloudberry Build Environment.
+# --------------------------------------------------------------------
+cat <<-'EOF'
+
+======================================================================
+
+                          ++++++++++       ++++++
+                        ++++++++++++++   +++++++
+                       ++++        +++++ ++++
+                      ++++          +++++++++
+                   =+====         =============+
+                 ========       =====+      =====
+                ====  ====     ====           ====
+               ====    ===     ===             ====
+               ====            === ===         ====
+               ====            ===  ==--       ===
+                =====          ===== --       ====
+                 =====================     ======
+                   ============================
+                                     =-----=
+     ____  _                    _  _
+    / ___|| |  ___   _   _   __| || |__    ___  _ __  _ __  _   _
+   | |    | | / _ \ | | | | / _` || '_ \  / _ \| '__|| '__|| | | |
+   | |___ | || (_) || |_| || (_| || |_) ||  __/| |   | |   | |_| |
+    \____||_| \____  \__,_| \__,_||_.__/  \___||_|   |_|    \__, |
+                                                            |___/
+----------------------------------------------------------------------
+
+EOF
+
+# --------------------------------------------------------------------
+# Display System Information
+# --------------------------------------------------------------------
+# The script sources the /etc/os-release file to retrieve the operating
+# system name and version. It then displays the following information:
+# - OS name and version
+# - Current user
+# - Container hostname
+# - IP address
+# - CPU model name and number of cores
+# - Total memory available
+# - Cloudberry version (if installed)
+# This information is useful for users to understand the environment they
+# are working in.
+# --------------------------------------------------------------------
+source /etc/os-release
+
+# First, create the CPU info detection function
+get_cpu_info() {
+   ARCH=$(uname -m)
+   if [ "$ARCH" = "x86_64" ]; then
+       lscpu | grep 'Model name:' | awk '{print substr($0, index($0,$3))}'
+   elif [ "$ARCH" = "aarch64" ]; then
+       VENDOR=$(lscpu | grep 'Vendor ID:' | awk '{print $3}')
+       if [ "$VENDOR" = "Apple" ] || [ "$VENDOR" = "0x61" ]; then
+           echo "Apple Silicon ($ARCH)"
+       else
+           if [ -f /proc/cpuinfo ]; then
+               IMPL=$(grep "CPU implementer" /proc/cpuinfo | head -1 | awk '{print $3}')
+               PART=$(grep "CPU part" /proc/cpuinfo | head -1 | awk '{print $3}')
+               if [ ! -z "$IMPL" ] && [ ! -z "$PART" ]; then
+                   echo "ARM $ARCH (Implementer: $IMPL, Part: $PART)"
+               else
+                   echo "ARM $ARCH"
+               fi
+           else
+               echo "ARM $ARCH"
+           fi
+       fi
+   else
+       echo "Unknown architecture: $ARCH"
+   fi
+}
+
+# Check if Apache Cloudberry is installed and display its version
+if rpm -q apache-cloudberry-db-incubating > /dev/null 2>&1; then
+    CBDB_VERSION=$(/usr/local/cbdb/bin/postgres --gp-version)
+else
+    CBDB_VERSION="Not installed"
+fi
+
+cat <<-EOF
+Welcome to the Apache Cloudberry Test Environment!
+
+Cloudberry version .. : $CBDB_VERSION
+Container OS ........ : $NAME $VERSION
+User ................ : $(whoami)
+Container hostname .. : $(hostname)
+IP Address .......... : $(hostname -I | awk '{print $1}')
+CPU Info ............ : $(get_cpu_info)
+CPU(s) .............. : $(nproc)
+Memory .............. : $(free -h | grep Mem: | awk '{print $2}') total
+======================================================================
+
+EOF
+
+# --------------------------------------------------------------------
+# Start an interactive bash shell
+# --------------------------------------------------------------------
+# Finally, the script starts an interactive bash shell to keep the
+# container running and allow the user to interact with the environment.
+# --------------------------------------------------------------------
+/bin/bash

--- a/deploy/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec
+++ b/deploy/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec
@@ -1,0 +1,161 @@
+%define cloudberry_install_dir /usr/local/cloudberry-db
+
+# Add at the top of the spec file
+# Default to non-debug build
+%bcond_with debug
+
+# Conditional stripping based on debug flag
+%if %{with debug}
+%define __os_install_post %{nil}
+%define __strip /bin/true
+%endif
+
+Name:           apache-cloudberry-db-incubating
+Version:        %{version}
+# In the release definition section
+%if %{with debug}
+Release:        %{release}.debug%{?dist}
+%else
+Release:        %{release}%{?dist}
+%endif
+Summary:        High-performance, open-source data warehouse based on PostgreSQL/Greenplum
+
+License:        ASL 2.0
+URL:            https://cloudberry.apache.org
+Vendor:         Apache Cloudberry (incubating)
+Group:          Applications/Databases
+Prefix:         %{cloudberry_install_dir}
+
+# Disabled as we are shipping GO programs (e.g. gpbackup)
+%define _missing_build_ids_terminate_build 0
+
+# Disable debugsource files
+%define _debugsource_template %{nil}
+
+# List runtime dependencies
+
+Requires:       bash
+Requires:       iproute
+Requires:       iputils
+Requires:       openssh
+Requires:       openssh-clients
+Requires:       openssh-server
+Requires:       rsync
+
+%if 0%{?rhel} == 8
+Requires:       apr
+Requires:       audit
+Requires:       bzip2
+Requires:       keyutils
+Requires:       libcurl
+Requires:       libevent
+Requires:       libidn2
+Requires:       libselinux
+Requires:       libstdc++
+Requires:       libuuid
+Requires:       libuv
+Requires:       libxml2
+Requires:       libyaml
+Requires:       libzstd
+Requires:       lz4
+Requires:       openldap
+Requires:       pam
+Requires:       perl
+Requires:       python3
+Requires:       readline
+%endif
+
+%if 0%{?rhel} == 9
+Requires:       apr
+Requires:       bzip2
+Requires:       glibc
+Requires:       keyutils
+Requires:       libcap
+Requires:       libcurl
+Requires:       libidn2
+Requires:       libpsl
+Requires:       libssh
+Requires:       libstdc++
+Requires:       libxml2
+Requires:       libyaml
+Requires:       libzstd
+Requires:       lz4
+Requires:       openldap
+Requires:       pam
+Requires:       pcre2
+Requires:       perl
+Requires:       readline
+Requires:       xz
+%endif
+
+%description
+
+Apache Cloudberry (incubating) is an advanced, open-source, massively
+parallel processing (MPP) data warehouse developed from PostgreSQL and
+Greenplum. It is designed for high-performance analytics on
+large-scale data sets, offering powerful analytical capabilities and
+enhanced security features.
+
+Key Features:
+
+- Massively parallel processing for optimized performance
+- Advanced analytics for complex data processing
+- Integration with ETL and BI tools
+- Compatibility with multiple data sources and formats
+- Enhanced security features
+
+Apache Cloudberry supports both batch processing and real-time data
+warehousing, making it a versatile solution for modern data
+environments.
+
+Apache Cloudberry (incubating) is an effort undergoing incubation at
+the Apache Software Foundation (ASF), sponsored by the Apache
+Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further
+review indicates that the infrastructure, communications, and decision
+making process have stabilized in a manner consistent with other
+successful ASF projects.
+
+While incubation status is not necessarily a reflection of the
+completeness or stability of the code, it does indicate that the
+project has yet to be fully endorsed by the ASF.
+
+%prep
+# No prep needed for binary RPM
+
+%build
+# No prep needed for binary RPM
+
+%install
+rm -rf %{buildroot}
+
+# Create the versioned directory
+mkdir -p %{buildroot}%{cloudberry_install_dir}-%{version}
+
+cp -R %{cloudberry_install_dir}/* %{buildroot}%{cloudberry_install_dir}-%{version}
+
+# Create the symbolic link
+ln -sfn %{cloudberry_install_dir}-%{version} %{buildroot}%{cloudberry_install_dir}
+
+%files
+%{prefix}-%{version}
+%{prefix}
+
+%license %{cloudberry_install_dir}-%{version}/LICENSE
+
+%debug_package
+
+%post
+# Change ownership to gpadmin.gpadmin if the gpadmin user exists
+if id "gpadmin" &>/dev/null; then
+    chown -R gpadmin:gpadmin %{cloudberry_install_dir}-%{version}
+    chown gpadmin:gpadmin %{cloudberry_install_dir}
+fi
+
+%postun
+if [ $1 -eq 0 ] ; then
+  if [ "$(readlink -f "%{cloudberry_install_dir}")" == "%{cloudberry_install_dir}-%{version}" ]; then
+    unlink "%{cloudberry_install_dir}" || true
+  fi
+fi

--- a/deploy/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec
+++ b/deploy/packaging/rpm/el/SPECS/apache-cloudberry-db-incubating.spec
@@ -1,3 +1,22 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
 %define cloudberry_install_dir /usr/local/cloudberry-db
 
 # Add at the top of the spec file

--- a/deploy/packaging/rpm/el/SPECS/apache-cloudberry-hll-incubating.spec
+++ b/deploy/packaging/rpm/el/SPECS/apache-cloudberry-hll-incubating.spec
@@ -1,0 +1,51 @@
+%global cloudberry_version %{?_cloudberry_version}%{!?_cloudberry_version:1.6}
+%global cloudberry_install_dir /usr/local/cloudberry-db
+
+Name:           apache-cloudberry-hll-incubating
+Version:        2.18.0
+Release:        %{?release}%{!?release:1}
+Summary:        HyperLogLog extension for Cloudberry Database %{cloudberry_version}
+License:        ASL 2.0
+URL:            https://github.com/citusdata/postgresql-hll
+Vendor:         Apache Cloudberry (incubating)
+Group:          Applications/Databases
+BuildArch:      x86_64
+Requires:       apache-cloudberry-db-incubating >= %{cloudberry_version}
+Prefix:         %{cloudberry_install_dir}
+
+%description
+HLL is an open-source PostgreSQL extension (compatible with Apache
+Cloudberry (incubating) %{cloudberry_version}) adding HyperLogLog data
+structures as a native data type. HyperLogLog is a fixed-size,
+set-like structure used for distinct value counting with tunable
+precision.
+
+%prep
+# No prep needed for binary RPM
+
+%build
+# No build needed for binary RPM
+
+%install
+mkdir -p %{buildroot}%{prefix}/lib/postgresql \
+         %{buildroot}%{prefix}/share/postgresql/extension
+
+cp -R %{cloudberry_install_dir}/lib/postgresql/hll.so \
+      %{buildroot}%{prefix}/lib/postgresql/hll.so
+
+cp -R %{cloudberry_install_dir}/share/postgresql/extension/hll* \
+      %{buildroot}%{prefix}/share/postgresql/extension
+
+%files
+%{prefix}/lib/postgresql/hll.so
+%{prefix}/share/postgresql/extension/hll--*.sql
+%{prefix}/share/postgresql/extension/hll.control
+
+%post
+echo "HLL extension for Cloudberry Database %{cloudberry_version} has been installed in %{prefix}."
+echo "To enable it in a database, run:"
+echo "  CREATE EXTENSION hll;"
+
+%postun
+echo "HLL extension for Cloudberry Database %{cloudberry_version} has been removed from %{prefix}."
+echo "You may need to manually clean up any database objects that were using the extension."

--- a/deploy/packaging/rpm/el/SPECS/apache-cloudberry-hll-incubating.spec
+++ b/deploy/packaging/rpm/el/SPECS/apache-cloudberry-hll-incubating.spec
@@ -1,3 +1,22 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
 %global cloudberry_version %{?_cloudberry_version}%{!?_cloudberry_version:1.6}
 %global cloudberry_install_dir /usr/local/cloudberry-db
 

--- a/deploy/packaging/rpm/el/SPECS/apache-cloudberry-pgvector-incubating.spec
+++ b/deploy/packaging/rpm/el/SPECS/apache-cloudberry-pgvector-incubating.spec
@@ -1,0 +1,53 @@
+%global cloudberry_version %{?_cloudberry_version}%{!?_cloudberry_version:1.6}
+%global cloudberry_install_dir /usr/local/cloudberry-db
+%global pgvector_version %{?_pgvector_version}%{!?_pgvector_version:0.5.1}
+
+Name:           cloudberry-pgvector
+Version:        %{pgvector_version}
+Release:        %{?release}%{!?release:1}
+Summary:        pgvector extension for Cloudberry Database %{cloudberry_version}
+License:        PostgreSQL
+URL:            https://github.com/pgvector/pgvector
+Vendor:         Cloudberry Open Source
+Group:          Applications/Databases
+BuildArch:      x86_64
+Requires:       cloudberry-db >= %{cloudberry_version}
+Prefix:         %{cloudberry_install_dir}
+
+%description
+pgvector is an open-source vector similarity search extension for
+PostgreSQL and Cloudberry Database %{cloudberry_version}.  It provides
+vector data types and vector similarity search functions, allowing for
+efficient similarity search operations on high-dimensional data.
+
+%prep
+# No prep needed for binary RPM
+
+%build
+# No build needed for binary RPM
+
+%install
+mkdir -p %{buildroot}%{prefix}/include/postgresql/server/extension/vector \
+         %{buildroot}%{prefix}/lib/postgresql                             \
+         %{buildroot}%{prefix}/share/postgresql/extension
+cp -R %{cloudberry_install_dir}/include/postgresql/server/extension/vector/* \
+      %{buildroot}%{prefix}/include/postgresql/server/extension/vector
+cp -R %{cloudberry_install_dir}/lib/postgresql/vector.so \
+      %{buildroot}%{prefix}/lib/postgresql/vector.so
+cp -R %{cloudberry_install_dir}/share/postgresql/extension/vector* \
+      %{buildroot}%{prefix}/share/postgresql/extension
+
+%files
+%{prefix}/include/postgresql/server/extension/vector/*
+%{prefix}/lib/postgresql/vector.so
+%{prefix}/share/postgresql/extension/vector--*.sql
+%{prefix}/share/postgresql/extension/vector.control
+
+%post
+echo "pgvector extension version %{version} for Cloudberry Database %{cloudberry_version} has been installed in %{prefix}."
+echo "To enable it in a database, run:"
+echo "  CREATE EXTENSION vector;"
+
+%postun
+echo "pgvector extension version %{version} for Cloudberry Database %{cloudberry_version} has been removed from %{prefix}."
+echo "You may need to manually clean up any database objects that were using the extension."

--- a/deploy/packaging/rpm/el/SPECS/apache-cloudberry-pgvector-incubating.spec
+++ b/deploy/packaging/rpm/el/SPECS/apache-cloudberry-pgvector-incubating.spec
@@ -1,3 +1,22 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
 %global cloudberry_version %{?_cloudberry_version}%{!?_cloudberry_version:1.6}
 %global cloudberry_install_dir /usr/local/cloudberry-db
 %global pgvector_version %{?_pgvector_version}%{!?_pgvector_version:0.5.1}

--- a/deploy/packaging/rpm/repo-el/SPECS/cloudberry-dev-repo.spec
+++ b/deploy/packaging/rpm/repo-el/SPECS/cloudberry-dev-repo.spec
@@ -1,0 +1,35 @@
+Name:           cloudberry-dev-repo
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Cloudberry Database Repository Configuration
+License:        ASL 2.0
+Group:          Applications/Databases
+URL:            https://cloudberrydb.org
+Vendor:         Cloudberry Open Source
+BuildArch:      noarch
+
+%description
+This package configures the Cloudberry Database repository on your
+system. Cloudberry Database is an open-source project aimed at
+providing a scalable, high-performance SQL database for
+analytics. This repository provides access to the latest RPM packages
+for Cloudberry Database, allowing you to easily install and stay
+up-to-date with the latest developments.
+
+%install
+mkdir -p %{buildroot}%{_sysconfdir}/yum.repos.d/
+cat > %{buildroot}%{_sysconfdir}/yum.repos.d/cloudberry-dev.repo <<EOF
+[cloudberry-dev]
+name=Cloudberry Database Repository
+baseurl=https://cloudberry-rpm-dev-bucket.s3.amazonaws.com/repo/el%{rhel}/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://cloudberry-rpm-dev-bucket.s3.amazonaws.com/repo/el%{rhel}/x86_64/RPM-GPG-KEY-cloudberry
+EOF
+
+%files
+%{_sysconfdir}/yum.repos.d/cloudberry-dev.repo
+
+%changelog
+* Thu Aug 21 2024 Ed Espino  eespino@gmail.com - 1.0-1
+- Initial package with repository configuration

--- a/deploy/packaging/rpm/repo-el/SPECS/cloudberry-dev-repo.spec
+++ b/deploy/packaging/rpm/repo-el/SPECS/cloudberry-dev-repo.spec
@@ -1,3 +1,22 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
 Name:           cloudberry-dev-repo
 Version:        1.0
 Release:        1%{?dist}

--- a/deploy/scripts/build-rpm.sh
+++ b/deploy/scripts/build-rpm.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+#
+# Script Name: build-rpm.sh
+#
+# Description:
+# This script automates the process of building an RPM package using a specified
+# version and release number. It ensures that the necessary tools are installed
+# and that the spec file exists before attempting to build the RPM. The script
+# also includes error handling to provide meaningful feedback in case of failure.
+#
+# Usage:
+# ./build-rpm.sh -v <version> [-r <release>] [-d|--with-debug] [-h] [--dry-run]
+#
+# Options:
+#   -v, --version <version>    : Specify the version (required)
+#   -r, --release <release>    : Specify the release (optional, default is 1)
+#   -d, --with-debug           : Build with debug symbols (optional)
+#   -h, --help                 : Display this help and exit
+#   -n, --dry-run              : Show what would be done, without making any changes
+#
+# Example:
+#   ./build-rpm.sh -v 1.5.5 -r 2          # Build with version 1.5.5 and release 2
+#   ./build-rpm.sh -v 1.5.5               # Build with version 1.5.5 and default release 1
+#   ./build-rpm.sh -v 1.5.5 --with-debug  # Build with debug symbols
+#
+# Prerequisites:
+# - The rpm-build package must be installed (provides the rpmbuild command).
+# - The spec file must exist at ~/rpmbuild/SPECS/apache-cloudberry-db-incubating.spec.
+#
+# Error Handling:
+# The script includes checks to ensure:
+# - The version option (-v or --version) is provided.
+# - The necessary commands are available.
+# - The spec file exists at the specified location.
+# If any of these checks fail, the script exits with an appropriate error message.
+
+# Enable strict mode for better error handling
+set -euo pipefail
+
+# Default values
+VERSION=""
+RELEASE="1"
+DEBUG_BUILD=false
+
+# Function to display usage information
+usage() {
+  echo "Usage: $0 -v <version> [-r <release>] [-h] [--dry-run]"
+  echo "  -v, --version <version>    : Specify the version (required)"
+  echo "  -r, --release <release>    : Specify the release (optional, default is 1)"
+  echo "  -d, --with-debug           : Build with debug symbols (optional)"
+  echo "  -h, --help                 : Display this help and exit"
+  echo "  -n, --dry-run              : Show what would be done, without making any changes"
+  exit 1
+}
+
+# Function to check if required commands are available
+check_commands() {
+  local cmds=("rpmbuild")
+  for cmd in "${cmds[@]}"; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "Error: Required command '$cmd' not found. Please install it before running the script."
+      exit 1
+    fi
+  done
+}
+
+# Parse options
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -v|--version)
+      VERSION="$2"
+      shift 2
+      ;;
+    -r|--release)
+      RELEASE="$2"
+      shift 2
+      ;;
+    -d|--with-debug)
+      DEBUG_BUILD=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -n|--dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: ($1)"
+      shift
+      ;;
+  esac
+done
+
+# Ensure version is provided
+if [ -z "$VERSION" ]; then
+  echo "Error: Version (-v or --version) is required."
+  usage
+fi
+
+# Check if required commands are available
+check_commands
+
+# Define the spec file path
+SPEC_FILE=~/rpmbuild/SPECS/apache-cloudberry-db-incubating.spec
+
+# Check if the spec file exists
+if [ ! -f "$SPEC_FILE" ]; then
+  echo "Error: Spec file not found at $SPEC_FILE."
+  exit 1
+fi
+
+# Build the rpmbuild command based on options
+RPMBUILD_CMD="rpmbuild -bb \"$SPEC_FILE\" --define \"version $VERSION\" --define \"release $RELEASE\""
+if [ "$DEBUG_BUILD" = true ]; then
+    RPMBUILD_CMD+=" --with debug"
+fi
+
+# Dry-run mode
+if [ "${DRY_RUN:-false}" = true ]; then
+  echo "Dry-run mode: This is what would be done:"
+  echo "  $RPMBUILD_CMD"
+  exit 0
+fi
+
+# Run rpmbuild with the provided options
+echo "Building RPM with Version: $VERSION, Release: $RELEASE$([ "$DEBUG_BUILD" = true ] && echo ", Debug: enabled")..."
+if ! eval "$RPMBUILD_CMD"; then
+  echo "Error: rpmbuild failed."
+  exit 1
+fi
+
+# Print completion message
+echo "RPM build completed successfully with Version: $VERSION, Release: $RELEASE"

--- a/deploy/scripts/build-rpm.sh
+++ b/deploy/scripts/build-rpm.sh
@@ -1,3 +1,23 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
 #!/bin/bash
 #
 # Script Name: build-rpm.sh

--- a/deploy/scripts/elf_rockylinux_dependency_analyzer.py
+++ b/deploy/scripts/elf_rockylinux_dependency_analyzer.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+
+"""
+ELF Dependency Analyzer
+
+This script analyzes ELF (Executable and Linkable Format) binaries to determine their runtime
+package dependencies. It can process individual files or recursively analyze directories.
+
+The script provides information about:
+- Required packages and their versions
+- Missing libraries
+- Custom or non-RPM libraries
+- Other special cases
+
+It also groups packages by their high-level dependencies, which can be cached for performance.
+
+Usage:
+    python3 elf_dependency_analyzer.py [--rebuild-cache] <file_or_directory> [<file_or_directory> ...]
+
+The script will automatically determine if each argument is a file or directory and process accordingly.
+Use --rebuild-cache to force rebuilding of the high-level packages cache.
+
+Requirements:
+- Python 3.6+
+- prettytable (pip install prettytable)
+- python-dateutil (pip install python-dateutil)
+- ldd (usually pre-installed on Linux systems)
+- file (usually pre-installed on Linux systems)
+- rpm (usually pre-installed on RPM-based Linux distributions)
+- repoquery (part of yum-utils package)
+
+Functions:
+- check_requirements(): Checks if all required commands are available.
+- run_command(command): Executes a shell command and returns its output.
+- parse_ldd_line(line): Parses a line of ldd output to extract the library name.
+- find_library_in_ld_library_path(lib_name): Searches for a library in LD_LIBRARY_PATH.
+- get_package_info(lib_path): Gets package information for a given library.
+- get_package_dependencies(package): Gets dependencies of a package using repoquery.
+- build_high_level_packages(grand_summary): Builds a mapping of high-level packages to their dependencies.
+- load_or_build_high_level_packages(grand_summary, force_rebuild): Loads or builds the high-level packages cache.
+- print_summary(packages, special_cases, missing_libraries, binary_path): Prints a summary for a single binary.
+- process_binary(binary_path): Processes a single binary file.
+- is_elf_binary(file_path): Checks if a file is an ELF binary.
+- print_grand_summary(...): Prints a grand summary of all processed binaries.
+- analyze_path(path, grand_summary, grand_special_cases, grand_missing_libraries): Analyzes a file or directory.
+- main(): Main function to handle command-line arguments and initiate the analysis.
+
+This script is designed to help system administrators and developers understand the dependencies
+of ELF binaries in their systems, which can be useful for troubleshooting, optimizing, or
+preparing deployment packages.
+"""
+
+import os, subprocess, re, sys, json, shutil
+from collections import defaultdict
+from datetime import datetime, timedelta
+import argparse
+from prettytable import PrettyTable
+from dateutil import parser
+
+CACHE_FILE = 'high_level_packages_cache.json'
+CACHE_EXPIRY_DAYS = 7
+
+def check_requirements():
+    required_commands = ['ldd', 'file', 'rpm', 'repoquery']
+    missing_commands = [cmd for cmd in required_commands if shutil.which(cmd) is None]
+    if missing_commands:
+        print("Error: The following required commands are missing:")
+        for cmd in missing_commands:
+            print(f"  - {cmd}")
+        print("\nPlease install these commands and try again.")
+        if 'repoquery' in missing_commands:
+            print("Note: 'repoquery' is typically part of the 'yum-utils' package.")
+        sys.exit(1)
+
+def run_command(command):
+    try:
+        return subprocess.check_output(command, stderr=subprocess.STDOUT).decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        print(f"Error running command {' '.join(command)}: {e.output.decode('utf-8').strip()}")
+        return None
+
+def parse_ldd_line(line):
+    match = re.search(r'\s*(\S+) => (\S+) \((0x[0-9a-f]+)\)', line)
+    return match.group(1) if match else None
+
+def find_library_in_ld_library_path(lib_name):
+    ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
+    for directory in ld_library_path.split(':'):
+        potential_path = os.path.join(directory, lib_name)
+        if os.path.isfile(potential_path):
+            return potential_path
+    return None
+
+def get_package_info(lib_path):
+    if not os.path.isfile(lib_path):
+        lib_name = os.path.basename(lib_path)
+        lib_path = find_library_in_ld_library_path(lib_name)
+        if not lib_path:
+            return None
+    try:
+        full_package_name = run_command(['rpm', '-qf', lib_path])
+        if full_package_name:
+            package_name = full_package_name.split('-')[0]
+            return package_name, full_package_name.strip()
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+def get_package_dependencies(package):
+    try:
+        output = subprocess.check_output(['repoquery', '--requires', '--resolve', package],
+                                         universal_newlines=True, stderr=subprocess.DEVNULL)
+        return set(output.strip().split('\n'))
+    except subprocess.CalledProcessError:
+        return set()
+
+def build_high_level_packages(grand_summary):
+    all_packages = set()
+    for packages in grand_summary.values():
+        all_packages.update(package.split('-')[0] for package in packages)
+    high_level_packages = {}
+    for package in all_packages:
+        deps = get_package_dependencies(package)
+        if deps:
+            high_level_packages[package] = [dep.split('-')[0] for dep in deps]
+    return high_level_packages
+
+def load_or_build_high_level_packages(grand_summary, force_rebuild=False):
+    if not force_rebuild and os.path.exists(CACHE_FILE):
+        with open(CACHE_FILE, 'r') as f:
+            cache_data = json.load(f)
+        if datetime.now() - parser.parse(cache_data['timestamp']) < timedelta(days=CACHE_EXPIRY_DAYS):
+            return cache_data['packages']
+    packages = build_high_level_packages(grand_summary)
+    with open(CACHE_FILE, 'w') as f:
+        json.dump({'timestamp': datetime.now().isoformat(), 'packages': packages}, f)
+    return packages
+
+def print_summary(packages, special_cases, missing_libraries, binary_path):
+    print("\nSummary of unique runtime packages required:")
+    table = PrettyTable(['Package Name', 'Full Package Name'])
+    table.align['Package Name'] = 'l'
+    table.align['Full Package Name'] = 'l'
+    unique_packages = sorted(set(packages))
+    for package_name, full_package_name in unique_packages:
+        table.add_row([package_name, full_package_name])
+    print(table)
+    if missing_libraries:
+        print("\nMISSING LIBRARIES:")
+        missing_table = PrettyTable(['Missing Library', 'Referenced By'])
+        missing_table.align['Missing Library'] = 'l'
+        missing_table.align['Referenced By'] = 'l'
+        for lib in missing_libraries:
+            missing_table.add_row([lib, binary_path])
+        print(missing_table)
+    if special_cases:
+        print("\nSPECIAL CASES:")
+        special_table = PrettyTable(['Library/Case', 'Referenced By', 'Category'])
+        special_table.align['Library/Case'] = 'l'
+        special_table.align['Referenced By'] = 'l'
+        special_table.align['Category'] = 'l'
+        for case in special_cases:
+            category = "Custom/Non-RPM" if "custom or non-RPM library" in case else "Other"
+            library = case.split(" is ")[0] if " is " in case else case
+            special_table.add_row([library, binary_path, category])
+        print(special_table)
+    else:
+        print("\nSPECIAL CASES: None found")
+
+def process_binary(binary_path):
+    print(f"Binary: {binary_path}\n")
+    print("Libraries and their corresponding packages:")
+    packages, special_cases, missing_libraries = [], [], []
+    known_special_cases = ['linux-vdso.so.1', 'ld-linux-x86-64.so.2']
+    ldd_output = run_command(['ldd', binary_path])
+    if ldd_output is None:
+        return packages, special_cases, missing_libraries
+    for line in ldd_output.splitlines():
+        if any(special in line for special in known_special_cases):
+            continue
+        parts = line.split('=>')
+        lib_name = parts[0].strip()
+        if "not found" in line:
+            missing_libraries.append(lib_name)
+            print(f"MISSING: {line.strip()}")
+        else:
+            if len(parts) > 1:
+                lib_path = parts[1].split()[0]
+                if lib_path != "not":
+                    package_info = get_package_info(lib_path)
+                    if package_info:
+                        print(f"{lib_path} => {package_info[1]}")
+                        packages.append(package_info)
+                    else:
+                        if os.path.exists(lib_path):
+                            special_case = f"{lib_path} is a custom or non-RPM library"
+                            special_cases.append(special_case)
+                            print(f"{lib_path} => Custom or non-RPM library")
+                        else:
+                            special_case = f"{lib_path} is not found and might be a special case"
+                            special_cases.append(special_case)
+                            print(f"{lib_path} => Not found, might be a special case")
+                else:
+                    special_case = f"{line.strip()} is a special case or built-in library"
+                    special_cases.append(special_case)
+                    print(f"{line.strip()} => Special case or built-in library")
+            else:
+                special_case = f"{line.strip()} is a special case or built-in library"
+                special_cases.append(special_case)
+                print(f"{line.strip()} => Special case or built-in library")
+    if special_cases:
+        print(f"Special cases found for {binary_path}:")
+        for case in special_cases:
+            print(f"  - {case}")
+    else:
+        print(f"No special cases found for {binary_path}")
+    print_summary(packages, special_cases, missing_libraries, binary_path)
+    print("-------------------------------------------")
+    return packages, special_cases, missing_libraries
+
+def is_elf_binary(file_path):
+    file_output = run_command(['file', file_path])
+    return 'ELF' in file_output and ('executable' in file_output or 'shared object' in file_output)
+
+def print_grand_summary(grand_summary, grand_special_cases, grand_missing_libraries, HIGH_LEVEL_PACKAGES, PACKAGE_TO_HIGH_LEVEL):
+    if grand_summary or grand_special_cases or grand_missing_libraries:
+        print("\nGrand Summary of high-level runtime packages required across all binaries:")
+        high_level_summary = defaultdict(set)
+        for package_name, full_package_names in grand_summary.items():
+            high_level_package = PACKAGE_TO_HIGH_LEVEL.get(package_name.split('-')[0], package_name.split('-')[0])
+            high_level_summary[high_level_package].update(full_package_names)
+        table = PrettyTable(['High-Level Package', 'Included Packages'])
+        table.align['High-Level Package'] = 'l'
+        table.align['Included Packages'] = 'l'
+        for high_level_package, full_package_names in sorted(high_level_summary.items()):
+            included_packages = '\n'.join(sorted(full_package_names))
+            table.add_row([high_level_package, included_packages])
+        print(table)
+        if grand_missing_libraries:
+            print("\nGrand Summary of MISSING LIBRARIES across all binaries:")
+            missing_table = PrettyTable(['Missing Library', 'Referenced By'])
+            missing_table.align['Missing Library'] = 'l'
+            missing_table.align['Referenced By'] = 'l'
+            for lib, binaries in sorted(grand_missing_libraries.items()):
+                missing_table.add_row([lib, '\n'.join(sorted(binaries))])
+            print(missing_table)
+        print("\nGrand Summary of special cases across all binaries:")
+        if grand_special_cases:
+            special_table = PrettyTable(['Library/Case', 'Referenced By', 'Category'])
+            special_table.align['Library/Case'] = 'l'
+            special_table.align['Referenced By'] = 'l'
+            special_table.align['Category'] = 'l'
+            for case, binary in sorted(set(grand_special_cases)):
+                category = "Custom/Non-RPM" if "custom or non-RPM library" in case else "Other"
+                library = case.split(" is ")[0] if " is " in case else case
+                special_table.add_row([library, binary, category])
+            print(special_table)
+        else:
+            print("No special cases found.")
+
+def analyze_path(path, grand_summary, grand_special_cases, grand_missing_libraries):
+    if os.path.isfile(path):
+        packages, special_cases, missing_libraries = process_binary(path)
+        for package_name, full_package_name in packages:
+            grand_summary[package_name].add(full_package_name)
+        grand_special_cases.extend((case, path) for case in special_cases)
+        for lib in missing_libraries:
+            grand_missing_libraries[lib].add(path)
+    elif os.path.isdir(path):
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                file_path = os.path.join(root, file)
+                if is_elf_binary(file_path):
+                    packages, special_cases, missing_libraries = process_binary(file_path)
+                    for package_name, full_package_name in packages:
+                        grand_summary[package_name].add(full_package_name)
+                    grand_special_cases.extend((case, file_path) for case in special_cases)
+                    for lib in missing_libraries:
+                        grand_missing_libraries[lib].add(file_path)
+    else:
+        print(f"Error: {path} is neither a valid file nor a directory.")
+    if grand_special_cases:
+        print(f"Accumulated special cases after processing {path}:")
+        for case, binary in grand_special_cases:
+            print(f"  - {case} (in {binary})")
+    else:
+        print(f"No special cases accumulated after processing {path}")
+
+def main():
+    check_requirements()
+    parser = argparse.ArgumentParser(description="ELF Dependency Analyzer")
+    parser.add_argument('paths', nargs='+', help="Paths to files or directories to analyze")
+    parser.add_argument('--rebuild-cache', action='store_true', help="Force rebuild of the high-level packages cache")
+    args = parser.parse_args()
+    grand_summary = defaultdict(set)
+    grand_special_cases = []
+    grand_missing_libraries = defaultdict(set)
+    for path in args.paths:
+        analyze_path(path, grand_summary, grand_special_cases, grand_missing_libraries)
+    HIGH_LEVEL_PACKAGES = load_or_build_high_level_packages(grand_summary, args.rebuild_cache)
+    PACKAGE_TO_HIGH_LEVEL = {low: high for high, lows in HIGH_LEVEL_PACKAGES.items() for low in lows}
+    print_grand_summary(grand_summary, grand_special_cases, grand_missing_libraries, HIGH_LEVEL_PACKAGES, PACKAGE_TO_HIGH_LEVEL)
+
+if __name__ == '__main__':
+    main()

--- a/deploy/scripts/elf_rockylinux_dependency_analyzer.py
+++ b/deploy/scripts/elf_rockylinux_dependency_analyzer.py
@@ -1,3 +1,23 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
 #!/usr/bin/env python3
 
 """

--- a/deploy/scripts/elf_ubuntu_dependency_analyzer.py
+++ b/deploy/scripts/elf_ubuntu_dependency_analyzer.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+
+"""
+ELF Dependency Analyzer for Ubuntu
+
+This script analyzes ELF (Executable and Linkable Format) binaries to determine their runtime
+package dependencies on Ubuntu systems. It can process individual files or recursively analyze directories.
+
+The script provides information about:
+- Required packages and their versions
+- Custom or non-APT libraries
+- Core system libraries
+- Missing libraries
+- Other special cases
+
+Usage:
+    python3 elf_dependency_analyzer.py [file_or_directory] [file_or_directory] ...
+
+Requirements:
+- Python 3.6+
+- prettytable (pip install prettytable)
+- ldd (usually pre-installed on Linux systems)
+- file (usually pre-installed on Linux systems)
+- dpkg (pre-installed on Ubuntu)
+"""
+
+import os
+import subprocess
+import re
+import sys
+import argparse
+from collections import defaultdict
+from prettytable import PrettyTable
+
+def run_command(command):
+    """
+    Execute a shell command and return its output.
+
+    Args:
+    command (list): The command to execute as a list of strings.
+
+    Returns:
+    str: The output of the command, or None if an error occurred.
+    """
+    try:
+        return subprocess.check_output(command, stderr=subprocess.STDOUT).decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        print(f"Error running command {' '.join(command)}: {e.output.decode('utf-8').strip()}")
+        return None
+
+def get_package_info(lib_path):
+    """
+    Get package information for a given library path.
+
+    Args:
+    lib_path (str): The path to the library.
+
+    Returns:
+    tuple: A tuple containing the package name and full package information.
+    """
+    if lib_path.startswith('/usr/local/cloudberry-db'):
+        return "cloudberry-custom", f"Cloudberry custom library: {lib_path}"
+
+    dpkg_output = run_command(['dpkg', '-S', lib_path])
+    if dpkg_output:
+        package_name = dpkg_output.split(':')[0]
+        return package_name, dpkg_output.strip()
+
+    # List of core system libraries that might not be individually tracked by dpkg
+    core_libs = {
+        'libc.so': 'libc6',
+        'libm.so': 'libc6',
+        'libdl.so': 'libc6',
+        'libpthread.so': 'libc6',
+        'libresolv.so': 'libc6',
+        'librt.so': 'libc6',
+        'libgcc_s.so': 'libgcc-s1',
+        'libstdc++.so': 'libstdc++6',
+        'libz.so': 'zlib1g',
+        'libbz2.so': 'libbz2-1.0',
+        'libpam.so': 'libpam0g',
+        'libaudit.so': 'libaudit1',
+        'libcap-ng.so': 'libcap-ng0',
+        'libkeyutils.so': 'libkeyutils1',
+        'liblzma.so': 'liblzma5',
+        'libcom_err.so': 'libcomerr2'
+    }
+
+    lib_name = os.path.basename(lib_path)
+    for core_lib, package in core_libs.items():
+        if lib_name.startswith(core_lib):
+            return package, f"Core system library: {lib_path}"
+
+    # If not a recognized core library, return as system library
+    file_output = run_command(['file', lib_path])
+    if file_output:
+        return "system-library", f"System library: {lib_path} - {file_output.strip()}"
+
+    return None
+
+def print_summary(packages, special_cases, missing_libraries, binary_path):
+    """
+    Print a summary of the dependencies for a binary.
+
+    Args:
+    packages (list): List of package tuples (package_name, full_package_name).
+    special_cases (list): List of special case strings.
+    missing_libraries (list): List of missing library names.
+    binary_path (str): Path to the binary being analyzed.
+    """
+    print("\nSummary of runtime dependencies:")
+    table = PrettyTable(['Category', 'Package/Library', 'Details'])
+    table.align['Category'] = 'l'
+    table.align['Package/Library'] = 'l'
+    table.align['Details'] = 'l'
+
+    categories = {
+        'cloudberry-custom': 'Cloudberry Custom',
+        'system-library': 'System Library',
+    }
+
+    for package_name, full_package_name in sorted(set(packages)):
+        category = categories.get(package_name, 'System Package')
+        table.add_row([category, package_name, full_package_name])
+
+    print(table)
+
+    if missing_libraries:
+        print("\nMISSING LIBRARIES:")
+        for lib in missing_libraries:
+            print(f"  - {lib}")
+
+    if special_cases:
+        print("\nSPECIAL CASES:")
+        for case in special_cases:
+            print(f"  - {case}")
+
+def process_binary(binary_path):
+    """
+    Process a single binary file to determine its dependencies.
+
+    Args:
+    binary_path (str): Path to the binary file.
+
+    Returns:
+    tuple: A tuple containing lists of packages, special cases, and missing libraries.
+    """
+    print(f"Binary: {binary_path}\n")
+    print("Libraries and their corresponding packages:")
+    packages, special_cases, missing_libraries = [], [], []
+
+    ldd_output = run_command(['ldd', binary_path])
+    if ldd_output is None:
+        return packages, special_cases, missing_libraries
+
+    for line in ldd_output.splitlines():
+        if "=>" not in line:
+            continue
+
+        parts = line.split('=>')
+        lib_name = parts[0].strip()
+        lib_path = parts[1].split()[0].strip()
+        lib_path = os.path.realpath(lib_path)
+
+        if lib_path == "not":
+            missing_libraries.append(lib_name)
+            print(f"MISSING: {line.strip()}")
+        else:
+            package_info = get_package_info(lib_path)
+            if package_info:
+                print(f"{lib_path} => {package_info[1]}")
+                packages.append(package_info)
+            else:
+                special_case = f"{lib_path} is not found and might be a special case"
+                special_cases.append(special_case)
+                print(f"{lib_path} => Not found, might be a special case")
+
+    print_summary(packages, special_cases, missing_libraries, binary_path)
+    print("-------------------------------------------")
+    return packages, special_cases, missing_libraries
+
+def is_elf_binary(file_path):
+    """
+    Check if a file is an ELF binary.
+
+    Args:
+    file_path (str): Path to the file.
+
+    Returns:
+    bool: True if the file is an ELF binary, False otherwise.
+    """
+    file_output = run_command(['file', file_path])
+    return 'ELF' in file_output and ('executable' in file_output or 'shared object' in file_output)
+
+def print_grand_summary(grand_summary, grand_special_cases, grand_missing_libraries):
+    """
+    Print a grand summary of all analyzed binaries.
+
+    Args:
+    grand_summary (dict): Dictionary of all packages and their details.
+    grand_special_cases (list): List of all special cases.
+    grand_missing_libraries (dict): Dictionary of all missing libraries.
+    """
+    if grand_summary or grand_special_cases or grand_missing_libraries:
+        print("\nGrand Summary of runtime packages required across all binaries:")
+        table = PrettyTable(['Package', 'Included Packages'])
+        table.align['Package'] = 'l'
+        table.align['Included Packages'] = 'l'
+        for package_name, full_package_names in sorted(grand_summary.items()):
+            included_packages = '\n'.join(sorted(full_package_names))
+            table.add_row([package_name, included_packages])
+        print(table)
+
+        if grand_missing_libraries:
+            print("\nGrand Summary of MISSING LIBRARIES across all binaries:")
+            missing_table = PrettyTable(['Missing Library', 'Referenced By'])
+            missing_table.align['Missing Library'] = 'l'
+            missing_table.align['Referenced By'] = 'l'
+            for lib, binaries in sorted(grand_missing_libraries.items()):
+                missing_table.add_row([lib, '\n'.join(sorted(binaries))])
+            print(missing_table)
+
+        print("\nGrand Summary of special cases across all binaries:")
+        if grand_special_cases:
+            special_table = PrettyTable(['Library/Case', 'Referenced By', 'Category'])
+            special_table.align['Library/Case'] = 'l'
+            special_table.align['Referenced By'] = 'l'
+            special_table.align['Category'] = 'l'
+            for case, binary in sorted(set(grand_special_cases)):
+                category = "System Library" if "system library" in case else "Other"
+                library = case.split(" is ")[0] if " is " in case else case
+                special_table.add_row([library, binary, category])
+            print(special_table)
+        else:
+            print("No special cases found.")
+
+def analyze_path(path, grand_summary, grand_special_cases, grand_missing_libraries):
+    """
+    Analyze a file or directory for ELF binaries and their dependencies.
+
+    Args:
+    path (str): Path to the file or directory to analyze.
+    grand_summary (dict): Dictionary to store all package information.
+    grand_special_cases (list): List to store all special cases.
+    grand_missing_libraries (dict): Dictionary to store all missing libraries.
+    """
+    if os.path.isfile(path):
+        if is_elf_binary(path):
+            packages, special_cases, missing_libraries = process_binary(path)
+            for package_name, full_package_name in packages:
+                grand_summary[package_name].add(full_package_name)
+            grand_special_cases.extend((case, path) for case in special_cases)
+            for lib in missing_libraries:
+                grand_missing_libraries[lib].add(path)
+    elif os.path.isdir(path):
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                file_path = os.path.join(root, file)
+                if is_elf_binary(file_path):
+                    packages, special_cases, missing_libraries = process_binary(file_path)
+                    for package_name, full_package_name in packages:
+                        grand_summary[package_name].add(full_package_name)
+                    grand_special_cases.extend((case, file_path) for case in special_cases)
+                    for lib in missing_libraries:
+                        grand_missing_libraries[lib].add(file_path)
+    else:
+        print(f"Error: {path} is neither a valid file nor a directory.")
+
+def main():
+    """
+    Main function to handle command-line arguments and initiate the analysis.
+    """
+    parser = argparse.ArgumentParser(description="ELF Dependency Analyzer for Ubuntu")
+    parser.add_argument('paths', nargs='+', help="Paths to files or directories to analyze")
+    args = parser.parse_args()
+
+    grand_summary = defaultdict(set)
+    grand_special_cases = []
+    grand_missing_libraries = defaultdict(set)
+
+    for path in args.paths:
+        analyze_path(path, grand_summary, grand_special_cases, grand_missing_libraries)
+
+    print_grand_summary(grand_summary, grand_special_cases, grand_missing_libraries)
+
+if __name__ == '__main__':
+    main()

--- a/deploy/scripts/elf_ubuntu_dependency_analyzer.py
+++ b/deploy/scripts/elf_ubuntu_dependency_analyzer.py
@@ -1,3 +1,23 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
 #!/usr/bin/env python3
 
 """

--- a/deploy/scripts/release/cloudberry-release.sh
+++ b/deploy/scripts/release/cloudberry-release.sh
@@ -1,0 +1,496 @@
+#!/usr/bin/env bash
+# ======================================================================
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ======================================================================
+#
+# cloudberry-release.sh — Apache Cloudberry (Incubating) release utility
+#
+# This script automates the preparation of an Apache Cloudberry release
+# candidate, including version validation, tag creation, and source
+# tarball assembly.
+#
+# Supported Features:
+#   - Validates version consistency across configure.ac, configure, gpversion.py, and pom.xml
+#   - Supports both final releases and release candidates (e.g., 2.0.0-incubating, 2.0.0-incubating-rc1)
+#   - Optionally reuses existing annotated Git tags if they match the current HEAD
+#   - Verifies that Git submodules are initialized (if defined in .gitmodules)
+#   - Verifies Git identity (user.name and user.email) prior to tagging
+#   - Creates a BUILD_NUMBER file (currently hardcoded as 1) in the release tarball
+#   - Recursively archives all submodules into the source tarball
+#   - Generates SHA-512 checksum (.sha512) for the source tarball
+#   - Generates GPG signature (.asc) for the source tarball, unless --skip-signing is used
+#   - Moves signed artifacts into a dedicated artifacts/ directory
+#   - Verifies integrity and authenticity of artifacts via SHA-512 checksum and GPG signature
+#   - Allows skipping of upstream remote URL validation (e.g., for forks) via --skip-remote-check
+#
+# Usage:
+#   ./cloudberry-release.sh --stage --tag 2.0.0-incubating-rc1 --gpg-user your@apache.org
+#
+# Options:
+#   -s, --stage               Stage a release candidate and generate source tarball
+#   -t, --tag <tag>           Tag to apply or validate (e.g., 2.0.0-incubating-rc1)
+#   -f, --force-tag-reuse     Allow reuse of an existing tag (must match HEAD)
+#   -r, --repo <path>         Optional path to local Cloudberry Git repository
+#   -S, --skip-remote-check   Skip validation of remote.origin.url (useful for forks/mirrors)
+#   -g, --gpg-user <key>      GPG key ID or email to use for signing (required)
+#   -k, --skip-signing        Skip GPG key validation and signature generation
+#   -h, --help                Show usage and exit
+#
+# Requirements:
+#   - Must be run from the root of a valid Apache Cloudberry Git clone,
+#     or the path must be explicitly provided using --repo
+#   - Git user.name and user.email must be configured
+#   - Repository remote must be: git@github.com:apache/cloudberry.git
+#
+# Examples:
+#   ./cloudberry-release.sh -s -t 2.0.0-incubating-rc1 --gpg-user your@apache.org
+#   ./cloudberry-release.sh -s -t 2.0.0-incubating-rc1 --skip-signing
+#   ./cloudberry-release.sh --stage --tag 2.0.0-incubating-rc2 --force-tag-reuse --gpg-user your@apache.org
+#   ./cloudberry-release.sh --stage --tag 2.0.0-incubating-rc1 -r ~/cloudberry --skip-remote-check --gpg-user your@apache.org
+#
+# Notes:
+#   - When reusing a tag, the `--force-tag-reuse` flag must be provided.
+#   - This script creates a BUILD_NUMBER file in the source root for traceability. It is included in the tarball.
+# ======================================================================
+
+set -euo pipefail
+
+confirm() {
+  read -r -p "$1 [y/N] " response
+  case "$response" in
+    [yY][eE][sS]|[yY]) true ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+}
+
+section() {
+  echo
+  echo "================================================================="
+  echo ">> $1"
+  echo "================================================================="
+}
+
+show_help() {
+  echo "Apache Cloudberry (Incubating) Release Tool"
+  echo
+  echo "Usage:"
+  echo "  $0 --stage --tag <version-tag>"
+  echo
+  echo "Options:"
+  echo "  -s, --stage"
+  echo "      Stage a release candidate and generate source tarball"
+  echo
+  echo "  -t, --tag <tag>"
+  echo "      Required with --stage (e.g., 2.0.0-incubating-rc1)"
+  echo
+  echo "  -f, --force-tag-reuse"
+  echo "      Reuse existing tag if it matches current HEAD"
+  echo
+  echo "  -r, --repo <path>"
+  echo "      Optional path to a local Cloudberry Git repository clone"
+  echo
+  echo "  -S, --skip-remote-check"
+  echo "      Skip remote.origin.url check (use for forks or mirrors)"
+  echo "      Required for official releases:"
+  echo "        git@github.com:apache/cloudberry.git"
+  echo
+  echo "  -g, --gpg-user <key>"
+  echo "      GPG key ID or email to use for signing (required unless --skip-signing)"
+  echo
+  echo "  -k, --skip-signing"
+  echo "      Skip GPG key validation and signature generation"
+  echo
+  echo "  -h, --help"
+  echo "      Show this help message"
+  exit 1
+}
+
+# Flags
+STAGE=false
+SKIP_SIGNING=false
+TAG=""
+FORCE_TAG_REUSE=false
+REPO_ARG=""
+SKIP_REMOTE_CHECK=false
+GPG_USER=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -g|--gpg-user)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --gpg-user requires an email." >&2
+        show_help
+      fi
+      GPG_USER="$2"
+      shift 2
+      ;;
+    -s|--stage)
+      STAGE=true
+      shift
+      ;;
+    -t|--tag)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: Missing tag value after --tag" >&2
+        show_help
+      fi
+      TAG="$2"
+      shift 2
+      ;;
+    -f|--force-tag-reuse)
+      FORCE_TAG_REUSE=true
+      shift
+      ;;
+    -r|--repo)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --repo requires a path." >&2
+        show_help
+      fi
+      REPO_ARG="$2"
+      shift 2
+      ;;
+    -S|--skip-remote-check)
+      SKIP_REMOTE_CHECK=true
+      shift
+      ;;
+    -k|--skip-signing)
+      SKIP_SIGNING=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      ;;
+    *)
+      echo "ERROR: Unknown option: $1" >&2
+      show_help
+      ;;
+  esac
+done
+
+# GPG signing checks
+if [[ "$SKIP_SIGNING" != true ]]; then
+  if [[ -z "$GPG_USER" ]]; then
+    echo "ERROR: --gpg-user is required for signing the release tarball." >&2
+    show_help
+  fi
+
+  if ! gpg --list-keys "$GPG_USER" > /dev/null 2>&1; then
+    echo "ERROR: GPG key '$GPG_USER' not found in your local keyring." >&2
+    echo "Please import or generate the key before proceeding." >&2
+    exit 1
+  fi
+else
+  echo "INFO: GPG signing has been intentionally skipped (--skip-signing)."
+fi
+
+if [[ -n "$REPO_ARG" ]]; then
+  if [[ -n "$REPO_ARG" ]]; then
+    if [[ ! -d "$REPO_ARG" || ! -f "$REPO_ARG/configure.ac" ]]; then
+      echo "ERROR: '$REPO_ARG' does not appear to be a valid Cloudberry source directory."
+      echo "Expected to find a 'configure.ac' file but it is missing."
+      echo
+      echo "Hint: Make sure you passed the correct --repo path to a valid Git clone."
+      exit 1
+    fi
+    cd "$REPO_ARG"
+  elif [[ ! -f configure.ac ]]; then
+    echo "ERROR: No Cloudberry source directory specified and no 'configure.ac' found in the current directory."
+    echo
+    echo "Hint: Either run this script from the root of a Cloudberry Git clone,"
+    echo "or use the --repo <path> option to specify the source directory."
+    exit 1
+  fi
+  cd "$REPO_ARG"
+
+  if [[ ! -d ".git" ]]; then
+    echo "ERROR: '$REPO_ARG' is not a valid Git repository."
+    exit 1
+  fi
+
+  if [[ "$SKIP_REMOTE_CHECK" != true ]]; then
+    REMOTE_URL=$(git config --get remote.origin.url || true)
+    if [[ "$REMOTE_URL" != "git@github.com:apache/cloudberry.git" ]]; then
+      echo "ERROR: remote.origin.url must be set to 'git@github.com:apache/cloudberry.git' for official releases."
+      echo "  Found: '${REMOTE_URL:-<unset>}'"
+      echo
+      echo "This check ensures the release is being staged from the authoritative upstream repository."
+      echo "Use --skip-remote-check only if this is a fork or non-release automation."
+      exit 1
+    fi
+  fi
+fi
+
+# If --repo was not provided, ensure we are in a valid source directory
+if [[ -z "$REPO_ARG" ]]; then
+  if [[ ! -f configure.ac || ! -f gpMgmt/bin/gppylib/gpversion.py || ! -f pom.xml ]]; then
+    echo "ERROR: You must run this script from the root of a valid Cloudberry Git clone"
+    echo "       or pass the path using --repo <source-dir>."
+    echo
+    echo "Missing one or more expected files:"
+    echo "  - configure.ac"
+    echo "  - gpMgmt/bin/gppylib/gpversion.py"
+    echo "  - pom.xml"
+    exit 1
+  fi
+fi
+
+if ! $STAGE && [[ -z "$TAG" ]]; then
+  show_help
+fi
+
+if $STAGE && [[ -z "$TAG" ]]; then
+  echo "ERROR: --tag (-t) is required when using --stage." >&2
+  show_help
+fi
+
+section "Validating Version Consistency"
+
+# Extract version from configure.ac
+CONFIGURE_AC_VERSION=$(grep "^AC_INIT" configure.ac | sed -E "s/^AC_INIT\(\[[^]]+\], \[([^]]+)\].*/\1/")
+CONFIGURE_AC_MAJOR=$(echo "$CONFIGURE_AC_VERSION" | cut -d. -f1)
+EXPECTED="[$CONFIGURE_AC_MAJOR,99]"
+
+# Validate tag format
+SEMVER_REGEX="^${CONFIGURE_AC_MAJOR}\\.[0-9]+\\.[0-9]+(-incubating(-rc[0-9]+)?)?$"
+if ! [[ "$TAG" =~ $SEMVER_REGEX ]]; then
+  echo "ERROR: Tag '$TAG' does not match expected pattern for major version $CONFIGURE_AC_MAJOR (e.g., ${CONFIGURE_AC_MAJOR}.0.0-incubating or ${CONFIGURE_AC_MAJOR}.0.0-incubating-rc1)"
+  exit 1
+fi
+
+# Check gpversion.py consistency
+PY_LINE=$(grep "^MAIN_VERSION" gpMgmt/bin/gppylib/gpversion.py | sed -E 's/#.*//' | tr -d '[:space:]')
+
+if [[ "$PY_LINE" != "MAIN_VERSION=$EXPECTED" ]]; then
+  echo "ERROR: gpversion.py MAIN_VERSION is $PY_LINE, but configure.ac suggests $EXPECTED"
+  echo "Please correct this mismatch before proceeding."
+  exit 1
+fi
+
+# For final releases (non-RC), ensure configure.ac version matches tag exactly
+if [[ "$TAG" != *-rc* && "$CONFIGURE_AC_VERSION" != "$TAG" ]]; then
+  echo "ERROR: configure.ac version ($CONFIGURE_AC_VERSION) does not match final release tag ($TAG)"
+  echo "Please update configure.ac to match the tag before proceeding."
+  exit 1
+fi
+
+# Ensure the generated 'configure' script is up to date
+CONFIGURE_VERSION_LINE=$(grep "^PACKAGE_VERSION=" configure || true)
+CONFIGURE_VERSION=$(echo "$CONFIGURE_VERSION_LINE" | sed -E "s/^PACKAGE_VERSION='([^']+)'.*/\1/")
+
+if [[ "$CONFIGURE_VERSION" != "$TAG" ]]; then
+  echo "ERROR: Version in generated 'configure' script ($CONFIGURE_VERSION) does not match release tag ($TAG)."
+  echo "This likely means autoconf was not run after updating configure.ac."
+  exit 1
+fi
+
+# Ensure xmllint is available
+if ! command -v xmllint >/dev/null 2>&1; then
+  echo "ERROR: xmllint is required but not installed."
+  exit 1
+fi
+
+# Extract version from pom.xml using xmllint with namespace stripping
+POM_VERSION=$(xmllint --xpath '//*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml 2>/dev/null || true)
+
+if [[ -z "$POM_VERSION" ]]; then
+  echo "ERROR: Could not extract <version> from pom.xml"
+  exit 1
+fi
+
+if [[ "$POM_VERSION" != "$TAG" ]]; then
+  echo "ERROR: Version in pom.xml ($POM_VERSION) does not match release tag ($TAG)."
+  echo "Please update pom.xml before tagging."
+  exit 1
+fi
+
+# Ensure working tree is clean
+if ! git diff-index --quiet HEAD --; then
+  echo "ERROR: Working tree is not clean. Please commit or stash changes before proceeding."
+  exit 1
+fi
+
+echo "MAIN_VERSION verified"
+printf "    %-14s: %s\n" "Release Tag"   "$TAG"
+printf "    %-14s: %s\n" "configure.ac"  "$CONFIGURE_AC_VERSION"
+printf "    %-14s: %s\n" "configure"     "$CONFIGURE_VERSION"
+printf "    %-14s: %s\n" "pom.xml"       "$POM_VERSION"
+printf "    %-14s: %s\n" "gpversion.py"  "${EXPECTED//[\[\]]}"
+
+section "Checking the state of the Tag"
+
+# Check if the tag already exists before making any changes
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+  TAG_COMMIT=$(git rev-list -n 1 "$TAG")
+  HEAD_COMMIT=$(git rev-parse HEAD)
+
+  if [[ "$TAG_COMMIT" == "$HEAD_COMMIT" && "$FORCE_TAG_REUSE" == true ]]; then
+    echo "INFO: Tag '$TAG' already exists and matches HEAD. Proceeding with reuse."
+  elif [[ "$FORCE_TAG_REUSE" == true ]]; then
+    echo "ERROR: --force-tag-reuse was specified but tag '$TAG' does not match HEAD."
+    echo "       Tags must be immutable. Cannot continue."
+    exit 1
+  else
+    echo "ERROR: Tag '$TAG' already exists and does not match HEAD."
+    echo "       Use --force-tag-reuse only when HEAD matches the tag commit."
+    exit 1
+  fi
+elif [[ "$FORCE_TAG_REUSE" == true ]]; then
+  echo "ERROR: --force-tag-reuse was specified, but tag '$TAG' does not exist."
+  echo "       You can only reuse a tag if it already exists."
+  exit 1
+else
+  echo "INFO: Tag '$TAG' does not yet exist. It will be created during staging."
+fi
+
+# Check and display submodule initialization status
+if [ -s .gitmodules ]; then
+  section "Checking Git Submodules"
+
+  UNINITIALIZED=false
+  while read -r status path rest; do
+    if [[ "$status" == "-"* ]]; then
+      echo "Uninitialized: $path"
+      UNINITIALIZED=true
+    else
+      echo "Initialized  : $path"
+    fi
+  done < <(git submodule status)
+
+  if [[ "$UNINITIALIZED" == true ]]; then
+    echo
+    echo "ERROR: One or more Git submodules are not initialized."
+    echo "Please run:"
+    echo "  git submodule update --init --recursive"
+    echo "before proceeding with the release preparation."
+    exit 1
+  fi
+fi
+
+section "Checking GIT_USER_NAME and GIT_USER_EMAIL values"
+
+if $STAGE; then
+  # Validate Git environment before performing tag operation
+  GIT_USER_NAME=$(git config --get user.name || true)
+  GIT_USER_EMAIL=$(git config --get user.email || true)
+
+  echo "Git User Info:"
+  printf "    %-14s: %s\n" "user.name"  "${GIT_USER_NAME:-<unset>}"
+  printf "    %-14s: %s\n" "user.email" "${GIT_USER_EMAIL:-<unset>}"
+
+  if [[ -z "$GIT_USER_NAME" || -z "$GIT_USER_EMAIL" ]]; then
+    echo "ERROR: Git configuration is incomplete."
+    echo
+    echo "  Detected:"
+    echo "    user.name  = ${GIT_USER_NAME:-<unset>}"
+    echo "    user.email = ${GIT_USER_EMAIL:-<unset>}"
+    echo
+    echo "  Git requires both to be set in order to create annotated tags for releases."
+    echo "  You may configure them globally using:"
+    echo "    git config --global user.name \"Your Name\""
+    echo "    git config --global user.email \"your@apache.org\""
+    echo
+    echo "  Alternatively, set them just for this repo using the same commands without --global."
+    exit 1
+  fi
+
+section "Staging release: $TAG"
+
+  if [[ "$FORCE_TAG_REUSE" == false ]]; then
+    confirm "You are about to create tag '$TAG'. Continue?"
+    git tag -a "$TAG" -m "Apache Cloudberry (Incubating) ${TAG} Release Candidate"
+  else
+    echo "INFO: Reusing existing tag '$TAG'; skipping tag creation."
+  fi
+
+  echo "Creating BUILD_NUMBER file with value of 1"
+  echo "1" > BUILD_NUMBER
+
+  echo -e "\nTag Summary"
+  TAG_OBJECT=$(git rev-parse "$TAG")
+  TAG_COMMIT=$(git rev-list -n 1 "$TAG")
+  echo "$TAG (tag object): $TAG_OBJECT"
+  echo "    Points to commit: $TAG_COMMIT"
+  git log -1 --format="%C(auto)%h %d" "$TAG"
+
+  section "Creating Source Tarball"
+
+  TAR_NAME="apache-cloudberry-${TAG}-src.tar.gz"
+  TMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+
+  git archive --format=tar --prefix="apache-cloudberry-${TAG}/" "$TAG" | tar -x -C "$TMP_DIR"
+  cp BUILD_NUMBER "$TMP_DIR/apache-cloudberry-${TAG}/"
+
+  # Archive submodules if any
+  if [ -s .gitmodules ]; then
+    git submodule foreach --recursive --quiet "
+      echo \"Archiving submodule: \$sm_path\"
+      fullpath=\"\$toplevel/\$sm_path\"
+      destpath=\"$TMP_DIR/apache-cloudberry-$TAG/\$sm_path\"
+      mkdir -p \"\$destpath\"
+      git -C \"\$fullpath\" archive --format=tar --prefix=\"\$sm_path/\" HEAD | tar -x -C \"$TMP_DIR/apache-cloudberry-$TAG\"
+    "
+  fi
+
+  tar -czf "$TAR_NAME" -C "$TMP_DIR" "apache-cloudberry-${TAG}"
+  rm -rf "$TMP_DIR"
+  echo -e "Archive saved to: $TAR_NAME"
+
+  # Generate SHA-512 checksum
+  section "Generating SHA-512 Checksum"
+
+  echo -e "\nGenerating SHA-512 checksum"
+  shasum -a 512 "$TAR_NAME" > "${TAR_NAME}.sha512"
+  echo "Checksum saved to: ${TAR_NAME}.sha512"
+
+  section "Signing with GPG key: $GPG_USER"
+  # Conditionally generate GPG signature
+  if [[ "$SKIP_SIGNING" != true ]]; then
+    echo -e "\nSigning tarball with GPG key: $GPG_USER"
+    gpg --armor --detach-sign --local-user "$GPG_USER" "$TAR_NAME"
+    echo "GPG signature saved to: ${TAR_NAME}.asc"
+  else
+    echo "INFO: Skipping tarball signing as requested (--skip-signing)"
+  fi
+
+  # Move artifacts to top-level artifacts directory
+
+  ARTIFACTS_DIR="$(cd "$(dirname "$REPO_ARG")" && cd .. && pwd)/artifacts"
+  mkdir -p "$ARTIFACTS_DIR"
+
+  section "Moving Artifacts to $ARTIFACTS_DIR"
+
+  echo -e "\nMoving release artifacts to: $ARTIFACTS_DIR"
+  mv -vf "$TAR_NAME" "$ARTIFACTS_DIR/"
+  mv -vf "${TAR_NAME}.sha512" "$ARTIFACTS_DIR/"
+  [[ -f "${TAR_NAME}.asc" ]] && mv -vf "${TAR_NAME}.asc" "$ARTIFACTS_DIR/"
+
+  section "Verifying sha512 ($ARTIFACTS_DIR/${TAR_NAME}.sha512) Release Artifact"
+  cd "$ARTIFACTS_DIR"
+  sha512sum -c "$ARTIFACTS_DIR/${TAR_NAME}.sha512"
+
+  section "Verifying GPG Signature ($ARTIFACTS_DIR/${TAR_NAME}.asc) Release Artifact"
+
+  if [[ "$SKIP_SIGNING" != true ]]; then
+    gpg --verify "${TAR_NAME}.asc" "$TAR_NAME"
+  else
+    echo "INFO: Signature verification skipped (--skip-signing). Signature is only available when generated via this script."
+  fi
+
+  section "Release candidate for $TAG staged successfully"
+fi

--- a/deploy/scripts/s3-repo-sync-and-sign.sh
+++ b/deploy/scripts/s3-repo-sync-and-sign.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Description:
+# This script automates several tasks related to managing RPM repositories in AWS S3.
+# It handles the following operations:
+#   1. Syncing an RPM repository from an S3 bucket to a local directory.
+#   2. Signing all RPMs in the local repository with a specified GPG key.
+#   3. Updating and signing the repository metadata.
+#   4. Exporting the GPG public key and placing it in the repository for client use.
+#   5. Optionally, uploading changes back to the S3 bucket and deleting files in S3 that no longer exist locally.
+#   6. Decrypting and importing a GPG private key used for signing.
+#   7. A mode to only decrypt and import the GPG private key.
+#   8. Identifying and copying a newly built RPM to the appropriate repository.
+
+# Function to display detailed usage information
+usage() {
+  cat << EOF
+Usage: $0 [OPTIONS]
+
+This script automates several tasks related to managing RPM repositories in AWS S3.
+It can be used to sync repositories from S3, sign RPMs with a GPG key, update and sign repository metadata,
+and optionally upload changes back to S3.
+
+Options:
+  -c                            Configure AWS credentials using 'aws configure'.
+  -s <s3-bucket>                Specify the S3 bucket and path to sync (required for S3 operations).
+  -d <local-dir>                Specify the local directory to sync to (default: ~/repo).
+  -k <encrypted-key-file>       Specify the encrypted GPG private key file to import (optional).
+  -g <gpg-key-id>               Specify the GPG key ID or email to use for signing (required for signing operations).
+  --upload-with-delete          Sync local changes to S3, deleting files in S3 that no longer exist locally.
+  --s3-sync-only                Perform only the S3 sync to the local directory, inform the user, and exit.
+  --import-gpg-key-only         Decrypt and import the GPG private key, then exit. No other operations will be performed.
+  --copy-new-rpm                Copy the newly built RPM(s) to the appropriate repository directory based on architecture and version.
+  -h, --help                    Display this help message and exit.
+
+Examples:
+  # Sync an S3 repository to a local directory and sign RPMs with a GPG key
+  $0 -s s3://mybucket/repo -g mygpgkey@example.com
+
+  # Sync an S3 repository only, without signing RPMs or performing other operations
+  $0 -s s3://mybucket/repo --s3-sync-only
+
+  # Decrypt and import a GPG private key, then exit
+  $0 -k ~/path/to/encrypted-gpg-key.asc --import-gpg-key-only
+
+  # Copy newly built RPMs to the appropriate repository and sign them
+  $0 --copy-new-rpm -g mygpgkey@example.com
+
+Notes:
+  - The -s option is required for any operation that interacts with S3, such as syncing or uploading with delete.
+  - The -g option is required for any operation that involves signing RPMs or repository metadata.
+  - When using --upload-with-delete, ensure that you have the necessary permissions to delete objects in the specified S3 bucket.
+  - If you only want to perform local operations (e.g., copying RPMs, signing), you do not need to specify the -s option.
+
+EOF
+}
+
+# Parse options and arguments
+GPG_KEY_ID=""
+UPLOAD_WITH_DELETE=false
+S3_SYNC_ONLY=false
+IMPORT_GPG_KEY_ONLY=false
+COPY_NEW_RPM=false
+CONFIGURE_AWS=false
+LOCAL_DIR=~/repo
+
+# Function to check if required commands are available
+check_commands() {
+  local cmds=("aws" "gpg" "shred" "createrepo" "rpm" "find")
+  for cmd in "${cmds[@]}"; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "Error: Required command '$cmd' not found. Please install it before running the script."
+      exit 1
+    fi
+  done
+}
+
+# Parse options
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -c) CONFIGURE_AWS=true; shift ;;
+    -s) S3_BUCKET="$2"; shift 2 ;;
+    -d) LOCAL_DIR="$2"; shift 2 ;;
+    -k) ENCRYPTED_KEY_FILE="$2"; shift 2 ;;
+    -g) GPG_KEY_ID="$2"; shift 2 ;;
+    --upload-with-delete) UPLOAD_WITH_DELETE=true; shift ;;
+    --s3-sync-only) S3_SYNC_ONLY=true; shift ;;
+    --import-gpg-key-only) IMPORT_GPG_KEY_ONLY=true; shift ;;
+    --copy-new-rpm) COPY_NEW_RPM=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+check_commands
+
+# AWS credentials configuration (optional)
+if [ "$CONFIGURE_AWS" = true ]; then
+  echo "Configuring AWS credentials..."
+  aws configure
+fi
+
+# Decrypt and import GPG private key if in import-only mode or not in sync-only mode
+if [ -n "${ENCRYPTED_KEY_FILE:-}" ]; then
+  DECRYPTED_KEY_FILE="${ENCRYPTED_KEY_FILE%.*}"
+  echo "Decrypting GPG private key..."
+  gpg --decrypt --output "$DECRYPTED_KEY_FILE" "$ENCRYPTED_KEY_FILE"
+
+  # Check if the key is already imported
+  if gpg --list-keys | grep -q "$GPG_KEY_ID"; then
+    echo "GPG key already imported."
+  else
+    gpg --import "$DECRYPTED_KEY_FILE"
+  fi
+
+  # Securely delete the decrypted key file
+  shred -u "$DECRYPTED_KEY_FILE"
+
+  # Exit if only importing GPG key
+  if [ "$IMPORT_GPG_KEY_ONLY" = true ]; then
+    echo "GPG key has been decrypted and imported successfully. Exiting."
+    exit 0
+  fi
+fi
+
+# Check access to the S3 bucket and perform sync only if needed
+if [ "$IMPORT_GPG_KEY_ONLY" = false ] && [ "$S3_SYNC_ONLY" = false ] && [ "$COPY_NEW_RPM" = false ] && [ "$UPLOAD_WITH_DELETE" = false ]; then
+  if [ -z "${S3_BUCKET:-}" ]; then
+    echo "Error: S3 bucket (-s) is required."
+    exit 1
+  fi
+
+  echo "Checking access to S3 bucket $S3_BUCKET..."
+  if ! aws s3 ls "$S3_BUCKET" &> /dev/null; then
+    echo "Error: Unable to access S3 bucket $S3_BUCKET. Please check your AWS credentials and permissions."
+    exit 1
+  fi
+
+  # Sync the S3 repository to the local directory
+  mkdir -p "$LOCAL_DIR"
+  echo "Syncing S3 repository from $S3_BUCKET to $LOCAL_DIR..."
+  aws s3 sync "$S3_BUCKET" "$LOCAL_DIR"
+
+  # Check if the operation is `s3-sync-only`
+  if [ "$S3_SYNC_ONLY" = true ]; then
+    echo "S3 sync operation completed successfully."
+    exit 0
+  fi
+fi
+
+# Copy the newly built RPM to the appropriate repository
+if [ "$COPY_NEW_RPM" = true ]; then
+  echo "Identifying the newly built RPMs..."
+
+  for ARCH in x86_64 noarch; do
+    RPM_DIR=~/rpmbuild/RPMS/$ARCH
+
+    # Check if the RPM directory exists
+    if [ ! -d "$RPM_DIR" ]; then
+      echo "Warning: Directory $RPM_DIR does not exist. Skipping $ARCH."
+      continue
+    fi
+
+    # Find all matching RPMs and copy them to the appropriate repository directory
+    NEW_RPMS=$(find "$RPM_DIR" -name "cloudberry-*.rpm" ! -name "*debuginfo*.rpm")
+    if [ -n "$NEW_RPMS" ]; then
+      for NEW_RPM in $NEW_RPMS; do
+        # Determine the repository (el8 or el9) based on the RPM filename
+        if echo "$NEW_RPM" | grep -q "\.el8\."; then
+          TARGET_REPO="$LOCAL_DIR/el8/$ARCH"
+        elif echo "$NEW_RPM" | grep -q "\.el9\."; then
+          TARGET_REPO="$LOCAL_DIR/el9/$ARCH"
+        else
+          echo "Error: Unable to determine the correct repository for $NEW_RPM. Exiting."
+          exit 1
+        fi
+
+        # Ensure the target repository directory exists
+        mkdir -p "$TARGET_REPO"
+
+        # Copy the RPM to the target repository
+        echo "Copying $NEW_RPM to $TARGET_REPO..."
+        cp "$NEW_RPM" "$TARGET_REPO/"
+        echo "Copy operation completed."
+      done
+    else
+      echo "No matching RPMs found in $RPM_DIR."
+    fi
+  done
+fi
+
+# Define the directories for `el8` and `el9` repositories
+REPO_DIRS=("$LOCAL_DIR/el8/x86_64" "$LOCAL_DIR/el8/noarch" "$LOCAL_DIR/el9/x86_64" "$LOCAL_DIR/el9/noarch")
+
+# Traverse each repository directory (el8 and el9) and sign RPMs
+for REPO_DIR in "${REPO_DIRS[@]}"; do
+  if [ -d "$REPO_DIR" ]; then
+    echo "Processing repository at $REPO_DIR..."
+
+    # Export GPG public key for clients and place it in the root of the repository
+    TEMP_GPG_KEY=$(mktemp)
+    echo "Exporting GPG public key to temporary location..."
+    gpg --armor --export "$GPG_KEY_ID" > "$TEMP_GPG_KEY"
+
+    # Import the GPG public key to RPM database
+    echo "Importing GPG public key into RPM database..."
+    sudo rpm --import "$TEMP_GPG_KEY"
+
+    # Sign each RPM in the directory
+    echo "Signing RPM packages in $REPO_DIR..."
+    find "$REPO_DIR" -name "*.rpm" -exec rpm --addsign --define "_gpg_name $GPG_KEY_ID" {} \;
+
+    # Verify that RPMs were signed successfully
+    echo "Verifying RPM signatures in $REPO_DIR..."
+    find "$REPO_DIR" -name "*.rpm" -exec rpm -Kv {} \;
+
+    # Recreate the repository metadata
+    echo "Updating repository metadata in $REPO_DIR..."
+    createrepo --update "$REPO_DIR"
+
+    # Sign the repository metadata, automatically overwriting if the file already exists
+    echo "Signing repository metadata in $REPO_DIR..."
+    gpg --batch --yes --detach-sign --armor --local-user "$GPG_KEY_ID" "$REPO_DIR/repodata/repomd.xml"
+
+    # Copy the public key to each repo
+    cp "$TEMP_GPG_KEY" "$REPO_DIR/RPM-GPG-KEY-cloudberry"
+
+    # Clean up temporary GPG key
+    rm -f "$TEMP_GPG_KEY"
+  else
+    echo "Warning: Repository directory $REPO_DIR does not exist. Skipping..."
+  fi
+done
+
+# Upload changes to S3 with --delete option if requested
+if [ "$UPLOAD_WITH_DELETE" = true ]; then
+  if [ -z "${S3_BUCKET:-}" ]; then
+    echo "Error: S3 bucket (-s) is required for upload with delete."
+    exit 1
+  fi
+
+  echo "Uploading local changes to S3 with --delete option..."
+  aws s3 sync "$LOCAL_DIR" "$S3_BUCKET" --delete
+  echo "S3 sync with --delete completed."
+fi
+
+# Print completion message
+echo "S3 repository sync, RPM signing, metadata signing, and public key export completed successfully."

--- a/deploy/scripts/s3-repo-sync-and-sign.sh
+++ b/deploy/scripts/s3-repo-sync-and-sign.sh
@@ -1,3 +1,23 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+#
 #!/bin/bash
 
 set -euo pipefail

--- a/pom.xml
+++ b/pom.xml
@@ -1241,6 +1241,11 @@ code or new licensing patterns.
             <exclude>aclocal.m4</exclude>
             <exclude>python-dependencies.txt</exclude>
 
+            <!-- Exclude python requirements files, since they are just a list of packages and do not support any comments
+            -->
+
+            <exclude>deploy/images/docker/cbdb/build/rocky8/tests/requirements.txt</exclude>
+            <exclude>deploy/images/docker/cbdb/build/rocky9/tests/requirements.txt</exclude>
             
             <!-- Finally we exclude a few file types (based on
                  extension) for which comments are tough to


### PR DESCRIPTION
As was discussed in https://lists.apache.org/thread/p6otyrrnosg8fsbyr6ok7hl8wxpx4ss2 it will be great to have all scripts in one repo. We could change the code and the building scripts at the same time.

The good example is PAX, a big feature where we needed to make several commits to all repositories at the same time because the changes depended on each other.

Here I:
1. Moved all scripts from cloudberry-devops-release to cloudberry (still need to check I may missed the last commit)
2. Placed them in deploy directory. See it's empty now and could be re-used.
3. Added license info to all files missing it
4. Write a small instruction how to use scripts
