### PR TITLE
Fix： Synchronise gang creation timeout with the reader to avoid premature abort

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -939,11 +939,26 @@ LockAcquireExtended(const LOCKTAG *locktag,
 			{
 				/* Find the guy who should manage our locks */
 				volatile PGPROC * proc = FindProcByGpSessionId(gp_session_id);
-				int count = 0;
-				while(proc==NULL && count < find_writer_proc_retry_time)
+				TimestampTz current_time;
+				TimestampTz start_time;
+				long        elapsed_secs;
+				int         elapsed_usecs;
+				start_time = GetCurrentTimestamp();
+
+				while (proc == NULL)
 				{
+					/*
+					 * The creation timeout retry logic of cdbgang_createGang_async
+					 * should be synchronized with the reader to avoid slow creation
+					 * due to platform, container, network and other reasons, 
+					 * which would cause the reader to prematurely consider it an abnormal termination.
+					 */
+					current_time = GetCurrentTimestamp();
+					TimestampDifference(start_time, current_time, &elapsed_secs, &elapsed_usecs);
+					if (elapsed_secs >= gp_segment_connect_timeout / 2)
+						break;
+
 					pg_usleep( /* microseconds */ 2000);
-					count++;
 					CHECK_FOR_INTERRUPTS();
 					/*
 					 * The reason for using pg_memory_barrier() is to ensure that
@@ -954,7 +969,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 				}
 				if (proc != NULL)
 				{
-					elog(DEBUG1,"Found writer proc entry.  My Pid %d, his pid %d", MyProc-> pid, proc->pid);
+					elog(DEBUG1, "Found writer proc entry.  My Pid %d, his pid %d", MyProc-> pid, proc->pid);
 					lockHolderProcPtr = (PGPROC*) proc;
 				}
 				else


### PR DESCRIPTION
Fix the creation timeout retry logic of cdbgang_createGang_async should be synchronized with the reader to avoid slow creation due to platform, container, network and other reasons, which would cause the reader to prematurely consider it an abnormal termination.

2025-11-20 11:48:27.925475 CST,"gpadmin","regression",p14056,th-1958096896,"172.18.0.2","40060",2025-11-20 11:48:27 CST,0,con33,,seg0,,,,sx1,"WARNING","58M01","reader could not find writer proc entry","lock [0,1260] AccessShareLock 0. Probably because writer gang is gone somehow. Maybe try rerunning.",,,,,,0,,"lock.c",963,"Stack trace:
1    0xaaaab4db9f14 postgres errstart + 0x494
2    0xaaaab4b9b064 postgres LockAcquireExtended + 0x76c
3    0xaaaab4b97d98 postgres LockRelationOid + 0x3c
4    0xaaaab44a6e30 postgres relation_open + 0x60
5    0xaaaab45a04e8 postgres table_open + 0x1c
6    0xaaaab4d7f3e8 postgres <symbol not found> + 0xb4d7f3e8
7    0xaaaab4d7fdcc postgres <symbol not found> + 0xb4d7fdcc
8    0xaaaab4d7fc5c postgres SearchCatCache1 + 0x2c
9    0xaaaab4da0258 postgres SearchSysCache1 + 0xb4
10   0xaaaab4dd6f48 postgres InitializeSessionUserId + 0x98
11   0xaaaab4dda874 postgres InitPostgres + 0x504
12   0xaaaab4bc93bc postgres PostgresMain + 0x390
13   0xaaaab4ac90b8 postgres <symbol not found> + 0xb4ac90b8
14   0xaaaab4ac8918 postgres <symbol not found> + 0xb4ac8918
15   0xaaaab4ac3114 postgres <symbol not found> + 0xb4ac3114
16   0xaaaab4ac2804 postgres PostmasterMain + 0x1668
17   0xaaaab4936b50 postgres <symbol not found> + 0xb4936b50
18   0xffff8b4f1724 libc.so.6 __libc_start_main + 0xf0
19   0xaaaab448327c postgres <symbol not found> + 0xb448327c

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Passed `make installcheck`
- [x] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
