### PR TITLE
Doc: update the Cloudberry branding in PAX tests

### DIFF
--- a/contrib/pax_storage/src/test/regress/expected/limit.out
+++ b/contrib/pax_storage/src/test/regress/expected/limit.out
@@ -131,7 +131,7 @@ select * from int8_tbl offset (case when random() < 0.5 then null::bigint end);
 (5 rows)
 
 -- Test assorted cases involving backwards fetch from a LIMIT plan node
--- Disable backward scan test which is not supported in this version of Cloudberry Database
+-- Disable backward scan test which is not supported in this version of Apache Cloudberry
 --start_ignore
 /*
  * begin;

--- a/contrib/pax_storage/src/test/regress/expected/limit_optimizer.out
+++ b/contrib/pax_storage/src/test/regress/expected/limit_optimizer.out
@@ -131,7 +131,7 @@ select * from int8_tbl offset (case when random() < 0.5 then null::bigint end);
 (5 rows)
 
 -- Test assorted cases involving backwards fetch from a LIMIT plan node
--- Disable backward scan test which is not supported in this version of Cloudberry Database
+-- Disable backward scan test which is not supported in this version of Apache Cloudberry
 --start_ignore
 /*
  * begin;

--- a/contrib/pax_storage/src/test/regress/expected/qp_misc.out
+++ b/contrib/pax_storage/src/test/regress/expected/qp_misc.out
@@ -745,7 +745,7 @@ f1,f2,f3
 
 -- SubqueryInCase_p1
 -- test expected to fail until function supported in GPDB
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryInCase_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -848,7 +848,7 @@ f1,f2,f3
 
 -- SubqueryPredicateNotIn_p1
 -- test expected to fail until function supported in GPDB
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryPredicateNotIn_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -923,7 +923,7 @@ f1,f2,f3
 
 -- SubqueryQuantifiedPredicateEmpty_p1
 -- test expected to fail until GPDB support this function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateEmpty_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -943,7 +943,7 @@ f1,f2,f3
 
 -- SubqueryQuantifiedPredicateLarge_p1
 -- test expected to fail until GPDB supports this function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateLarge_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -2732,7 +2732,7 @@ f1
 
 -- SubqueryQuantifiedPredicateNull_gp_p1
 -- test expected to fail until GPDB support function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateNull_gp_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1, count(*) c  from (
@@ -2749,7 +2749,7 @@ f1
 
 -- SubqueryQuantifiedPredicateSmall_gp_p1
 -- test expected to fail until GPDB supports function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateSmall_gp_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1, count(*) c  from (

--- a/contrib/pax_storage/src/test/regress/expected/qp_misc_rio_join_small.out
+++ b/contrib/pax_storage/src/test/regress/expected/qp_misc_rio_join_small.out
@@ -31,10 +31,10 @@ CREATE TABLE my_tt_agg_small (
 --
 COPY my_tt_agg_small (symbol, event_ts, trade_price, trade_volume) FROM stdin;
 --
--- Cloudberry Database database dump complete
+-- Apache Cloudberry database dump complete
 --
 --
--- Cloudberry Database database dump
+-- Apache Cloudberry database dump
 --
 --
 -- Name: my_tq_agg_small; Type: TABLE; Schema: public; Tablespace: 
@@ -55,7 +55,7 @@ COPY my_tq_agg_small (ets, sym, bid_price, ask_price, end_ts) FROM stdin;
 --
 CREATE INDEX my_tq_agg_small_ets_end_ts_ix ON my_tq_agg_small USING btree (ets, end_ts);
 --
--- Cloudberry Database database dump complete
+-- Apache Cloudberry database dump complete
 --
 set enable_hashjoin=off;
 create index my_tt_agg_small_event_ts_ix on my_tt_agg_small(event_ts);

--- a/contrib/pax_storage/src/test/regress/sql/limit.sql
+++ b/contrib/pax_storage/src/test/regress/sql/limit.sql
@@ -37,7 +37,7 @@ select * from int8_tbl limit (case when random() < 0.5 then null::bigint end);
 select * from int8_tbl offset (case when random() < 0.5 then null::bigint end);
 
 -- Test assorted cases involving backwards fetch from a LIMIT plan node
--- Disable backward scan test which is not supported in this version of Cloudberry Database
+-- Disable backward scan test which is not supported in this version of Apache Cloudberry
 --start_ignore
 /*
  * begin;

--- a/contrib/pax_storage/src/test/regress/sql/qp_misc.sql
+++ b/contrib/pax_storage/src/test/regress/sql/qp_misc.sql
@@ -1,6 +1,6 @@
 -- start_ignore
 --
--- Cloudberry Database database dump
+-- Apache Cloudberry database dump
 --
 
 SET client_encoding = 'UTF8';
@@ -1153,7 +1153,7 @@ ALTER TABLE ONLY tclob
     ADD CONSTRAINT clobpk PRIMARY KEY (rnum);
 
 --
--- Cloudberry Database database dump complete
+-- Apache Cloudberry database dump complete
 --
 
 -- end_ignore
@@ -1379,7 +1379,7 @@ f1,f2,f3
 ) Q ) P;
 -- SubqueryInCase_p1
 -- test expected to fail until function supported in GPDB
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryInCase_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -1452,7 +1452,7 @@ f1,f2,f3
 ) Q ) P;
 -- SubqueryPredicateNotIn_p1
 -- test expected to fail until function supported in GPDB
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryPredicateNotIn_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -1507,7 +1507,7 @@ f1,f2,f3
 ) Q ) P;
 -- SubqueryQuantifiedPredicateEmpty_p1
 -- test expected to fail until GPDB support this function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateEmpty_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -1522,7 +1522,7 @@ f1,f2,f3
 ) Q ) P;
 -- SubqueryQuantifiedPredicateLarge_p1
 -- test expected to fail until GPDB supports this function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support that query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateLarge_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1,f2,f3, count(*) c  from (
@@ -2801,7 +2801,7 @@ f1
 ) Q ) P;
 -- SubqueryQuantifiedPredicateNull_gp_p1
 -- test expected to fail until GPDB support function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateNull_gp_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1, count(*) c  from (
@@ -2813,7 +2813,7 @@ f1
 ) Q ) P;
 -- SubqueryQuantifiedPredicateSmall_gp_p1
 -- test expected to fail until GPDB supports function
--- GPDB Limitation ERROR:  Cloudberry Database does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
+-- GPDB Limitation ERROR:  Apache Cloudberry does not yet support this query.  DETAIL:  The query contains a multi-row subquery.
 select 'SubqueryQuantifiedPredicateSmall_gp_p1' test_name_part, case when c = 1 then 1 else 0 end pass_ind from (
 select count(distinct c) c from (
 select f1, count(*) c  from (

--- a/contrib/pax_storage/src/test/regress/sql/qp_misc_rio_join_small.sql
+++ b/contrib/pax_storage/src/test/regress/sql/qp_misc_rio_join_small.sql
@@ -5,7 +5,7 @@ drop index if exists my_tt_agg_small_event_ts_ix;
 
 
 --
--- Cloudberry Database database dump
+-- Apache Cloudberry database dump
 --
 
 SET client_encoding = 'UTF8';
@@ -4042,11 +4042,11 @@ SSO             	20101126114705550	415500	200
 \.
 
 --
--- Cloudberry Database database dump complete
+-- Apache Cloudberry database dump complete
 --
 
 --
--- Cloudberry Database database dump
+-- Apache Cloudberry database dump
 --
 
 --
@@ -24078,7 +24078,7 @@ CREATE INDEX my_tq_agg_small_ets_end_ts_ix ON my_tq_agg_small USING btree (ets, 
 
 
 --
--- Cloudberry Database database dump complete
+-- Apache Cloudberry database dump complete
 --
 
 set enable_hashjoin=off;

--- a/contrib/pax_storage/src/test/regress/sql/tidrangescan.sql
+++ b/contrib/pax_storage/src/test/regress/sql/tidrangescan.sql
@@ -97,7 +97,7 @@ DECLARE c SCROLL CURSOR FOR SELECT ctid FROM tidrangescan WHERE ctid < '(1,0)';
 FETCH NEXT c;
 FETCH NEXT c;
 --start_ignore
-/* backward scan is not supported in this version of Cloudberry Database */
+/* backward scan is not supported in this version of Apache Cloudberry */
 /*
 FETCH PRIOR c;
 FETCH FIRST c;


### PR DESCRIPTION
This commit is used to rename the old brand to the new one in the PAX test SQL files.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
