### PR TITLE
Fix: check and ereport error in external table

### DIFF
--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3700,3 +3700,6 @@ SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid 
 DROP EXTERNAL TABLE ext_false;
 DROP EXTERNAL TABLE ext_true;
 DROP EXTERNAL TABLE ext_persistently;
+
+CREATE EXTERNAL WEB TEMP TABLE test_program_not_exist(content text) EXECUTE '/xx/seq 1 5' ON MASTER FORMAT 'TEXT';
+SELECT * FROM test_program_not_exist;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -5052,3 +5052,7 @@ SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid 
 DROP EXTERNAL TABLE ext_false;
 DROP EXTERNAL TABLE ext_true;
 DROP EXTERNAL TABLE ext_persistently;
+CREATE EXTERNAL WEB TEMP TABLE test_program_not_exist(content text) EXECUTE '/xx/seq 1 5' ON MASTER FORMAT 'TEXT';
+SELECT * FROM test_program_not_exist;
+DETAIL:  Command: execute:/xx/seq 1 5
+ERROR:  external table test_program_not_exist command ended with error. sh: line 1: /xx/seq: No such file or directory

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -5054,3 +5054,7 @@ SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid 
 DROP EXTERNAL TABLE ext_false;
 DROP EXTERNAL TABLE ext_true;
 DROP EXTERNAL TABLE ext_persistently;
+CREATE EXTERNAL WEB TEMP TABLE test_program_not_exist(content text) EXECUTE '/xx/seq 1 5' ON MASTER FORMAT 'TEXT';
+SELECT * FROM test_program_not_exist;
+DETAIL:  Command: execute:/xx/seq 1 5
+ERROR:  external table test_program_not_exist command ended with error. sh: line 1: /xx/seq: No such file or directory


### PR DESCRIPTION
In external table with CFTYPE_EXEC. We check stderr and ereport error when external_getnext return null.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #1385 

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
