### PR TITLE
Fix readable CTE with SELECT INTO clause.

### DIFF
--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -3264,3 +3264,76 @@ ERROR:  writable CTE queries cannot be used with writable queries
 DETAIL:  Apache Cloudberry currently only support CTEs with one writable clause, called in a non-writable context.
 HINT:  Rewrite the query to only include one writable clause.
 DROP TABLE t_w_cte_relp;
+--
+-- readable CTE with SELECT INTO clause.
+--
+WITH sel AS (
+  SELECT 1 as a
+)
+SELECT a INTO t_r_cte FROM sel;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_r_cte;
+ a 
+---
+ 1
+(1 row)
+
+DROP TABLE t_r_cte;
+--
+-- Multiple readable CTEs with SELECT INTO
+--
+WITH cte1 AS (SELECT 1 as a),
+     cte2 AS (SELECT 2 as b)
+SELECT a, b INTO t_multi_r_cte FROM cte1, cte2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_multi_r_cte;
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+DROP TABLE t_multi_r_cte;
+--
+-- Nested SELECT in CTE with SELECT INTO
+--
+WITH nested_cte AS (
+  SELECT * FROM (SELECT 100 as val, 'test'::text as name) subq
+)
+SELECT val, name INTO t_nested_r_cte FROM nested_cte;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_nested_r_cte;
+ val | name 
+-----+------
+ 100 | test
+(1 row)
+
+DROP TABLE t_nested_r_cte;
+--
+-- CTE with JOIN and SELECT INTO
+--
+WITH cte1 AS (SELECT 1 as id, 'foo' as val),
+     cte2 AS (SELECT 1 as id, 'bar' as val)
+SELECT cte1.id, cte1.val as val1, cte2.val as val2
+INTO t_join_r_cte
+FROM cte1 JOIN cte2 ON cte1.id = cte2.id;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_join_r_cte;
+ id | val1 | val2 
+----+------+------
+  1 | foo  | bar
+(1 row)
+
+DROP TABLE t_join_r_cte;
+--
+-- Verify mixed readable and writable CTEs blocked (negative test)
+--
+CREATE TABLE t_mixed_test (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WITH read_cte AS (SELECT 1 as x),
+     write_cte AS (INSERT INTO t_mixed_test VALUES (1) RETURNING *)
+SELECT x INTO t_should_fail2 FROM read_cte;  -- should fail
+ERROR:  writable CTE queries cannot be used with writable queries
+DETAIL:  Apache Cloudberry currently only support CTEs with one writable clause, called in a non-writable context.
+HINT:  Rewrite the query to only include one writable clause.
+DROP TABLE t_mixed_test;

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -3284,3 +3284,76 @@ ERROR:  writable CTE queries cannot be used with writable queries
 DETAIL:  Apache Cloudberry currently only support CTEs with one writable clause, called in a non-writable context.
 HINT:  Rewrite the query to only include one writable clause.
 DROP TABLE t_w_cte_relp;
+--
+-- readable CTE with SELECT INTO clause.
+--
+WITH sel AS (
+  SELECT 1 as a
+)
+SELECT a INTO t_r_cte FROM sel;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_r_cte;
+ a 
+---
+ 1
+(1 row)
+
+DROP TABLE t_r_cte;
+--
+-- Multiple readable CTEs with SELECT INTO
+--
+WITH cte1 AS (SELECT 1 as a),
+     cte2 AS (SELECT 2 as b)
+SELECT a, b INTO t_multi_r_cte FROM cte1, cte2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_multi_r_cte;
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+DROP TABLE t_multi_r_cte;
+--
+-- Nested SELECT in CTE with SELECT INTO
+--
+WITH nested_cte AS (
+  SELECT * FROM (SELECT 100 as val, 'test'::text as name) subq
+)
+SELECT val, name INTO t_nested_r_cte FROM nested_cte;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_nested_r_cte;
+ val | name 
+-----+------
+ 100 | test
+(1 row)
+
+DROP TABLE t_nested_r_cte;
+--
+-- CTE with JOIN and SELECT INTO
+--
+WITH cte1 AS (SELECT 1 as id, 'foo' as val),
+     cte2 AS (SELECT 1 as id, 'bar' as val)
+SELECT cte1.id, cte1.val as val1, cte2.val as val2
+INTO t_join_r_cte
+FROM cte1 JOIN cte2 ON cte1.id = cte2.id;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM t_join_r_cte;
+ id | val1 | val2 
+----+------+------
+  1 | foo  | bar
+(1 row)
+
+DROP TABLE t_join_r_cte;
+--
+-- Verify mixed readable and writable CTEs blocked (negative test)
+--
+CREATE TABLE t_mixed_test (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+WITH read_cte AS (SELECT 1 as x),
+     write_cte AS (INSERT INTO t_mixed_test VALUES (1) RETURNING *)
+SELECT x INTO t_should_fail2 FROM read_cte;  -- should fail
+ERROR:  writable CTE queries cannot be used with writable queries
+DETAIL:  Apache Cloudberry currently only support CTEs with one writable clause, called in a non-writable context.
+HINT:  Rewrite the query to only include one writable clause.
+DROP TABLE t_mixed_test;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1594,3 +1594,52 @@ EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
 )
 SELECT sum(a) INTO t_w_cte_relp_1 FROM ins;
 DROP TABLE t_w_cte_relp;
+
+--
+-- readable CTE with SELECT INTO clause.
+--
+WITH sel AS (
+  SELECT 1 as a
+)
+SELECT a INTO t_r_cte FROM sel;
+SELECT * FROM t_r_cte;
+DROP TABLE t_r_cte;
+
+--
+-- Multiple readable CTEs with SELECT INTO
+--
+WITH cte1 AS (SELECT 1 as a),
+     cte2 AS (SELECT 2 as b)
+SELECT a, b INTO t_multi_r_cte FROM cte1, cte2;
+SELECT * FROM t_multi_r_cte;
+DROP TABLE t_multi_r_cte;
+
+--
+-- Nested SELECT in CTE with SELECT INTO
+--
+WITH nested_cte AS (
+  SELECT * FROM (SELECT 100 as val, 'test'::text as name) subq
+)
+SELECT val, name INTO t_nested_r_cte FROM nested_cte;
+SELECT * FROM t_nested_r_cte;
+DROP TABLE t_nested_r_cte;
+
+--
+-- CTE with JOIN and SELECT INTO
+--
+WITH cte1 AS (SELECT 1 as id, 'foo' as val),
+     cte2 AS (SELECT 1 as id, 'bar' as val)
+SELECT cte1.id, cte1.val as val1, cte2.val as val2
+INTO t_join_r_cte
+FROM cte1 JOIN cte2 ON cte1.id = cte2.id;
+SELECT * FROM t_join_r_cte;
+DROP TABLE t_join_r_cte;
+
+--
+-- Verify mixed readable and writable CTEs blocked (negative test)
+--
+CREATE TABLE t_mixed_test (a int);
+WITH read_cte AS (SELECT 1 as x),
+     write_cte AS (INSERT INTO t_mixed_test VALUES (1) RETURNING *)
+SELECT x INTO t_should_fail2 FROM read_cte;  -- should fail
+DROP TABLE t_mixed_test;


### PR DESCRIPTION
Cloudberry currently only support one WITH clause per query level.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #1400 

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
