### PR TITLE
Fix check_heap regression test.

### DIFF
--- a/contrib/amcheck/expected/check_btree.out
+++ b/contrib/amcheck/expected/check_btree.out
@@ -206,8 +206,6 @@ SELECT bt_index_check('bttest_a_expr_idx', true);
  
 (1 row)
 
-<<<<<<< HEAD
-=======
 -- Check support of both 1B and 4B header sizes of short varlena datum
 CREATE TABLE varlena_bug (v text);
 ALTER TABLE varlena_bug ALTER column v SET storage plain;
@@ -230,7 +228,6 @@ SELECT bt_index_check('varlena_bug_idx', true);
  
 (1 row)
 
->>>>>>> REL_16_9
 -- cleanup
 DROP TABLE bttest_a;
 DROP TABLE bttest_b;

--- a/contrib/amcheck/expected/check_heap.out
+++ b/contrib/amcheck/expected/check_heap.out
@@ -1,9 +1,11 @@
 CREATE TABLE heaptest (a integer, b text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 REVOKE ALL ON heaptest FROM PUBLIC;
 NOTICE:  no privileges could be revoked
 -- Check that invalid skip option is rejected
 SELECT * FROM verify_heapam(relation := 'heaptest', skip := 'rope');
-ERROR:  invalid skip option
+ERROR:  invalid skip option  (seg0 slice1 127.0.1.1:7002 pid=2559521)
 HINT:  Valid skip options are "all-visible", "all-frozen", and "none".
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
@@ -126,7 +128,7 @@ INSERT INTO heaptest (a, b)
 SET allow_in_place_tablespaces = true;
 CREATE TABLESPACE regress_test_stats_tblspc LOCATION '';
 SELECT sum(reads) AS stats_bulkreads_before
-  FROM pg_stat_io WHERE context = 'bulkread' \gset
+  FROM gp_dist_random('pg_stat_io') WHERE context = 'bulkread' \gset
 BEGIN;
 ALTER TABLE heaptest SET TABLESPACE regress_test_stats_tblspc;
 -- Check that valid options are not rejected nor corruption reported
@@ -167,14 +169,18 @@ COMMIT;
 -- verify_heapam should have read in the page written out by
 --   ALTER TABLE ... SET TABLESPACE ...
 -- causing an additional bulkread, which should be reflected in pg_stat_io.
-SELECT pg_stat_force_next_flush();
+-- XXX: Cloubderry version of this differs from upstream. We need to dispatch
+-- flush on segments, so use gp_dist_random
+SELECT pg_stat_force_next_flush() FROM gp_dist_random('gp_id');
  pg_stat_force_next_flush 
 --------------------------
  
-(1 row)
+ 
+ 
+(3 rows)
 
 SELECT sum(reads) AS stats_bulkreads_after
-  FROM pg_stat_io WHERE context = 'bulkread' \gset
+  FROM gp_dist_random('pg_stat_io') WHERE context = 'bulkread' \gset
 SELECT :stats_bulkreads_after > :stats_bulkreads_before;
  ?column? 
 ----------
@@ -182,6 +188,7 @@ SELECT :stats_bulkreads_after > :stats_bulkreads_before;
 (1 row)
 
 CREATE ROLE regress_heaptest_role;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- verify permissions are checked (error due to function not callable)
 SET ROLE regress_heaptest_role;
 SELECT * FROM verify_heapam(relation := 'heaptest');
@@ -201,7 +208,7 @@ SELECT * FROM verify_heapam(relation := 'heaptest');
 RESET ROLE;
 -- Check specifying invalid block ranges when verifying a non-empty table.
 SELECT * FROM verify_heapam(relation := 'heaptest', startblock := 0, endblock := 10000);
-ERROR:  ending block number must be between 0 and 0
+ERROR:  ending block number must be between 0 and 0  (seg0 slice1 127.0.1.1:7002 pid=2559521)
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
 							 on_error_stop,
@@ -212,7 +219,7 @@ CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 							 )t"
 PL/pgSQL function verify_heapam(regclass,boolean,boolean,text,bigint,bigint) line 3 at RETURN QUERY
 SELECT * FROM verify_heapam(relation := 'heaptest', startblock := 10000, endblock := 11000);
-ERROR:  starting block number must be between 0 and 0
+ERROR:  starting block number must be between 0 and 0  (seg0 slice1 127.0.1.1:7002 pid=2559521)
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
 							 on_error_stop,
