### PR TITLE
Set join_collapse_limit default value to 13

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2290,7 +2290,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_EXPLAIN
 		},
 		&join_collapse_limit,
-		8, 1, INT_MAX,
+		13, 1, INT_MAX,
 		NULL, NULL, NULL
 	},
 	{

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -434,7 +434,7 @@ max_prepared_transactions = 250		# can be 0 or more
 #cursor_tuple_fraction = 0.1		# range 0.0-1.0
 
 #from_collapse_limit = 20
-#join_collapse_limit = 8		# 1 disables collapsing of explicit
+#join_collapse_limit = 13		# 1 disables collapsing of explicit
 					# JOIN clauses
 #force_parallel_mode = off
 #jit = on				# allow JIT compilation

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4224,7 +4224,7 @@ from tj1
 ----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----
 (0 rows)
 
-select (trunc(extract(epoch from now())) - :unix_time1) < 10 is_ok;
+select (trunc(extract(epoch from now())) - :unix_time1) < 100 is_ok;
  is_ok 
 -------
  t

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4241,7 +4241,7 @@ from tj1
 ----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----
 (0 rows)
 
-select (trunc(extract(epoch from now())) - :unix_time1) < 10 is_ok;
+select (trunc(extract(epoch from now())) - :unix_time1) < 100 is_ok;
  is_ok 
 -------
  t

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -639,7 +639,7 @@ from tj1
   join tj19 on tj18.id = tj19.id
   join tj20 on tj19.id = tj20.id;
 
-select (trunc(extract(epoch from now())) - :unix_time1) < 10 is_ok;
+select (trunc(extract(epoch from now())) - :unix_time1) < 100 is_ok;
 
 reset optimizer;
 


### PR DESCRIPTION
The default value of join_collapse_limit was 20. When this value is set and
the query contains about 20 joins (see added test), Postgres query optimizer
cannot build a plan during hours and consumes a lot of memory, because the
planner checks a lot of possible ways to join the tables. 
When join_collapse_limit is 13, the query plan is built in reasonable time.