### PR TITLE
ORCA: Fix assertion failure for dynamic table scan rewindability

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicTableScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicTableScan.h
@@ -74,6 +74,9 @@ public:
 	CPartitionPropagationSpec *PppsDerive(
 		CMemoryPool *mp, CExpressionHandle &exprhdl) const override;
 
+	// return rewindability property enforcing type for this operator
+	CEnfdProp::EPropEnforcingType EpetRewindability(CExpressionHandle &, const CEnfdRewindability *) const override;
+
 };	// class CPhysicalDynamicTableScan
 
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicTableScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicTableScan.cpp
@@ -91,4 +91,19 @@ CPhysicalDynamicTableScan::PppsDerive(CMemoryPool *mp,
 	return pps;
 }
 
+
+CEnfdProp::EPropEnforcingType
+CPhysicalDynamicTableScan::EpetRewindability(CExpressionHandle &exprhdl,
+											 const CEnfdRewindability *per) const
+{
+	CRewindabilitySpec *prs = CDrvdPropPlan::Pdpplan(exprhdl.Pdp())->Prs();
+	if (per->FCompatible(prs))
+	{
+		// required rewindability is already provided
+		return CEnfdProp::EpetUnnecessary;
+	}
+
+	return CEnfdProp::EpetRequired;
+}
+
 // EOF


