### PR TITLE
Enable `src/bin` TAP tests in CI

### DIFF
--- a/.github/workflows/build-cloudberry.yml
+++ b/.github/workflows/build-cloudberry.yml
@@ -227,7 +227,7 @@ jobs:
           # Define base test configurations
           ALL_TESTS='{
             "include": [
-              {"test":"ic-tap-bin-opt-off",
+              {"test":"ic-world-opt-off",
                "make_configs":["./:installcheck-world"],
                "pg_settings":{"optimizer":"off"}
               },


### PR DESCRIPTION
This is my attempt to get TAP tests in Cloudberry CI.

x-ref to my sandbox repo
https://github.com/open-gpdb/cloudberry/pull/10