### PR TITLE
Allow ON COORDINATOR for ext file:// protocol

### DIFF
--- a/contrib/pax_storage/src/test/regress/input/external_table.source
+++ b/contrib/pax_storage/src/test/regress/input/external_table.source
@@ -1365,10 +1365,22 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 \! rm @abs_srcdir@/data/tableless.csv
 
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 -- end_ignore
 
--- Create external table with on clause
+-- Create external table on coordinator
+-- good, should fetch data from coordinator
+CREATE EXTERNAL TABLE ext_nation_on_coordinator ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON COORDINATOR
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_coordinator ORDER BY N_NATIONKEY DESC LIMIT 5;
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_coordinator( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON COORDINATOR FORMAT 'TEXT' (DELIMITER '|');
 

--- a/contrib/pax_storage/src/test/regress/output/external_table.source
+++ b/contrib/pax_storage/src/test/regress/output/external_table.source
@@ -2601,14 +2601,36 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 
 \! rm @abs_srcdir@/data/tableless.csv
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+NOTICE:  table "ext_nation_on_coordinator" does not exist, skipping
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 NOTICE:  table "exttab_with_on_coordinator" does not exist, skipping
 -- end_ignore
--- Create external table with on clause
+-- Create external table on coordinator
+-- good, should fetch data from coordinator
+CREATE EXTERNAL TABLE ext_nation_on_coordinator ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON COORDINATOR
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_coordinator ORDER BY N_NATIONKEY DESC LIMIT 5;
+ gp_segment_id | n_nationkey |          n_name           | n_regionkey |                                                   n_comment                                                    
+---------------+-------------+---------------------------+-------------+----------------------------------------------------------------------------------------------------------------
+            -1 |          24 | UNITED STATES             |           1 | y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+            -1 |          23 | UNITED KINGDOM            |           3 | eans boost carefully special requests. accounts are. carefull
+            -1 |          22 | RUSSIA                    |           3 |  requests against the platelets use never according to the quickly regular pint
+            -1 |          21 | VIETNAM                   |           2 | hely enticingly express accounts. even, final 
+            -1 |          20 | SAUDI ARABIA              |           4 | ts. silent requests haggle. closely express packages sleep across the blithely
+(5 rows)
+
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_coordinator( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON COORDINATOR FORMAT 'TEXT' (DELIMITER '|');
 SELECT * FROM exttab_with_on_coordinator;
-ERROR:  'ON COORDINATOR' is not supported by this protocol yet
+ERROR:  invalid input syntax for type integer: "error_0"
+CONTEXT:  External table exttab_with_on_coordinator, line 3 of file://@hostname@@abs_srcdir@/data/exttab_few_errors.data, column i
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;

--- a/contrib/pax_storage/src/test/regress/output/external_table_optimizer.source
+++ b/contrib/pax_storage/src/test/regress/output/external_table_optimizer.source
@@ -2601,14 +2601,36 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 
 \! rm @abs_srcdir@/data/tableless.csv
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+NOTICE:  table "ext_nation_on_coordinator" does not exist, skipping
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 NOTICE:  table "exttab_with_on_coordinator" does not exist, skipping
 -- end_ignore
--- Create external table with on clause
+-- Create external table on coordinator
+-- good, should fetch data from coordinator
+CREATE EXTERNAL TABLE ext_nation_on_coordinator ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON COORDINATOR
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_coordinator ORDER BY N_NATIONKEY DESC LIMIT 5;
+ gp_segment_id | n_nationkey |          n_name           | n_regionkey |                                                   n_comment                                                    
+---------------+-------------+---------------------------+-------------+----------------------------------------------------------------------------------------------------------------
+            -1 |          24 | UNITED STATES             |           1 | y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+            -1 |          23 | UNITED KINGDOM            |           3 | eans boost carefully special requests. accounts are. carefull
+            -1 |          22 | RUSSIA                    |           3 |  requests against the platelets use never according to the quickly regular pint
+            -1 |          21 | VIETNAM                   |           2 | hely enticingly express accounts. even, final 
+            -1 |          20 | SAUDI ARABIA              |           4 | ts. silent requests haggle. closely express packages sleep across the blithely
+(5 rows)
+
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_coordinator( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON COORDINATOR FORMAT 'TEXT' (DELIMITER '|');
 SELECT * FROM exttab_with_on_coordinator;
-ERROR:  'ON COORDINATOR' is not supported by this protocol yet
+ERROR:  invalid input syntax for type integer: "error_0"
+CONTEXT:  External table exttab_with_on_coordinator, line 3 of file://@hostname@@abs_srcdir@/data/exttab_few_errors.data, column i
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -443,7 +443,7 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 	 * protocols only */
 	on_clause = (char *) strVal(linitial(ext->execlocations));
 	if ((strcmp(on_clause, "COORDINATOR_ONLY") == 0)
-		&& using_location && (uri->protocol != URI_CUSTOM)) {
+		&& using_location && (uri->protocol != URI_CUSTOM && uri->protocol != URI_FILE)) {
 		ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 				errmsg("\'ON COORDINATOR\' is not supported by this protocol yet")));
 	}
@@ -523,6 +523,13 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 
 			found_candidate = false;
 			found_match = false;
+
+			if ((strcmp(on_clause, "COORDINATOR_ONLY") == 0) && uri->protocol == URI_FILE)
+			{
+				found_match = true;
+				segdb_file_map[0] = pstrdup(uri_str);
+				*ismasteronly = true;
+			}
 
 			/*
 			 * look through our segment database list and try to find a

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1402,10 +1402,22 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 \! rm @abs_srcdir@/data/tableless.csv
 
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 -- end_ignore
 
--- Create external table with on clause
+-- Create external table on coordinator
+-- good, should fetch data from coordinator
+CREATE EXTERNAL TABLE ext_nation_on_coordinator ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON COORDINATOR
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_coordinator ORDER BY N_NATIONKEY DESC LIMIT 5;
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_coordinator( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON COORDINATOR FORMAT 'TEXT' (DELIMITER '|');
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -2657,14 +2657,36 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 
 \! rm @abs_srcdir@/data/tableless.csv
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+NOTICE:  table "ext_nation_on_coordinator" does not exist, skipping
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 NOTICE:  table "exttab_with_on_coordinator" does not exist, skipping
 -- end_ignore
--- Create external table with on clause
+-- Create external table on coordinator
+-- good, should fetch data from coordinator
+CREATE EXTERNAL TABLE ext_nation_on_coordinator ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON COORDINATOR
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_coordinator ORDER BY N_NATIONKEY DESC LIMIT 5;
+ gp_segment_id | n_nationkey |          n_name           | n_regionkey |                                                   n_comment                                                    
+---------------+-------------+---------------------------+-------------+----------------------------------------------------------------------------------------------------------------
+            -1 |          24 | UNITED STATES             |           1 | y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+            -1 |          23 | UNITED KINGDOM            |           3 | eans boost carefully special requests. accounts are. carefull
+            -1 |          22 | RUSSIA                    |           3 |  requests against the platelets use never according to the quickly regular pint
+            -1 |          21 | VIETNAM                   |           2 | hely enticingly express accounts. even, final 
+            -1 |          20 | SAUDI ARABIA              |           4 | ts. silent requests haggle. closely express packages sleep across the blithely
+(5 rows)
+
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_coordinator( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON COORDINATOR FORMAT 'TEXT' (DELIMITER '|');
 SELECT * FROM exttab_with_on_coordinator;
-ERROR:  'ON COORDINATOR' is not supported by this protocol yet
+ERROR:  invalid input syntax for type integer: "error_0"
+CONTEXT:  External table exttab_with_on_coordinator, line 3 of file://@hostname@@abs_srcdir@/data/exttab_few_errors.data, column i
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -2657,14 +2657,36 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 
 \! rm @abs_srcdir@/data/tableless.csv
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+NOTICE:  table "ext_nation_on_coordinator" does not exist, skipping
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 NOTICE:  table "exttab_with_on_coordinator" does not exist, skipping
 -- end_ignore
--- Create external table with on clause
+-- Create external table on coordinator
+-- good, should fetch data from coordinator
+CREATE EXTERNAL TABLE ext_nation_on_coordinator ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON COORDINATOR
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_coordinator ORDER BY N_NATIONKEY DESC LIMIT 5;
+ gp_segment_id | n_nationkey |          n_name           | n_regionkey |                                                   n_comment                                                    
+---------------+-------------+---------------------------+-------------+----------------------------------------------------------------------------------------------------------------
+            -1 |          24 | UNITED STATES             |           1 | y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+            -1 |          23 | UNITED KINGDOM            |           3 | eans boost carefully special requests. accounts are. carefull
+            -1 |          22 | RUSSIA                    |           3 |  requests against the platelets use never according to the quickly regular pint
+            -1 |          21 | VIETNAM                   |           2 | hely enticingly express accounts. even, final 
+            -1 |          20 | SAUDI ARABIA              |           4 | ts. silent requests haggle. closely express packages sleep across the blithely
+(5 rows)
+
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_coordinator;
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_coordinator( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON COORDINATOR FORMAT 'TEXT' (DELIMITER '|');
 SELECT * FROM exttab_with_on_coordinator;
-ERROR:  'ON COORDINATOR' is not supported by this protocol yet
+ERROR:  invalid input syntax for type integer: "error_0"
+CONTEXT:  External table exttab_with_on_coordinator, line 3 of file://@hostname@@abs_srcdir@/data/exttab_few_errors.data, column i
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_coordinator;
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

### What does this PR do?
Allows LOCATION ... ON COORDINATOR syntax for file:// protocol in external tables.

### Additional Context
The syntax was already there but it is not supported for any ext table protocols except CUSTOM. I've added support for local files. My motivation is use this mechanism as yet another way to read logs from the local filesystem. It's already possible with EXECUTE in external web tables, but for security reasons we prohibit it completely in our installations.
Something like this:
```
CREATE READABLE EXTERNAL TABLE pg_log_tbl_coordinator 
(                                    
    logtime timestamp with time zone,
    loguser text,
    logdatabase text,
    logpid text,
    logthread text,
    loghost text,
    logport text,                           
    logsessiontime timestamp with time zone,
    logtransaction int,
    logsession text,
    logcmdcount text,
    logsegment text,
    logslice text,
    logdistxact text,
    loglocalxact text,
    logsubxact text,
    logseverity text,
    logstate text,
    logmessage text,
    logdetail text,
    loghint text,
    logquery text,
    logquerypos int,
    logcontext text,
    logdebug text,
    logcursorpos int,
    logfunction text,
    logfile text,
    logline int,
    logstack text
)                                                                      
LOCATION (
    'file://my_local_cloudberry_build/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_log/*.csv' 
) ON COORDINATOR
FORMAT 'CSV' (DELIMITER AS ',' NULL AS '' QUOTE AS '"');
```

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->

### my considerations
Let me know what you think about it. I don't think there is another security risk introduced by this patch cuz you already can access files on segments this way. Just adding coordinator to get the implementation more complete.
However, I'm not sure why it wasn't done in the first place: simply forgotten/not needed or perhaps there were some concerns.