@@ -262,11 +269,13 @@ SELECT * FROM verify_heapam(relation := 'heaptest', startblock := 0, endblock :=
 -- maps are rejected
 CREATE TABLE test_partitioned (a int, b text default repeat('x', 5000))
 			 PARTITION BY list (a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT * FROM verify_heapam('test_partitioned',
 							startblock := NULL,
 							endblock := NULL);
-<<<<<<< HEAD
-ERROR:  "test_partitioned" is not a table, materialized view, or TOAST table
+ERROR:  cannot check relation "test_partitioned"  (seg0 slice1 127.0.1.1:7002 pid=2559521)
+DETAIL:  This operation is not supported for partitioned tables.
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
 							 on_error_stop,
@@ -276,13 +285,10 @@ CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 							 endblock
 							 )t"
 PL/pgSQL function verify_heapam(regclass,boolean,boolean,text,bigint,bigint) line 3 at RETURN QUERY
-=======
-ERROR:  cannot check relation "test_partitioned"
-DETAIL:  This operation is not supported for partitioned tables.
->>>>>>> REL_16_9
 -- Check that valid options are not rejected nor corruption reported
 -- for an empty partition table (the child one)
 CREATE TABLE test_partition partition OF test_partitioned FOR VALUES IN (1);
+NOTICE:  table has parent, setting distribution columns to match parent table
 SELECT * FROM verify_heapam('test_partition',
 							startblock := NULL,
 							endblock := NULL);
@@ -311,8 +317,8 @@ CREATE INDEX test_index ON test_partition (a);
 SELECT * FROM verify_heapam('test_index',
 							startblock := NULL,
 							endblock := NULL);
-<<<<<<< HEAD
-ERROR:  "test_index" is not a table, materialized view, or TOAST table
+ERROR:  cannot check relation "test_index"  (seg1 slice1 127.0.1.1:7003 pid=2559522)
+DETAIL:  This operation is not supported for indexes.
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
 							 on_error_stop,
@@ -322,17 +328,13 @@ CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 							 endblock
 							 )t"
 PL/pgSQL function verify_heapam(regclass,boolean,boolean,text,bigint,bigint) line 3 at RETURN QUERY
-=======
-ERROR:  cannot check relation "test_index"
-DETAIL:  This operation is not supported for indexes.
->>>>>>> REL_16_9
 -- Check that views are rejected
 CREATE VIEW test_view AS SELECT 1;
 SELECT * FROM verify_heapam('test_view',
 							startblock := NULL,
 							endblock := NULL);
-<<<<<<< HEAD
-ERROR:  "test_view" is not a table, materialized view, or TOAST table
+ERROR:  cannot check relation "test_view"  (seg0 slice1 127.0.1.1:7002 pid=2559521)
+DETAIL:  This operation is not supported for views.
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
 							 on_error_stop,
@@ -342,32 +344,18 @@ CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 							 endblock
 							 )t"
 PL/pgSQL function verify_heapam(regclass,boolean,boolean,text,bigint,bigint) line 3 at RETURN QUERY
-=======
-ERROR:  cannot check relation "test_view"
-DETAIL:  This operation is not supported for views.
->>>>>>> REL_16_9
 -- Check that sequences are rejected
 CREATE SEQUENCE test_sequence;
 SELECT * FROM verify_heapam('test_sequence',
 							startblock := NULL,
 							endblock := NULL);
-<<<<<<< HEAD
-ERROR:  "test_sequence" is not a table, materialized view, or TOAST table
-CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
-	FROM verify_heapam_internal(relation,
-							 on_error_stop,
-							 check_toast,
-							 skip,
-							 startblock,
-							 endblock
-							 )t"
-PL/pgSQL function verify_heapam(regclass,boolean,boolean,text,bigint,bigint) line 3 at RETURN QUERY
-=======
  blkno | offnum | attnum | msg 
 -------+--------+--------+-----
-(0 rows)
+       |        |        | 
+       |        |        | 
+       |        |        | 
+(3 rows)
 
->>>>>>> REL_16_9
 -- Check that foreign tables are rejected
 CREATE FOREIGN DATA WRAPPER dummy;
 CREATE SERVER dummy_server FOREIGN DATA WRAPPER dummy;
@@ -375,8 +363,8 @@ CREATE FOREIGN TABLE test_foreign_table () SERVER dummy_server;
 SELECT * FROM verify_heapam('test_foreign_table',
 							startblock := NULL,
 							endblock := NULL);
-<<<<<<< HEAD
-ERROR:  "test_foreign_table" is not a table, materialized view, or TOAST table
+ERROR:  cannot check relation "test_foreign_table"  (seg0 slice1 127.0.1.1:7002 pid=2559521)
+DETAIL:  This operation is not supported for foreign tables.
 CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 	FROM verify_heapam_internal(relation,
 							 on_error_stop,
@@ -386,10 +374,6 @@ CONTEXT:  SQL statement "SELECT t.blkno, t.offnum, t.attnum, t.msg
 							 endblock
 							 )t"
 PL/pgSQL function verify_heapam(regclass,boolean,boolean,text,bigint,bigint) line 3 at RETURN QUERY
-=======
-ERROR:  cannot check relation "test_foreign_table"
-DETAIL:  This operation is not supported for foreign tables.
->>>>>>> REL_16_9
 -- cleanup
 DROP TABLE heaptest;
 DROP TABLESPACE regress_test_stats_tblspc;

--- a/contrib/amcheck/sql/check_btree.sql
+++ b/contrib/amcheck/sql/check_btree.sql
@@ -135,8 +135,6 @@ CREATE INDEX bttest_a_expr_idx ON bttest_a ((ifun(id) + ifun(0)))
 
 SELECT bt_index_check('bttest_a_expr_idx', true);
 
-<<<<<<< HEAD
-=======
 -- Check support of both 1B and 4B header sizes of short varlena datum
 CREATE TABLE varlena_bug (v text);
 ALTER TABLE varlena_bug ALTER column v SET storage plain;
@@ -153,7 +151,6 @@ INSERT INTO varlena_bug VALUES (repeat('Test', 250));
 ALTER TABLE varlena_bug ALTER COLUMN v SET STORAGE extended;
 SELECT bt_index_check('varlena_bug_idx', true);
 
->>>>>>> REL_16_9
 -- cleanup
 DROP TABLE bttest_a;
 DROP TABLE bttest_b;


### PR DESCRIPTION
Were failing mainly due to 10a082b. Fix by
adapting test to MPP realities
