### PR TITLE
Fix memory leak for bitmap in PAX

### DIFF
--- a/contrib/pax_storage/src/cpp/access/pax_visimap.cc
+++ b/contrib/pax_storage/src/cpp/access/pax_visimap.cc
@@ -143,8 +143,7 @@ bool TestVisimap(Relation rel, const char *visimap_name, int offset) {
   fs = Singleton<LocalFileSystem>::GetInstance();
 
   auto visimap = LoadVisimap(fs, options, file_path);
-  auto bm = Bitmap8(BitmapRaw<uint8>(visimap->data(), visimap->size()),
-                    Bitmap8::ReadOnlyOwnBitmap);
+  auto bm = Bitmap8(BitmapRaw<uint8>(visimap->data(), visimap->size()));
   auto is_set = bm.Test(offset);
   return !is_set;
 }

--- a/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.cc
+++ b/contrib/pax_storage/src/cpp/storage/orc/orc_format_reader.cc
@@ -909,8 +909,7 @@ std::unique_ptr<PaxColumns> OrcFormatReader::ReadStripe(
           reinterpret_cast<uint8 *>(data_buffer->GetAvailableBuffer());
 
       Assert(non_null_stream.kind() == pax::porc::proto::Stream_Kind_PRESENT);
-      non_null_bitmap = std::make_unique<Bitmap8>(BitmapRaw<uint8>(bm_bytes, bm_nbytes),
-                                         BitmapTpl<uint8>::ReadOnlyRefBitmap);
+      non_null_bitmap = std::make_unique<Bitmap8>(BitmapRaw<uint8>(bm_bytes, bm_nbytes));
       data_buffer->Brush(bm_nbytes);
     }
 

--- a/contrib/pax_storage/src/cpp/storage/pax.cc
+++ b/contrib/pax_storage/src/cpp/storage/pax.cc
@@ -615,8 +615,7 @@ void TableDeleter::DeleteWithVisibilityMap(
         auto buffer = LoadVisimap(file_system_, file_system_options_,
                                   visibility_map_filename);
         auto visibility_file_bitmap =
-            Bitmap8(BitmapRaw<uint8>(buffer->data(), buffer->size()),
-                    Bitmap8::ReadOnlyOwnBitmap);
+            Bitmap8(BitmapRaw<uint8>(buffer->data(), buffer->size()));
         visi_bitmap =
             Bitmap8::Union(&visibility_file_bitmap, delete_visi_bitmap.get());
 
@@ -664,8 +663,7 @@ void TableDeleter::DeleteWithVisibilityMap(
     // Update the stats in pax aux table
     // Notice that: PAX won't update the stats in group
     UpdateStatsInAuxTable(catalog_update, micro_partition_metadata,
-                          std::make_shared<Bitmap8>(visi_bitmap->Raw(),
-                                                    Bitmap8::ReadOnlyOwnBitmap),
+                          std::make_shared<Bitmap8>(visi_bitmap->Raw()),
                           min_max_col_idxs,
                           cbdb::GetBloomFilterColumnIndexes(rel_),
                           stats_updater_projection);

--- a/contrib/pax_storage/src/cpp/storage/vec/pax_porc_adpater.cc
+++ b/contrib/pax_storage/src/cpp/storage/vec/pax_porc_adpater.cc
@@ -576,8 +576,7 @@ std::pair<size_t, size_t> VecAdapter::AppendPorcFormat(PaxColumns *columns,
         vec_buffer->Set(boolean_buffer, align_size);
 
         Bitmap8 vec_bool_bitmap(
-            BitmapRaw<uint8>((uint8 *)(boolean_buffer), align_size),
-            BitmapTpl<uint8>::ReadOnlyRefBitmap);
+            BitmapRaw<uint8>((uint8 *)(boolean_buffer), align_size));
 
         CopyBitPackedBuffer(column, micro_partition_visibility_bitmap_,
                             group_base_offset_, range_begin, range_lens,

--- a/contrib/pax_storage/src/cpp/storage/vec_parallel_pax.cc
+++ b/contrib/pax_storage/src/cpp/storage/vec_parallel_pax.cc
@@ -60,7 +60,7 @@ class MicroPartitionInfo : public MicroPartitionInfoProvider {
     if (!visimap_name.empty()) {
       visimap = pax::LoadVisimap(file_system, nullptr, visimap_name);
       BitmapRaw<uint8_t> raw(visimap->data(), visimap->size());
-      bitmap = std::make_unique<Bitmap8>(raw, BitmapTpl<uint8>::ReadOnlyRefBitmap);
+      bitmap = std::make_unique<Bitmap8>(raw);
     }
     return {std::move(visimap), std::move(bitmap)};
   }


### PR DESCRIPTION
Bitmap should free memory if the memory is allocated by itself.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
