### PR TITLE
Fix `contrib/formatter_fixedwidth/`.

### DIFF
--- a/src/include/access/formatter.h
+++ b/src/include/access/formatter.h
@@ -83,7 +83,7 @@ typedef struct FormatterData
 #define FORMATTER_GET_ARG_LIST(fcinfo)	      (((FormatterData*) fcinfo->context)->fmt_args)
 #define FORMATTER_GET_NUM_ARGS(fcinfo)	      (list_length(FORMATTER_GET_ARG_LIST(fcinfo)))
 #define FORMATTER_GET_NTH_ARG_KEY(fcinfo, n)  (((DefElem *)(list_nth(FORMATTER_GET_ARG_LIST(fcinfo),(n - 1))))->defname)
-#define FORMATTER_GET_NTH_ARG_VAL(fcinfo, n)  (((Value *)((DefElem *)(list_nth(FORMATTER_GET_ARG_LIST(fcinfo),(n - 1))))->arg)->val.str)
+#define FORMATTER_GET_NTH_ARG_VAL(fcinfo, n)  (((String *)((DefElem *)(list_nth(FORMATTER_GET_ARG_LIST(fcinfo),(n - 1))))->arg)->sval)
 #define FORMATTER_GET_EXTENCODING(fcinfo)     (((FormatterData*) fcinfo->context)->fmt_external_encoding)
 
 #define FORMATTER_SET_USER_CTX(fcinfo, p) \


### PR DESCRIPTION
After REL_16 rebase, this no longer compiles due to https://git.postgresql.org/cgit/postgresql.git/commit/?id=639a86e36aaecb84faaf941dcd0b183ba0aba9e9

Fix by enforsing new kernel coding practice
