### PR TITLE
Fix RUN_GTEST/RUN_GBENCH leak into pax.so build

### DIFF
--- a/contrib/pax_storage/src/cpp/cmake/pax.cmake
+++ b/contrib/pax_storage/src/cpp/cmake/pax.cmake
@@ -223,7 +223,6 @@ add_custom_command(TARGET pax POST_BUILD
 
 if (BUILD_GTEST)
   add_subdirectory(contrib/googletest)
-  ADD_DEFINITIONS(-DRUN_GTEST)
   file(GLOB test_case_sources
     pax_gtest_helper.cc
     pax_gtest.cc
@@ -231,6 +230,7 @@ if (BUILD_GTEST)
     ${CMAKE_CURRENT_SOURCE_DIR}/*/*/*_test.cc)
 
   add_executable(test_main ${pax_target_src} ${test_case_sources})
+  target_compile_definitions(test_main PRIVATE RUN_GTEST)
   add_dependencies(test_main ${pax_target_dependencies} gtest gmock)
   target_include_directories(test_main PUBLIC ${pax_target_include} ${CMAKE_CURRENT_SOURCE_DIR} ${gtest_SOURCE_DIR}/include contrib/cpp-stub/src/ contrib/cpp-stub/src_linux/)
 
@@ -240,13 +240,13 @@ endif(BUILD_GTEST)
 
 if(BUILD_GBENCH)
   add_subdirectory(contrib/googlebench)
-  ADD_DEFINITIONS(-DRUN_GBENCH)
   file(GLOB bench_sources
       pax_gbench.cc
       ${CMAKE_CURRENT_SOURCE_DIR}/*/*_bench.cc
       ${CMAKE_CURRENT_SOURCE_DIR}/*/*/*_bench.cc)
 
     add_executable(bench_main ${pax_target_src} ${bench_sources})
+    target_compile_definitions(bench_main PRIVATE RUN_GBENCH)
     add_dependencies(bench_main ${pax_target_dependencies} gtest gmock)
     target_include_directories(bench_main PUBLIC ${pax_target_include} ${CMAKE_CURRENT_SOURCE_DIR} contrib/googlebench/include contrib/cpp-stub/src/ contrib/cpp-stub/src_linux/)
     link_directories(contrib/googlebench/src)


### PR DESCRIPTION
ADD_DEFINITIONS(-DRUN_GTEST) and ADD_DEFINITIONS(-DRUN_GBENCH) are directory-scoped CMake commands that apply to ALL targets, including the production pax shared library. This caused test- only macros to be defined in production builds.

In pax_porc_adpater.cc, the leaked RUN_GTEST activates:

    expect_hdr = rel_tuple_desc_->attrs[index].attlen == -1 &&
                 rel_tuple_desc_->attrs[index].attbyval == false;

    #ifdef RUN_GTEST
    expect_hdr = false;
    #endif

This forces expect_hdr to false in production, skipping the stripping of PostgreSQL varlena headers from dictionary entries. As a result, dictionary-encoded string columns return garbled data (varlena header bytes are included as part of the string content).

Replace ADD_DEFINITIONS with target_compile_definitions scoped to test_main and bench_main targets only, so RUN_GTEST and RUN_GBENCH are no longer defined when building pax.so.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
