### PR TITLE
ORCA: Validate hash function existence in IsOpHashJoinable

### DIFF
--- a/src/test/regress/expected/gp_hashagg.out
+++ b/src/test/regress/expected/gp_hashagg.out
@@ -274,3 +274,169 @@ EXPLAIN (COSTS OFF, VERBOSE) :qry;
         
 (1 row)
 
+drop schema if exists tinc_base_types cascade;
+NOTICE:  schema "tinc_base_types" does not exist, skipping
+create schema tinc_base_types;
+set search_path=tinc_base_types;
+CREATE FUNCTION int42_in(cstring)
+   RETURNS int42
+   AS 'int4in'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  type "int42" is not yet defined
+DETAIL:  Creating a shell type definition.
+CREATE FUNCTION int42_out(int42)
+   RETURNS cstring
+   AS 'int4out'
+   LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type int42 is only a shell
+CREATE TYPE int42 (
+   internallength = 4,
+   input = int42_in,
+   output = int42_out,
+   alignment = int4,
+   default = 42,
+   passedbyvalue
+);
+CREATE TABLE aTABLE(k int, a int42);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'k' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO aTABLE VALUES(1, '21');
+INSERT INTO aTABLE VALUES(2, '22');
+INSERT INTO aTABLE VALUES(3, '23');
+INSERT INTO aTABLE VALUES(4, '24');
+SELECT * FROM aTABLE;
+ k | a  
+---+----
+ 2 | 22
+ 3 | 23
+ 4 | 24
+ 1 | 21
+(4 rows)
+
+CREATE OR REPLACE FUNCTION my_lt(int42, int42)
+RETURNS boolean AS
+'int4lt'
+language internal;
+CREATE OR REPLACE FUNCTION my_lteq(int42, int42)
+RETURNS boolean AS
+'int4le'
+language internal;
+CREATE OR REPLACE FUNCTION my_gt(int42, int42)
+RETURNS boolean AS
+'int4gt'
+language internal;
+CREATE OR REPLACE FUNCTION my_gteq(int42, int42)
+RETURNS boolean AS
+'int4ge'
+language internal;
+CREATE OR REPLACE FUNCTION my_eq(int42, int42)
+RETURNS boolean AS
+'int4eq'
+language internal;
+CREATE OPERATOR < (
+  leftarg = int42,
+  rightarg = int42,
+  procedure = my_lt,
+  hashes
+);
+CREATE OPERATOR <= (
+  leftarg = int42,
+  rightarg = int42,
+  procedure = my_lteq,
+  hashes
+);
+CREATE OPERATOR = (
+  leftarg = int42,
+  rightarg = int42,
+  procedure = my_eq,
+  hashes
+);
+CREATE OPERATOR > (
+  leftarg = int42,
+  rightarg = int42,
+  procedure = my_gt,
+  hashes
+);
+CREATE OPERATOR >= (
+  leftarg = int42,
+  rightarg = int42,
+  procedure = my_gteq,
+  hashes
+);
+CREATE OR REPLACE FUNCTION my_comp_func(int42, int42)
+RETURNS int AS
+$$
+BEGIN
+IF $1 < $2 THEN
+  return -1;
+ELSIF $1 = $2 THEN
+  return 0;
+ELSE
+  return 1;
+END IF;
+END;
+$$ LANGUAGE PLPGSQL;
+CREATE OPERATOR CLASS my_operator_class_comp_type
+DEFAULT
+FOR TYPE int42 USING btree
+AS
+OPERATOR 1 <,
+OPERATOR 2 <=,
+OPERATOR 3 =,
+OPERATOR 4 >=,
+OPERATOR 5 >,
+FUNCTION 1 my_comp_func(int42, int42);
+CREATE OPERATOR CLASS my_operator_class_comp_type_hash_lt
+DEFAULT
+FOR TYPE int42 USING hash
+AS
+OPERATOR 1 <,
+FUNCTION 1 my_comp_func(int42, int42);
+ERROR:  hash function 1 must have one argument
+CREATE OPERATOR CLASS my_operator_class_comp_type_hash_eq
+FOR TYPE int42 USING hash
+AS
+OPERATOR 1 =,
+FUNCTION 1 my_comp_func(int42, int42);
+ERROR:  hash function 1 must have one argument
+select * from atable group by a,k;
+ k | a  
+---+----
+ 1 | 21
+ 2 | 22
+ 3 | 23
+ 4 | 24
+(4 rows)
+
+-- Before fix: This would fail at runtime with:
+--   ERROR: could not find hash function for hash operator XXXXX (execGrouping.c:118)
+-- After fix: ORCA should detect missing hash function at planning time
+--   and either use GroupAgg or report a clear planning error
+SET optimizer_enable_groupagg=off;
+select * from atable group by a,k;
+ k | a  
+---+----
+ 1 | 21
+ 2 | 22
+ 3 | 23
+ 4 | 24
+(4 rows)
+
+drop schema if exists tinc_base_types cascade;
+NOTICE:  drop cascades to 16 other objects
+DETAIL:  drop cascades to function int42_out(int42)
+drop cascades to type int42
+drop cascades to function int42_in(cstring)
+drop cascades to table atable
+drop cascades to function my_lt(int42,int42)
+drop cascades to function my_lteq(int42,int42)
+drop cascades to function my_gt(int42,int42)
+drop cascades to function my_gteq(int42,int42)
+drop cascades to function my_eq(int42,int42)
+drop cascades to operator <(int42,int42)
+drop cascades to operator <=(int42,int42)
+drop cascades to operator =(int42,int42)
+drop cascades to operator >(int42,int42)
+drop cascades to operator >=(int42,int42)
+drop cascades to function my_comp_func(int42,int42)
+drop cascades to operator family my_operator_class_comp_type for access method btree


### PR DESCRIPTION
```sql
postgres=#  set optimizer_enable_groupagg=off;
SET
postgres=# explain select * from atable group by a,k;
ERROR:  could not find hash function for hash operator 78765 (execGrouping.c:118) 
```

Fix execution-time error when operators have oprcanhash=true but lack actual hash functions. Previously, ORCA would generate HashAgg plans that failed at runtime with "could not find hash function for hash operator" errors.

This occurred when operators were marked with the 'hashes' option but only registered in btree operator families, not hash operator families. The fix adds validation using get_op_hash_functions() to ensure hash functions exist before allowing HashAgg plans, moving error detection from execution to planning time.


Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