### PR DESCRIPTION
fix below:
```sql
2025-12-27 08:38:19:006722 CST,THD000,TRACE,"
PROPERTY MISMATCH:

GROUP ID: 54

GEXPR:
1: CPhysicalDynamicTableScan "store_sales" ("store_sales"), Columns: ["ss_sold_date_sk" (147,Used), "ss_sold_time_sk" (148,Unknown), "ss_item_sk" (146,Used), "ss_customer_sk" (145,Used), "ss_cdemo_sk" (149,Unknown), "ss_hdemo_sk" (150,Unknown), "ss_addr_sk" (151,Unknown), "ss_store_sk" (152,Unknown), "ss_promo_sk" (153,Unknown), "ss_ticket_number" (154,Unknown), "ss_quantity" (155,Unknown), "ss_wholesale_cost" (156,Unknown), "ss_list_price" (157,Unknown), "ss_sales_price" (158,Unknown), "ss_ext_discount_amt" (159,Unknown), "ss_ext_sales_price" (160,Unknown), "ss_ext_wholesale_cost" (161,Unknown), "ss_ext_list_price" (162,Unknown), "ss_ext_tax" (163,Unknown), "ss_coupon_amt" (164,Unknown), "ss_net_paid" (165,Unknown), "ss_net_paid_inc_tax" (166,Unknown), "ss_net_profit" (167,Unknown), "ctid" (168,Unknown), "xmin" (169,Unknown), "cmin" (170,Unknown), "xmax" (171,Unknown), "cmax" (172,Unknown), "tableoid" (173,Unknown), "gp_segment_id" (174,Unknown), "gp_foreign_server" (175,Unknown)] Scan Id: 1 Parts to scan: 221 [ ]

REQUIRED PROPERTIES:
req cols: ["ss_customer_sk" (145,Used), "ss_item_sk" (146,Used), "ss_sold_date_sk" (147,Used)], req CTEs: [0:p(opt) 1:p(opt) ], req order: [<empty> match: satisfy ], req dist: [NON-SINGLETON  match: satisfy], req rewind: [], req rewind: [MARK-RESTORE NO-MOTION match: satisfy], req partition propagation: [consumer<1>({10}) match: satisfy ]
DERIVED PROPERTIES:
Output Cols: ["ss_customer_sk" (145,Used), "ss_item_sk" (146,Used), "ss_sold_date_sk" (147,Used), "ss_sold_time_sk" (148,Unknown), "ss_cdemo_sk" (149,Unknown), "ss_hdemo_sk" (150,Unknown), "ss_addr_sk" (151,Unknown), "ss_store_sk" (152,Unknown), "ss_promo_sk" (153,Unknown), "ss_ticket_number" (154,Unknown), "ss_quantity" (155,Unknown), "ss_wholesale_cost" (156,Unknown), "ss_list_price" (157,Unknown), "ss_sales_price" (158,Unknown), "ss_ext_discount_amt" (159,Unknown), "ss_ext_sales_price" (160,Unknown), "ss_ext_wholesale_cost" (161,Unknown), "ss_ext_list_price" (162,Unknown), "ss_ext_tax" (163,Unknown), "ss_coupon_amt" (164,Unknown), "ss_net_paid" (165,Unknown), "ss_net_paid_inc_tax" (166,Unknown), "ss_net_profit" (167,Unknown), "ctid" (168,Unknown), "xmin" (169,Unknown), "cmin" (170,Unknown), "xmax" (171,Unknown), "cmax" (172,Unknown), "tableoid" (173,Unknown), "gp_segment_id" (174,Unknown), "gp_foreign_server" (175,Unknown)], Outer Refs: [], Not Null Cols: [], Corr. Apply Cols: [],  Keys: (["ctid" (168,Unknown), "tableoid" (173,Unknown), "gp_segment_id" (174,Unknown)]), Max Card: unbounded, Join Depth: 1, Constraint Property: [Equivalence Classes: { ("ss_item_sk" (146,Used)) ("ss_ticket_number" (154,Unknown)) } Constraint:({"ss_item_sk" (146,Used), ranges: (-inf, inf) } AND {"ss_ticket_number" (154,Unknown), ranges: (-inf, inf) })], FDs: [("ctid" (168,Unknown), "tableoid" (173,Unknown), "gp_segment_id" (174,Unknown)) --> ("ss_customer_sk" (145,Used), "ss_item_sk" (146,Used), "ss_sold_date_sk" (147,Used), "ss_sold_time_sk" (148,Unknown), "ss_cdemo_sk" (149,Unknown), "ss_hdemo_sk" (150,Unknown), "ss_addr_sk" (151,Unknown), "ss_store_sk" (152,Unknown), "ss_promo_sk" (153,Unknown), "ss_ticket_number" (154,Unknown), "ss_quantity" (155,Unknown), "ss_wholesale_cost" (156,Unknown), "ss_list_price" (157,Unknown), "ss_sales_price" (158,Unknown), "ss_ext_discount_amt" (159,Unknown), "ss_ext_sales_price" (160,Unknown), "ss_ext_wholesale_cost" (161,Unknown), "ss_ext_list_price" (162,Unknown), "ss_ext_tax" (163,Unknown), "ss_coupon_amt" (164,Unknown), "ss_net_paid" (165,Unknown), "ss_net_paid_inc_tax" (166,Unknown), "ss_net_profit" (167,Unknown), "xmin" (169,Unknown), "cmin" (170,Unknown), "xmax" (171,Unknown), "cmax" (172,Unknown), "gp_foreign_server" (175,Unknown))], Function Properties: [Immutable], Part Info: [Part Consumers: 1, Part Keys: (("ss_sold_date_sk" (147,Used)))]
Drvd Plan Props (ORD: <empty>, DIST: HASHED: [ +--CScalarIdent "ss_item_sk" (146,Used)
+--CScalarIdent "ss_ticket_number" (154,Unknown)
, nulls colocated ], opfamilies: (0.1977.1.0),(0.1977.1.0),, REWIND: REWINDABLE NO-MOTION, PART PROP:consumer<1>({})), CTE Map: []0",
2025-12-27 08:38:19:029091 CST,THD000,ERROR,"CGroupExpression.cpp:458: Failed assertion: !(COptCtxt::FAllEnforcersEnabled()) || (fValid && "Cost context carries an invalid plan")
Stack trace:
1    0x000055d572a6351a gpos::CException::Raise + 278
2    0x000055d572d0f038 gpopt::CGroupExpression::PccComputeCost + 666
3    0x000055d572d26c5d gpopt::CJobGroupExpressionOptimization::EevtOptimizeSelf + 217
4    0x000055d572d27606 gpopt::CJobStateMachine + 376
5    0x000055d572d26edf gpopt::CJobGroupExpressionOptimization::FExecute + 123
6    0x000055d572d35bbb gpopt::CScheduler::FExecute + 77
7    0x000055d572d35505 gpopt::CScheduler::ExecuteJobs + 121
8    0x000055d572d35488 gpopt::CScheduler::Run + 46
9    0x000055d572c2265d gpopt::CEngine::Optimize + 919
10   0x000055d572cfbd0f gpopt::COptimizer::PexprOptimize + 115
11   0x000055d572cfb50e gpopt::COptimizer::PdxlnOptimize + 1416
12   0x000055d572e8883d COptTasks::OptimizeTask + 1651
13   0x000055d572a77aae gpos::CTask::Execute + 202
14   0x000055d572a7a61d gpos::CWorker::Execute + 197
15   0x000055d572a75e33 gpos::CAutoTaskProxy::Execute + 227
16   0x000055d572a7c8aa gpos_exec + 933
```  
  Implements EpetRewindability() method for CPhysicalDynamicTableScan to properly
  handle rewindability enforcement. The missing implementation caused assertion
  failures in CGroupExpression when validating plan contexts, as the optimizer
  couldn't determine if rewindability requirements were satisfied.





### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
