### PR TITLE
Sandbox: add `-c local` build mode

### DIFF
--- a/devops/sandbox/Dockerfile.main.rockylinux9
+++ b/devops/sandbox/Dockerfile.main.rockylinux9
@@ -19,13 +19,19 @@
 # --------------------------------------------------------------------
 # Multi-stage Dockerfile for Apache Cloudberry Sandbox Environment
 # --------------------------------------------------------------------
-# This Dockerfile uses pre-built Apache Cloudberry build images to
-# compile and install Cloudberry from the main branch, then creates
-# a runtime environment for testing and development.
+# This Dockerfile supports two source modes:
+#   - Main branch: clone the latest main from GitHub (CODEBASE_VERSION=main)
+#   - Local source: use the repository contents from the Docker build context
+#     (CODEBASE_VERSION=local), recommended for developers working from
+#     their current checkout.
+# In both modes it compiles and installs Cloudberry, then creates a
+# runtime environment for testing and development.
 # --------------------------------------------------------------------
 
 # Build stage: Use pre-built image to compile Cloudberry
+ARG CODEBASE_VERSION=main
 FROM rockylinux/rockylinux:9.6 AS builder
+ARG CODEBASE_VERSION
 
 # Install build toolchains and development headers (avoid coreutils/curl conflicts on arm64)
 RUN dnf makecache && \
@@ -118,8 +124,20 @@ RUN groupadd -r gpadmin && \
 USER gpadmin
 WORKDIR /home/gpadmin
 
-# Clone the latest Cloudberry source code
-RUN git clone --recurse-submodules --branch main --single-branch --depth=1 https://github.com/apache/cloudberry.git
+# Copy repository contents from build context
+# Note: This COPY always executes regardless of CODEBASE_VERSION due to Docker
+# layer caching behavior. For main branch builds, the copied content will be
+# removed and replaced by a fresh git clone in the RUN step below. This is an
+# acceptable tradeoff to keep the Dockerfile simple and maintainable.
+COPY --chown=gpadmin:gpadmin . /home/gpadmin/cloudberry
+
+# Obtain Cloudberry source code based on build mode
+RUN if [ "${CODEBASE_VERSION}" = "local" ]; then \
+        echo "Using local source from build context"; \
+    else \
+        rm -rf /home/gpadmin/cloudberry && \
+        git clone --recurse-submodules --branch main --single-branch --depth=1 https://github.com/apache/cloudberry.git; \
+    fi
 
 # Build Cloudberry using the official build scripts
 RUN cd /home/gpadmin/cloudberry && \
@@ -188,12 +206,12 @@ COPY --from=builder /usr/local/xerces-c/lib/libxerces-c.so /usr/local/cloudberry
 COPY --from=builder /usr/local/xerces-c/lib/libxerces-c-3.*.so /usr/local/cloudberry-db/lib/
 
 # Copy configuration files to their final destinations
-COPY ./configs/90-cbdb-limits.conf /etc/security/limits.d/90-cbdb-limits.conf
-COPY ./configs/90-cbdb-sysctl.conf /etc/sysctl.d/90-cbdb-sysctl.conf
-COPY ./configs/gpinitsystem_singlenode /tmp/gpinitsystem_singlenode
-COPY ./configs/gpinitsystem_multinode /tmp/gpinitsystem_multinode
-COPY ./configs/multinode-gpinit-hosts /tmp/multinode-gpinit-hosts
-COPY ./configs/init_system.sh /tmp/init_system.sh
+COPY devops/sandbox/configs/90-cbdb-limits.conf /etc/security/limits.d/90-cbdb-limits.conf
+COPY devops/sandbox/configs/90-cbdb-sysctl.conf /etc/sysctl.d/90-cbdb-sysctl.conf
+COPY devops/sandbox/configs/gpinitsystem_singlenode /tmp/gpinitsystem_singlenode
+COPY devops/sandbox/configs/gpinitsystem_multinode /tmp/gpinitsystem_multinode
+COPY devops/sandbox/configs/multinode-gpinit-hosts /tmp/multinode-gpinit-hosts
+COPY devops/sandbox/configs/init_system.sh /tmp/init_system.sh
 
 # Runtime configuration
 RUN echo "cdw" > /tmp/gpdb-hosts && \

--- a/devops/sandbox/README.md
+++ b/devops/sandbox/README.md
@@ -54,8 +54,9 @@ When building and deploying Apache Cloudberry in Docker, you will have 2 differe
 
 **Build Options**
 
-1. Compile with the source code of the latest Apache Cloudberry (released in [Apache Cloudberry Release Page](https://github.com/apache/cloudberry/releases)). The base OS will be Rocky Linux 9 Docker image.
-2. Method 2 - Compile with the latest Apache Cloudberry [main](https://github.com/apache/cloudberry/tree/main) branch. The base OS will be Rocky Linux 9 Docker image.
+1. **Recommended for most users** – Build directly from your current local source code using `-c local`. This is the fastest way to get started as it reuses your existing checkout, avoiding the need to download the code again inside the container. It is also ideal for developers testing local changes.
+2. Compile with the source code of the latest Apache Cloudberry (released in [Apache Cloudberry Release Page](https://github.com/apache/cloudberry/releases)). The base OS will be Rocky Linux 9 Docker image.
+3. Compile with the latest Apache Cloudberry [main](https://github.com/apache/cloudberry/tree/main) branch. The base OS will be Rocky Linux 9 Docker image.
 
 Build and deploy steps:
 
@@ -69,18 +70,38 @@ Build and deploy steps:
 
 3. Enter the repository and run the `run.sh` script to start the Docker container. This will start the automatic installation process. Depending on your environment, you may need to run this with 'sudo' command.
 
+    - **Recommended: Build from your current local source code (single container)**
+
+        This is the most efficient option for both new users and developers. It uses your local checkout directly, saving time by skipping the code download step inside the container. It also allows you to immediately test any local code modifications.
+
+    ```shell
+    cd cloudberry/devops/sandbox
+    ./run.sh -c local
+    ```
+
+    - **Recommended: Build from your current local source code (multi-container)**
+
+        Same as above, but deploys a multi-container cluster. Ideal for testing distributed features or high availability with your local code.
+
+    ```shell
+    cd cloudberry/devops/sandbox
+    ./run.sh -c local -m
+    ```
+
     - For latest Apache Cloudberry release running on a single container
 
     ```shell
     cd cloudberry/devops/sandbox
     ./run.sh -c 2.0.0
     ```
+
     - For latest Apache Cloudberry release running across multiple containers
 
     ```shell
     cd cloudberry/devops/sandbox
     ./run.sh -c 2.0.0 -m
     ```
+
     - For latest main branch running on a single container
 
     ```shell


### PR DESCRIPTION
Introduce a new "local" codebase option to the sandbox run script so developers can build Docker images directly from their current local checkout without cloning Cloudberry again inside the container.

Usage:

    ./run.sh -c local #single node
    ./run.sh -c local -m #multi node

Key changes:

- Extend devops/sandbox/run.sh to accept CODEBASE_VERSION=local, compute the repository root as the Docker build context, and pass the version through to Docker as a build argument.
- For local builds, initialize git submodules only when both a .git directory exists under the repository root and the git command is available; otherwise print a clear warning so users know to prepare required submodules themselves.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
