### PR TITLE
Fix: initialize FuncExpr.is_tablefunc to false

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2203,8 +2203,8 @@ _copyFuncExpr(const FuncExpr *from)
 	COPY_SCALAR_FIELD(funccollid);
 	COPY_SCALAR_FIELD(inputcollid);
 	COPY_NODE_FIELD(args);
-	COPY_SCALAR_FIELD(is_tablefunc);
 	COPY_LOCATION_FIELD(location);
+	COPY_SCALAR_FIELD(is_tablefunc);
 
 	return newnode;
 }

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -534,6 +534,7 @@ makeFuncExpr(Oid funcid, Oid rettype, List *args,
 	funcexpr->inputcollid = inputcollid;
 	funcexpr->args = args;
 	funcexpr->location = -1;
+	funcexpr->is_tablefunc = false;
 
 	return funcexpr;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1469,8 +1469,8 @@ _outFuncExpr(StringInfo str, const FuncExpr *node)
 	WRITE_OID_FIELD(funccollid);
 	WRITE_OID_FIELD(inputcollid);
 	WRITE_NODE_FIELD(args);
-	WRITE_BOOL_FIELD(is_tablefunc);  /* GPDB */
 	WRITE_LOCATION_FIELD(location);
+	WRITE_BOOL_FIELD(is_tablefunc);  /* GPDB */
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -749,9 +749,8 @@ _readFuncExpr(void)
 	READ_OID_FIELD(funccollid);
 	READ_OID_FIELD(inputcollid);
 	READ_NODE_FIELD(args);
-	READ_BOOL_FIELD(is_tablefunc);  /* GPDB */
 	READ_LOCATION_FIELD(location);
-
+	READ_BOOL_FIELD(is_tablefunc);  /* GPDB */
 	READ_DONE();
 }
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4153,29 +4153,23 @@ simplify_function(Oid funcid, Oid result_type, int32 result_typmod,
 		 * function is actually being invoked.
 		 */
 		SupportRequestSimplify req;
-		FuncExpr	fexpr;
+		FuncExpr *fexpr = makeFuncExpr(funcid, result_type, args,
+									   result_collid, input_collid,
+									   COERCE_EXPLICIT_CALL);
 
-		fexpr.xpr.type = T_FuncExpr;
-		fexpr.funcid = funcid;
-		fexpr.funcresulttype = result_type;
-		fexpr.funcretset = func_form->proretset;
-		fexpr.funcvariadic = funcvariadic;
-		fexpr.funcformat = COERCE_EXPLICIT_CALL;
-		fexpr.funccollid = result_collid;
-		fexpr.inputcollid = input_collid;
-		fexpr.args = args;
-		fexpr.location = -1;
+		fexpr->funcvariadic = funcvariadic;
+		fexpr->funcretset = func_form->proretset;
 
 		req.type = T_SupportRequestSimplify;
 		req.root = context->root;
-		req.fcall = &fexpr;
+		req.fcall = fexpr;
 
 		newexpr = (Expr *)
 			DatumGetPointer(OidFunctionCall1(func_form->prosupport,
 											 PointerGetDatum(&req)));
 
 		/* catch a possible API misunderstanding */
-		Assert(newexpr != (Expr *) &fexpr);
+		Assert(newexpr != (Expr *) fexpr);
 	}
 
 	if (!newexpr && allow_non_const)


### PR DESCRIPTION
explicitly initialize the new is_tablefunc field in makeFuncExpr to false. 

In simplify_function(), switched to using makeFuncExpr() to construct a FuncExpr node , Without initialization, the field contained random values, which could lead to unpredictable behavior during expression simplification.

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
