### PR TITLE
PAX: Adapter the capacity of column by GUC

### DIFF
--- a/contrib/pax_storage/src/cpp/storage/columns/pax_column.h
+++ b/contrib/pax_storage/src/cpp/storage/columns/pax_column.h
@@ -46,7 +46,7 @@
 
 namespace pax {
 
-#define DEFAULT_CAPACITY 2048
+#define DEFAULT_CAPACITY MIN(2048, MAX(16, MAXALIGN(pax::pax_max_tuples_per_group)))
 
 // Used to mapping pg_type
 enum PaxColumnTypeInMem {


### PR DESCRIPTION
The initial size of pax column is hard-coded to 2048. It may consume much memory for all pax columns when the inserted table is a large partition table. For extream example, the partition table has 2000+ leaf-partition tables, and each table has 300 columns. The writer backend will writes 600000+ columns in the same time. The initial capacity of column will affect the memory usage greatly.

When the GUC pax_max_tuples_per_group is low, the large initial size will cause high memory usage that most of them is wasted.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
