### PR TITLE
Fix PAX build failure on GCC 8.x (Rocky Linux 8)

### DIFF
--- a/contrib/pax_storage/CMakeLists.txt
+++ b/contrib/pax_storage/CMakeLists.txt
@@ -21,7 +21,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(TOP_DIR ${PROJECT_SOURCE_DIR}/../..)
 set(CBDB_INCLUDE_DIR ${TOP_DIR}/src/include)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Werror=pessimizing-move  -Wno-unused-function -Wno-error=ignored-qualifiers -Wno-error=array-bounds  -Wuninitialized -Winit-self -Wstrict-aliasing -Wno-missing-field-initializers -Wno-unused-parameter -Wno-clobbered -Wno-sized-deallocation -g")
+# Base CXX flags
+# Note: -Wpessimizing-move is enabled by default in GCC 9+ and will be caught by -Werror
+# No need to explicitly add -Werror=pessimizing-move (which breaks GCC 8.x compatibility)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-error=ignored-qualifiers -Wno-error=array-bounds -Wuninitialized -Winit-self -Wstrict-aliasing -Wno-missing-field-initializers -Wno-unused-parameter -Wno-clobbered -Wno-sized-deallocation -g")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-parameter -Wno-parameter-name")
 
 option(USE_MANIFEST_API "Use manifest API" OFF)

--- a/contrib/pax_storage/src/cpp/catalog/pax_aux_table.cc
+++ b/contrib/pax_storage/src/cpp/catalog/pax_aux_table.cc
@@ -700,7 +700,7 @@ pax::MicroPartitionMetadata PaxGetMicroPartitionMetadata(Relation rel,
     paxc::FetchMicroPartitionAuxRow(rel, snapshot, block_id,
                                     FetchMicroPartitionAuxRowCallbackWrapper,
                                     &ctx);
-    return std::move(ctx.info);
+    return ctx.info;
   }
   CBDB_WRAP_END;
 }

--- a/contrib/pax_storage/src/cpp/comm/fast_io.cc
+++ b/contrib/pax_storage/src/cpp/comm/fast_io.cc
@@ -27,6 +27,17 @@
 
 #include "fast_io.h"
 
+#include <unistd.h>  // for pread
+
+// uring_likely may not be defined in older liburing versions
+#ifndef uring_likely
+#if __GNUC__ >= 3
+#define uring_likely(x) __builtin_expect((x) != 0, 1)
+#else
+#define uring_likely(x) ((x) != 0)
+#endif
+#endif
+
 namespace pax
 {
 


### PR DESCRIPTION
1. Remove explicit -Werror=pessimizing-move flag from CMakeLists.txt. This flag was added in commit e7e07c27a7 to catch pessimizing-move warnings on higher GCC versions, but it breaks compilation on GCC 8.x where this warning option does not exist. The fix is safe because GCC 9+ enables -Wpessimizing-move by default and the existing -Werror flag already converts all warnings to errors.

2. Fix fast_io.cc compatibility issues:
   - Add missing <unistd.h> include for pread()
   - Define uring_likely macro fallback for older liburing versions

See: Issue#1441 <https://github.com/apache/cloudberry/issues/1441>

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #1441 

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
