### PR TITLE
Fix move semantics misuse and unhide Equals() overload

### DIFF
--- a/contrib/pax_storage/src/cpp/storage/micro_partition.cc
+++ b/contrib/pax_storage/src/cpp/storage/micro_partition.cc
@@ -91,7 +91,7 @@ size_t MicroPartitionReaderProxy::GetTupleCountsInGroup(size_t group_index) {
 
 std::unique_ptr<ColumnStatsProvider>
 MicroPartitionReaderProxy::GetGroupStatsInfo(size_t group_index) {
-  return std::move(reader_->GetGroupStatsInfo(group_index));
+  return reader_->GetGroupStatsInfo(group_index);
 }
 
 std::unique_ptr<MicroPartitionReader::Group>

--- a/src/backend/gporca/libgpos/include/gpos/string/CWStringConst.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CWStringConst.h
@@ -57,6 +57,9 @@ public:
 
 	// checks whether the string is byte-wise equal to another string
 	BOOL Equals(const CWStringBase *str) const override;
+
+	// bring base class Equals(const WCHAR*) into scope to avoid hiding
+	using CWStringBase::Equals;
 };
 }  // namespace gpos
 


### PR DESCRIPTION
- In pax_storage, remove unnecessary std::move when returning a std::unique_ptr from GetGroupStatsInfo(). Returning directly avoids warnings and redundant moves.
- In gporca/gpos, bring CWStringBase::Equals(const WCHAR*) into scope in CWStringConst to prevent it from being hidden by the derived class overload.


Fixes #1303

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
