### PR TITLE
Do not initialize program query string when unneeded.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1420,20 +1420,17 @@ close_program_pipes(ProgramPipes *program_pipes, bool ifThrow)
 {
 	int ret = 0;
 	StringInfoData sinfo;
-	initStringInfo(&sinfo);
 
 	/* just return if pipes not created, like when relation does not exist */
 	if (!program_pipes)
-	{
 		return;
-	}
+	
+	initStringInfo(&sinfo);
 
 	ret = pclose_with_stderr(program_pipes->pid, program_pipes->pipes, &sinfo);
 
 	if (ret == 0 || !ifThrow)
-	{
 		return;
-	}
 
 	if (ret == -1)
 	{


### PR DESCRIPTION
Also, while on it, beautify code to conform PG-style coding.

Per coverity report 544476
