### PR TITLE
Fix SonarQube build-wrapper path and usage

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -32,6 +32,7 @@
 # Triggers:
 # - Weekly schedule
 # - optional manual dispatch.
+# - Changes on sonarqube.yml file
 #
 # Notes:
 # - SONARCLOUD_TOKEN secret is provided by the ASF Infra team
@@ -42,6 +43,14 @@ on:
   schedule:
   - cron: "0 0 * * 1"
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/sonarqube.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/sonarqube.yml'
 
 permissions:
   contents: read
@@ -112,9 +121,10 @@ jobs:
         build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} make -j$(nproc)
 
     - name: SonarQube Scan
+      if: ${{ github.event_name != 'pull_request' }}
       uses: SonarSource/sonarqube-scan-action@v6
       env:
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
       with:
         args: >
-          --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
+          --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"


### PR DESCRIPTION
This commit updates the SonarQube GitHub Actions workflow to follow the officially recommended configuration. The previous workflow failed because the CFamily analyzer could not locate the generated compile_commands.json file due to an incorrect or quoted build-wrapper output path.

Changes included:
- Align workflow steps with SonarSource’s recommended sequence.
- Ensure build-wrapper-linux-x86-64 correctly produces output under $BUILD_WRAPPER_OUT_DIR.

This update should allow the C/C++ analysis to run successfully and avoid exit code 3 errors in future SonarQube scans.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #1449 

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
