### PR TITLE
Resolve rebase conflicts in `contrib/dblink`.

### DIFF
--- a/contrib/dblink/expected/dblink.out
+++ b/contrib/dblink/expected/dblink.out
@@ -967,13 +967,8 @@ SET SESSION AUTHORIZATION regress_dblink_user;
 -- should fail
 -- GPDB: We also check for hostname in connection string which is checked first
 SELECT dblink_connect('myconn', 'fdtest');
-<<<<<<< HEAD
 DETAIL:  Non-superusers must provide a host in the connection string.
 ERROR:  host is required
-=======
-ERROR:  password or GSSAPI delegated credentials required
-DETAIL:  Non-superusers must provide a password in the connection string or send delegated GSSAPI credentials.
->>>>>>> REL_16_9
 -- should succeed
 SELECT dblink_connect_u('myconn', 'fdtest');
  dblink_connect_u 


### PR DESCRIPTION
In MPP/Cloudberry we historically have dblink
behaviour differencies with upstream.
They were initially introduced 9b75844, as bug-fix. Namely, we do not allow non-superuser to create dblink connection without explicit password/username. We also force username in connection string to match session user, if not specified (see dblink_connstr_has_pw).

Two function declarations changed:
dblink_connstr_check
dblink_connstr_has_pw

they now return modified connection string.

