### PR TITLE
Fix gawk regexp escape sequence '\#' warning

### DIFF
--- a/src/Makefile.shlib
+++ b/src/Makefile.shlib
@@ -130,7 +130,7 @@ ifeq ($(PORTNAME), darwin)
     DLSUFFIX		= .so
     LINK.shared		= $(COMPILER) -bundle -multiply_defined suppress
   endif
-  BUILD.exports		= $(AWK) '/^[^\#]/ {printf "_%s\n",$$1}' $< >$@
+  BUILD.exports		= $(AWK) '/^[^\043]/ {printf "_%s\n",$$1}' $< >$@
   exports_file		= $(SHLIB_EXPORTS:%.txt=%.list)
   ifneq (,$(exports_file))
     exported_symbols_list = -exported_symbols_list $(exports_file)
@@ -142,7 +142,7 @@ ifeq ($(PORTNAME), openbsd)
   ifdef soname
     LINK.shared		+= -Wl,-x,-soname,$(soname)
   endif
-  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
+  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\043]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
   exports_file		= $(SHLIB_EXPORTS:%.txt=%.list)
   ifneq (,$(exports_file))
     LINK.shared		+= -Wl,--version-script=$(exports_file)
@@ -158,7 +158,7 @@ ifeq ($(PORTNAME), freebsd)
   ifdef soname
     LINK.shared		+= -Wl,-x,-soname,$(soname)
   endif
-  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
+  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\043]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
   exports_file		= $(SHLIB_EXPORTS:%.txt=%.list)
   ifneq (,$(exports_file))
     LINK.shared		+= -Wl,--version-script=$(exports_file)
@@ -170,7 +170,7 @@ ifeq ($(PORTNAME), netbsd)
   ifdef soname
     LINK.shared		+= -Wl,-x,-soname,$(soname)
   endif
-  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
+  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\043]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
   exports_file		= $(SHLIB_EXPORTS:%.txt=%.list)
   ifneq (,$(exports_file))
     LINK.shared		+= -Wl,--version-script=$(exports_file)
@@ -215,7 +215,7 @@ ifeq ($(PORTNAME), linux)
   ifdef soname
     LINK.shared		+= -Wl,-soname,$(soname)
   endif
-  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
+  BUILD.exports		= ( echo '{ global:'; $(AWK) '/^[^\043]/ {printf "%s;\n",$$1}' $<; echo ' local: *; };' ) >$@
   exports_file		= $(SHLIB_EXPORTS:%.txt=%.list)
   ifneq (,$(exports_file))
     LINK.shared		+= -Wl,--version-script=$(exports_file)

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -95,14 +95,14 @@ SYMBOL_MAPPING_FLAGS =
 ifeq ($(PORTNAME), darwin)
 SYMBOL_MAP_FILE = hide_symbols.list
 $(SYMBOL_MAP_FILE): $(top_builddir)/src/interfaces/libpq/exports.txt
-	$(AWK) '/^[^\#]/ {printf "_%s\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN) >$@
+	$(AWK) '/^[^\043]/ {printf "_%s\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN) >$@
 SYMBOL_MAPPING_FLAGS = -unexported_symbols_list $(SYMBOL_MAP_FILE)
 endif
 
 ifeq ($(PORTNAME), linux)
 SYMBOL_MAP_FILE = postgres_symbols.map
 $(SYMBOL_MAP_FILE): $(top_builddir)/src/interfaces/libpq/exports.txt
-	( echo '{ global: *; '; echo ' local:'; $(AWK) '/^[^\#]/ {printf "%s;\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN); echo '};' ) >$@
+	( echo '{ global: *; '; echo ' local:'; $(AWK) '/^[^\043]/ {printf "%s;\n",$$1}' $< | grep -v -E $(SAFELY_EXPORTED_SYMBOLS_PATTERN); echo '};' ) >$@
 SYMBOL_MAPPING_FLAGS = -Wl,--version-script=$(SYMBOL_MAP_FILE)
 endif
 ifeq ($(enable_shared_postgres_backend),yes)


### PR DESCRIPTION
Fixes #1206

### What does this PR do?
This PR fixes a `gawk` warning that appears during `make install`:

    gawk: cmd. line:1: warning: regexp escape sequence `#' is not a known regexp operator

The original code used `[^\#]` to match lines not starting with `#`. While the backslash was intended to escape `#` for Make (preventing it from being interpreted as a comment), `gawk` treats `\#` as an invalid escape sequence and emits a warning.

**Solution:**
Use `[^\043]` instead, where `\043` is the octal representation of `#` (ASCII 35). This approach:
1. Is properly escaped for Make (not interpreted as a comment character).
2. Is a valid AWK escape sequence (no warning from gawk).
3. Works correctly with both `gawk` and `mawk`.

**Changes made:**
- **Makefile.shlib**: Replaced `[^\#]` with `[^\043]` in 5 places (darwin, openbsd, freebsd, netbsd, linux BUILD.exports).
- **src/backend/Makefile**: Replaced `[^\#]` with `[^\043]` in 2 places (darwin and linux symbol mapping rules).

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Passed `make installcheck`
- [x] Passed `make -C src/test installcheck-cbdb-parallel`

**Manual Verification:**
Verified the regex works correctly with both `gawk` and `mawk`:

    # Test with gawk
    $ echo -e "# comment\nfunction1 123" | gawk '/^[^\043]/ {printf "%s;\n",$1}'
    function1;

    # Test with mawk
    $ echo -e "# comment\nfunction1 123" | mawk '/^[^\043]/ {printf "%s;\n",$1}'
    function1;

Confirmed that `make install` no longer emits the gawk warning.

### Impact
**Performance:**
No performance impact - this is a cosmetic fix to eliminate build warnings.

**User-facing changes:**
No functional user-facing changes. Build output will no longer show the gawk warning.

**Dependencies:**
None.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [x] Reviewed code for security implications
- [x] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
The initial attempt to fix this by simply removing the backslash (`[^#]`) broke the build because Make interprets `#` as a comment character, causing the AWK command to be truncated. The octal escape `\043` solves both problems elegantly.

### CI Skip Instructions