### PR TITLE
Enhancement: use `-e` in getversion to check Git repo

### DIFF
--- a/getversion
+++ b/getversion
@@ -94,7 +94,7 @@ generate_dev_version() {
 }
 
 # Check if we're in a Git repo and git is available
-if type git >/dev/null 2>&1 && [ -d '.git' ]; then
+if type git >/dev/null 2>&1 && [ -e '.git' ]; then
     # Ensure git describe doesn't fail due to shallow clone
     if git describe --tags --long >/dev/null 2>&1; then
         if git describe --exact-match >/dev/null 2>&1; then


### PR DESCRIPTION
This commit replaces the use of the -d parameter with the -e parameter
when checking for the presence of a Git repository. This allows for more
comprehensive checks, including cases where the working directory may be
part of a Git repository but not the entire repository.-e has better compatibility

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->



### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Passed `make installcheck`
- [x] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
