### PR TITLE
Fix: ERROR: too many sample rows received from gp_acquire_sample_rows

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -713,8 +713,10 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	 * statistics target. So we may need to sample more rows and then build
 	 * the statistics with enough detail.
 	 */
-	minrows = ComputeExtStatisticsRows(onerel, attr_cnt, vacattrstats);
-	
+	if (IS_QD_OR_SINGLENODE())
+		minrows = ComputeExtStatisticsRows(onerel, attr_cnt, vacattrstats);
+	else
+		minrows = 0;
 
 	if (targrows < minrows)
 		targrows = minrows;

--- a/src/test/regress/expected/stats_ext.out
+++ b/src/test/regress/expected/stats_ext.out
@@ -3240,3 +3240,16 @@ NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table tststats.priv_test_tbl
 drop cascades to view tststats.priv_test_view
 DROP USER regress_stats_user1;
+-- test analyze with extended statistics 
+CREATE TABLE tbl_issue1293 (col1 int, col2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tbl_issue1293
+SELECT i / 10000, i / 100000
+FROM generate_series(1, 1000000) s(i);
+ANALYZE tbl_issue1293;
+-- Create extended statistics on col1, col2
+CREATE STATISTICS s1 (dependencies) ON col1, col2 FROM tbl_issue1293;
+-- Trigger extended stats collection
+ANALYZE tbl_issue1293;
+DROP TABLE tbl_issue1293;

--- a/src/test/regress/expected/stats_ext_optimizer.out
+++ b/src/test/regress/expected/stats_ext_optimizer.out
@@ -3275,3 +3275,16 @@ NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table tststats.priv_test_tbl
 drop cascades to view tststats.priv_test_view
 DROP USER regress_stats_user1;
+-- test analyze with extended statistics 
+CREATE TABLE tbl_issue1293 (col1 int, col2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO tbl_issue1293
+SELECT i / 10000, i / 100000
+FROM generate_series(1, 1000000) s(i);
+ANALYZE tbl_issue1293;
+-- Create extended statistics on col1, col2
+CREATE STATISTICS s1 (dependencies) ON col1, col2 FROM tbl_issue1293;
+-- Trigger extended stats collection
+ANALYZE tbl_issue1293;
+DROP TABLE tbl_issue1293;

--- a/src/test/regress/sql/stats_ext.sql
+++ b/src/test/regress/sql/stats_ext.sql
@@ -1651,3 +1651,15 @@ DROP FUNCTION op_leak(int, int);
 RESET SESSION AUTHORIZATION;
 DROP SCHEMA tststats CASCADE;
 DROP USER regress_stats_user1;
+
+-- test analyze with extended statistics 
+CREATE TABLE tbl_issue1293 (col1 int, col2 int);
+INSERT INTO tbl_issue1293
+SELECT i / 10000, i / 100000
+FROM generate_series(1, 1000000) s(i);
+ANALYZE tbl_issue1293;
+-- Create extended statistics on col1, col2
+CREATE STATISTICS s1 (dependencies) ON col1, col2 FROM tbl_issue1293;
+-- Trigger extended stats collection
+ANALYZE tbl_issue1293;
+DROP TABLE tbl_issue1293;


### PR DESCRIPTION

In `do_analyze_rel`, the function `ComputeExtStatisticsRows` calculates the minimum number of sample rows needed for extended statistics (e.g., dependencies, ndistinct).

This calculation is only meaningful and required on the Query Dispatcher (QD), since only the QD is responsible for coordinating the final extended statistics generation.

Previously, all segments (including QEs) executed this logic, resulting in excessive sampling. For large tables, this caused the QD to receive more rows than it can handle, leading to the error:

    ERROR: too many sample rows received from gp_acquire_sample_rows


Fixes #1293 

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
