### PR TITLE
Fix sed -i compatibility on macOS in configure

### DIFF
--- a/configure
+++ b/configure
@@ -24833,4 +24833,11 @@ fi
 # The configure args contain '-Wl,-rpath,\$$ORIGIN`, when it falls
 # as a C literal string, it's invalid, so converting `\` to `\\`
 # to be correct for C program.
-sed -i '/define CONFIGURE_ARGS/s,\([^\\]\)\\\$\$,\1\\\\$$,g' src/include/pg_config.h
+case $build_os in
+darwin*)
+  sed -i '' '/define CONFIGURE_ARGS/s,\([^\\]\)\\\$\$,\1\\\\$$,g' src/include/pg_config.h
+  ;;
+*)
+  sed -i '/define CONFIGURE_ARGS/s,\([^\\]\)\\\$\$,\1\\\\$$,g' src/include/pg_config.h
+  ;;
+esac


### PR DESCRIPTION
macOS BSD sed requires an explicit empty string argument after -i (sed -i '' 'script' file), unlike GNU sed which takes -i without a suffix argument. Without this fix, BSD sed misinterprets the sed script as a backup suffix and treats the filename as the script, causing "unterminated substitute pattern" error.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #28, #1335

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
