### PR TITLE
Backport: Ban role pg_signal_backend from more superuser backend types.

### DIFF
--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -52,7 +52,6 @@ static int
 pg_signal_backend(int pid, int sig, char *msg)
 {
 	PGPROC	   *proc = BackendPidGetProc(pid);
-	LocalPgBackendStatus *local_beentry;
 
 	/*
 	 * BackendPidGetProc returns NULL if the pid isn't valid; but by the time
@@ -73,34 +72,14 @@ pg_signal_backend(int pid, int sig, char *msg)
 		return SIGNAL_BACKEND_ERROR;
 	}
 
-	local_beentry = pgstat_fetch_stat_local_beentry_by_pid(pid);
-
-	/* Only allow superusers to signal superuser-owned backends. */
-	if (superuser_arg(proc->roleId) && !superuser())
-	{
-		Oid role;
-		char * appname;
-
-		if (local_beentry == NULL) {
-			return SIGNAL_BACKEND_NOSUPERUSER;
-		}
-
-		role = get_role_oid("mdb_admin", true /*if nodoby created mdb_admin role in this database*/);
-		appname = local_beentry->backendStatus.st_appname;
-
-		// only allow mdb_admin to kill su queries
-		if (!is_member_of_role(GetUserId(), role)) {
-			return SIGNAL_BACKEND_NOSUPERUSER;
-		}
-
-		if (local_beentry->backendStatus.st_backendType == B_AUTOVAC_WORKER) {
-			// ok
-		} else if (appname != NULL && strcmp(appname, "MDB") == 0) {
-			// ok
-		} else {
-			return SIGNAL_BACKEND_NOSUPERUSER;
-		}
-	}
+	/*
+	 * Only allow superusers to signal superuser-owned backends.  Any process
+	 * not advertising a role might have the importance of a superuser-owned
+	 * backend, so treat it that way.
+	 */
+	if ((!OidIsValid(proc->roleId) || superuser_arg(proc->roleId)) &&
+		!superuser())
+		return SIGNAL_BACKEND_NOSUPERUSER;
 
 	/* Users can signal backends they have role membership in. */
 	if (!has_privs_of_role(GetUserId(), proc->roleId) &&

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1987,6 +1987,24 @@ TABLE information_schema.enabled_roles;
 INSERT INTO datdba_only DEFAULT VALUES;
 ERROR:  permission denied for table datdba_only
 ROLLBACK;
+-- pg_signal_backend can't signal superusers
+RESET SESSION AUTHORIZATION;
+BEGIN;
+CREATE OR REPLACE FUNCTION terminate_nothrow(pid int) RETURNS bool
+	LANGUAGE plpgsql SECURITY DEFINER SET client_min_messages = error AS $$
+BEGIN
+	RETURN pg_terminate_backend($1);
+EXCEPTION WHEN OTHERS THEN
+	RETURN false;
+END$$;
+ALTER FUNCTION terminate_nothrow OWNER TO pg_signal_backend;
+SELECT backend_type FROM pg_stat_activity
+WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END;
+ backend_type 
+--------------
+(0 rows)
+
+ROLLBACK;
 -- test default ACLs
 \c -
 CREATE SCHEMA testns;


### PR DESCRIPTION
Cherry-picked from
https://git.postgresql.org/cgit/postgresql.git/commit/?id=3a9b18b3095366cd0c4305441d426d04572d88c1

Documentation says it cannot signal "a backend owned by a superuser". On the contrary, it could signal background workers, including the logical replication launcher.  It could signal autovacuum workers and the autovacuum launcher.  Block all that.  Signaling autovacuum workers and those two launchers doesn't stall progress beyond what one could achieve other ways.  If a cluster uses a non-core extension with a background worker that does not auto-restart, this could create a denial of service with respect to that background worker.  A background worker with bugs in its code for responding to terminations or cancellations could experience those bugs at a time the pg_signal_backend member chooses.  Back-patch to v11 (all supported versions).

Reviewed by Jelte Fennema-Nio.  Reported by Hemanth Sandrana and Mahendrakar Srinivasarao.

Security: CVE-2023-5870
