### PR TITLE
feat: support runtime filter push down to Table AM

### DIFF
--- a/contrib/pax_storage/src/cpp/access/pax_access_handle.cc
+++ b/contrib/pax_storage/src/cpp/access/pax_access_handle.cc
@@ -453,6 +453,7 @@ uint32 PaxAccessMethod::ScanFlags(Relation relation) {
   flags |= SCAN_FORCE_BIG_WRITE_LOCK;
 #endif
 
+  flags |= SCAN_SUPPORT_RUNTIME_FILTER;
   return flags;
 }
 

--- a/contrib/pax_storage/src/cpp/storage/filter/pax_filter.cc
+++ b/contrib/pax_storage/src/cpp/storage/filter/pax_filter.cc
@@ -44,11 +44,12 @@ namespace pax {
 PaxFilter::PaxFilter() : sparse_filter_(nullptr), row_filter_(nullptr) {}
 
 void PaxFilter::InitSparseFilter(Relation relation, List *quals,
+                                 ScanKey key, int nkeys,
                                  bool allow_fallback_to_pg) {
   Assert(!sparse_filter_);
   sparse_filter_ =
       std::make_shared<PaxSparseFilter>(relation, allow_fallback_to_pg);
-  sparse_filter_->Initialize(quals);
+  sparse_filter_->Initialize(quals, key, nkeys);
 }
 
 #ifdef VEC_BUILD

--- a/contrib/pax_storage/src/cpp/storage/filter/pax_filter.h
+++ b/contrib/pax_storage/src/cpp/storage/filter/pax_filter.h
@@ -50,7 +50,7 @@ class PaxFilter final {
   ~PaxFilter() = default;
 
   // The sparse filter
-  void InitSparseFilter(Relation relation, List *quals,
+  void InitSparseFilter(Relation relation, List *quals, ScanKey key, int nkeys,
                         bool allow_fallback_to_pg = false);
 #ifdef VEC_BUILD
   void InitSparseFilter(

--- a/contrib/pax_storage/src/cpp/storage/filter/pax_sparse_filter.h
+++ b/contrib/pax_storage/src/cpp/storage/filter/pax_sparse_filter.h
@@ -65,7 +65,7 @@ class PaxSparseFilter final {
 
   bool ExistsFilterPath() const;
 
-  void Initialize(List *quals);
+  void Initialize(List *quals, ScanKey key, int nkeys);
 
 #ifdef VEC_BUILD
   void Initialize(
@@ -82,6 +82,8 @@ class PaxSparseFilter final {
 #ifndef RUN_GTEST
  private:
 #endif
+
+  std::shared_ptr<PFTNode> ProcessScanKey(ScanKey key);
 
   // Used to build the filter tree with the PG quals
   std::shared_ptr<PFTNode> ExprWalker(Expr *expr);

--- a/contrib/pax_storage/src/cpp/storage/filter/pax_sparse_pg_path.cc
+++ b/contrib/pax_storage/src/cpp/storage/filter/pax_sparse_pg_path.cc
@@ -36,7 +36,7 @@
 
 namespace pax {
 
-void PaxSparseFilter::Initialize(List *quals) {
+void PaxSparseFilter::Initialize(List *quals, ScanKey key, int nkeys) {
   ListCell *qual_cell;
   std::vector<std::shared_ptr<PFTNode>> fl_nodes; /* first level nodes */
   std::string origin_tree_str;
@@ -44,7 +44,7 @@ void PaxSparseFilter::Initialize(List *quals) {
   // no inited
   Assert(!filter_tree_);
 
-  if (!quals) {
+  if (!quals && nkeys == 0) {
     return;
   }
 
@@ -57,6 +57,23 @@ void PaxSparseFilter::Initialize(List *quals) {
     fl_nodes.emplace_back(std::move(fl_node));
   }
 
+  // walk scan key and only support min/max filter now
+  for (int i = 0; i < nkeys; i++) {
+    // TODO: support bloom filter in PaxFilter
+    // but now just skip it, SeqNext() will check bloom filter in PassByBloomFilter()
+    if (key[i].sk_flags & SK_BLOOM_FILTER) {
+      continue;
+    }
+
+    if (key[i].sk_strategy != BTGreaterEqualStrategyNumber &&
+        key[i].sk_strategy != BTLessEqualStrategyNumber) {
+      continue;
+    }
+    std::shared_ptr<PFTNode> fl_node = ProcessScanKey(&key[i]);
+    Assert(fl_node);
+    fl_nodes.emplace_back(std::move(fl_node));
+  }
+
   // build the root of `filter_tree_`
   BuildPFTRoot(fl_nodes);
   if (pax_log_filter_tree) origin_tree_str = DebugString();
@@ -65,6 +82,47 @@ void PaxSparseFilter::Initialize(List *quals) {
   PAX_LOG_IF(pax_log_filter_tree,
              "Origin filter tree: \n%s\nFinal filter tree: \n%s\n",
              origin_tree_str.c_str(), DebugString().c_str());
+}
+
+std::shared_ptr<PFTNode> PaxSparseFilter::ProcessScanKey(ScanKey key) {
+  std::shared_ptr<PFTNode> node = nullptr;
+  Assert(key);
+  Assert(!(key->sk_flags & SK_BLOOM_FILTER));
+  Assert(key->sk_strategy == BTGreaterEqualStrategyNumber ||
+         key->sk_strategy == BTLessEqualStrategyNumber);
+  Assert(key->sk_attno > 0 &&
+         key->sk_attno <= RelationGetNumberOfAttributes(rel_));
+
+  AttrNumber attno = key->sk_attno;
+
+  // Build VarNode on the left
+  auto var_node = std::make_shared<VarNode>();
+  var_node->attrno = attno;
+
+  // Build ConstNode on the right from ScanKey
+  auto const_node = std::make_shared<ConstNode>();
+  const_node->const_val = key->sk_argument;
+  const_node->const_type = key->sk_subtype;
+  if (key->sk_flags & SK_ISNULL) {
+    const_node->sk_flags |= SK_ISNULL;
+  }
+
+  // Build OpNode and attach children: (var, const)
+  auto op_node = std::make_shared<OpNode>();
+  op_node->strategy = key->sk_strategy;
+  op_node->collation = key->sk_collation;  // may be InvalidOid; executor will
+                                           // fallback to attr collation
+
+  // Set operand types
+  Form_pg_attribute attr = TupleDescAttr(RelationGetDescr(rel_), attno - 1);
+  op_node->left_typid = attr->atttypid;
+  op_node->right_typid = key->sk_subtype;
+
+  PFTNode::AppendSubNode(op_node, std::move(var_node));
+  PFTNode::AppendSubNode(op_node, std::move(const_node));
+
+  node = op_node;
+  return node;
 }
 
 Expr *PaxSparseFilter::ExprFlatVar(Expr *clause) {

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -80,13 +80,18 @@ SeqNext(SeqScanState *node)
 		 * node->filter_in_seqscan is false means scankey need to be pushed to
 		 * AM.
 		 */
-		if (gp_enable_runtime_filter_pushdown && !node->filter_in_seqscan)
+		if (gp_enable_runtime_filter_pushdown && node->filters &&
+			(table_scan_flags(node->ss.ss_currentRelation) &
+			 (SCAN_SUPPORT_RUNTIME_FILTER)))
+		{
+			// pushdown runtime filter to AM
 			keys = ScanKeyListToArray(node->filters, &nkeys);
+		}
 
 		/*
-		* We reach here if the scan is not parallel, or if we're serially
-		* executing a scan that was planned to be parallel.
-		*/
+		 * We reach here if the scan is not parallel, or if we're serially
+		 * executing a scan that was planned to be parallel.
+		 */
 		scandesc = table_beginscan_es(node->ss.ss_currentRelation,
 									  estate->es_snapshot,
 									  nkeys, keys,
@@ -102,6 +107,7 @@ SeqNext(SeqScanState *node)
 	{
 		while (table_scan_getnextslot(scandesc, direction, slot))
 		{
+			// TODO: later pushdown bloom filter to AM
 			if (!PassByBloomFilter(&node->ss.ps, node->filters, slot))
 				continue;
 


### PR DESCRIPTION
when seq scan begins, check whether the scanflags of table am is set to determine whether the runtime filter is pushed down.

When the runtime filter is pushed down to pax am, pax am converts the min/max scankey in the runtime filter into PFTNode and performs min/max filtering.

```
CREATE TABLE t1(c1 int, c2 int, c3 int, c4 int, c5 int) using pax with(minmax_columns='c1,c2');
insert into t1 select i,i,i,i,i from generate_series(1,10000000) i;
analyze t1;

CREATE TABLE t2(c1 int, c2 int, c3 int, c4 int, c5 int) with (appendonly=true, orientation=column) distributed REPLICATED;
INSERT INTO t2 VALUES (1,1,1,1,1), (2,2,2,2,2), (3,3,3,3,3), (4,4,4,4,4);
INSERT INTO t2 select * FROM t2;
INSERT INTO t2 select * FROM t2;
INSERT INTO t2 select * FROM t2;

set gp_enable_runtime_filter_pushdown to off;
EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
SELECT t1.c3 FROM t1, t2 WHERE t1.c2 = t2.c2;
                                    QUERY PLAN
----------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1) (actual rows=32 loops=1)
   ->  Hash Join (actual rows=32 loops=1)
         Hash Cond: (t1.c2 = t2.c2)
         Extra Text: Hash chain length 8.0 avg, 8 max, using 4 of 524288 buckets.
         ->  Seq Scan on t1 (actual rows=10000000 loops=1)
         ->  Hash (actual rows=32 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
               ->  Seq Scan on t2 (actual rows=32 loops=1)
 Optimizer: GPORCA
(9 rows)

Time: 1576.548 ms (00:01.577)

gpadmin=# set gp_enable_runtime_filter_pushdown to on;
SET
Time: 0.362 ms
gpadmin=# EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
SELECT t1.c3 FROM t1, t2 WHERE t1.c2 = t2.c2;
                                    QUERY PLAN
----------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1) (actual rows=32 loops=1)
   ->  Hash Join (actual rows=32 loops=1)
         Hash Cond: (t1.c2 = t2.c2)
         Extra Text: Hash chain length 8.0 avg, 8 max, using 4 of 524288 buckets.
         ->  Seq Scan on t1 (actual rows=131072 loops=1)
         ->  Hash (actual rows=32 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
               ->  Seq Scan on t2 (actual rows=32 loops=1)
 Optimizer: GPORCA
(9 rows)

Time: 38.471 ms
```

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
