### PR TITLE
Fix UDF pg_database_size

### DIFF
--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -153,6 +153,15 @@ db_dir_size(const char *path)
 			continue;
 
 		snprintf(filename, sizeof(filename), "%s/%s", path, direntry->d_name);
+		if (direntry->d_type == DT_DIR)
+		{
+			/**
+			 * Recurse into subdirectory. PAX stores data file in a separate
+			 * directory, so we need to account for that.
+			 */
+			dirsize += db_dir_size(filename);
+			continue;
+		}
 
 		if (stat(filename, &fst) < 0)
 		{


### PR DESCRIPTION
pg_database_size only counts phyical files in database directory. The sub-directory under database directory can't represent the real storage size.

Currently, PAX creates a separate directory to storage all its phyical files, like micro-partition files, visibility-map files, etc. To include the phyical files occupied by PAX tables, `db_dir_size` should calculate its sub-directories recursively.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
