### PR TITLE
Fix: Python build dependencies installation

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -111,8 +111,19 @@ download-python-deps:
 	else \
 		echo "PyGreSQL-$(PYGRESQL_VERSION).tar.gz already exists, skipping download"; \
 	fi
-	# Install wheel and cython for PyYAML building
-	pip3 install --user wheel "cython<3.0.0"
+	# Install wheel and cython for PyYAML building (only if not exists)
+	@if python3 -c "import wheel" >/dev/null 2>&1; then \
+		echo "wheel already exists, skipping installation"; \
+	else \
+		echo "Installing wheel..."; \
+		pip3 install --user wheel 2>/dev/null || pip3 install --user --break-system-packages wheel; \
+	fi
+	@if python3 -c "import cython" >/dev/null 2>&1; then \
+		echo "cython already exists, skipping installation"; \
+	else \
+		echo "Installing cython..."; \
+		pip3 install --user "cython<3.0.0" 2>/dev/null || pip3 install --user --break-system-packages "cython<3.0.0"; \
+	fi
 
 #
 # PyGreSQL


### PR DESCRIPTION
Improve wheel and cython dependency management in gpMgmt/bin/Makefile to handle Ubuntu 24.04's PEP 668 restrictions while maintaining compatibility with Rocky Linux and older Ubuntu versions.

Changes:
- Split wheel and cython dependency checks into separate commands
- Add fallback to --break-system-packages flag for Ubuntu 24.04+
- Only install dependencies if not already present in the system
- Maintain backward compatibility with existing build environments

This resolves build failures on Ubuntu 24.04 where pip install --user is restricted by default, while preserving the existing behavior on Rocky Linux 8/9 and Ubuntu 20.04/22.04 systems.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #1433

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
