### PR TITLE
Fix `make clean` by removing rebase markers

### DIFF
--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -19,10 +19,7 @@ SUBDIRS = \
 		  test_custom_rmgrs \
 		  test_ddl_deparse \
 		  test_escape \
-<<<<<<< HEAD
-=======
 		  test_extensions \
->>>>>>> REL_16_9
 		  test_ginpostinglist \
 		  test_integerset \
 		  test_lfind \
@@ -35,11 +32,8 @@ SUBDIRS = \
 		  test_regex \
 		  test_rls_hooks \
 		  test_shm_mq \
-<<<<<<< HEAD
-=======
 		  test_slru \
 		  unsafe_tests \
->>>>>>> REL_16_9
 		  worker_spi
 
 #ignore cases:

--- a/src/test/modules/test_extensions/Makefile
+++ b/src/test/modules/test_extensions/Makefile
@@ -6,29 +6,21 @@ PGFILEDESC = "test_extensions - regression testing for EXTENSION support"
 EXTENSION = test_ext1 test_ext2 test_ext3 test_ext4 test_ext5 test_ext6 \
             test_ext7 test_ext8 test_ext_cine test_ext_cor \
             test_ext_cyclic1 test_ext_cyclic2 \
-<<<<<<< HEAD
-            test_ext_extschema
-=======
             test_ext_extschema \
             test_ext_evttrig \
             test_ext_req_schema1 test_ext_req_schema2 test_ext_req_schema3
 
->>>>>>> REL_16_9
 DATA = test_ext1--1.0.sql test_ext2--1.0.sql test_ext3--1.0.sql \
        test_ext4--1.0.sql test_ext5--1.0.sql test_ext6--1.0.sql \
        test_ext7--1.0.sql test_ext7--1.0--2.0.sql test_ext8--1.0.sql \
        test_ext_cine--1.0.sql test_ext_cine--1.0--1.1.sql \
        test_ext_cor--1.0.sql \
        test_ext_cyclic1--1.0.sql test_ext_cyclic2--1.0.sql \
-<<<<<<< HEAD
-       test_ext_extschema--1.0.sql
-=======
        test_ext_extschema--1.0.sql \
        test_ext_evttrig--1.0.sql test_ext_evttrig--1.0--2.0.sql \
        test_ext_req_schema1--1.0.sql \
        test_ext_req_schema2--1.0.sql \
        test_ext_req_schema3--1.0.sql
->>>>>>> REL_16_9
 
 
 REGRESS = test_extensions #test_extdepend TODO: enable this test after https://github.com/greenplum-db/gpdb/issues/14532

--- a/src/test/recovery/Makefile
+++ b/src/test/recovery/Makefile
@@ -15,11 +15,7 @@ subdir = src/test/recovery
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-<<<<<<< HEAD
-# required for 017_shm.pl
-=======
 # required for 017_shm.pl and 027_stream_regress.pl
->>>>>>> REL_16_9
 REGRESS_SHLIB=$(abs_top_builddir)/src/test/regress/regress$(DLSUFFIX)
 export REGRESS_SHLIB
 


### PR DESCRIPTION
Now you can run `make clean` without any errors