### PR TITLE
Fix GPG verify path for staged release artifacts

### DIFF
--- a/devops/release/cloudberry-release.sh
+++ b/devops/release/cloudberry-release.sh
@@ -677,7 +677,7 @@ section "Staging release: $TAG"
   section "Verifying GPG Signature ($ARTIFACTS_DIR/${TAR_NAME}.asc) Release Artifact"
 
   if [[ "$SKIP_SIGNING" != true ]]; then
-    gpg --verify "${TAR_NAME}.asc" "$TAR_NAME"
+    gpg --verify "$ARTIFACTS_DIR/${TAR_NAME}.asc" "$ARTIFACTS_DIR/$TAR_NAME"
   else
     echo "INFO: Signature verification skipped (--skip-signing). Signature is only available when generated via this script."
   fi


### PR DESCRIPTION
Use absolute artifact paths in the GPG verification step of devops/release/cloudberry-release.sh.

Previously, the script verified SHA-512 using an absolute path but called `gpg --verify` with relative file names. When running with `--repo` from a different working directory, this could fail with "No such file or directory" even though the `.asc` file existed in the artifacts directory.

This change aligns the GPG verify command with the SHA-512 check by verifying:
  $ARTIFACTS_DIR/${TAR_NAME}.asc
against:
  $ARTIFACTS_DIR/$TAR_NAME

No behavior change for successful local runs besides making path resolution robust.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
