### PR TITLE
Fix the issue of duplicate counting of num_executed in gp_toolkit.gp_resgroup_status

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3700,7 +3700,6 @@ check_and_unassign_from_resgroup(PlannedStmt* stmt)
 	} while (!groupIncBypassedRef(&groupInfo));
 
 	bypassedGroup = groupInfo.group;
-	bypassedGroup->totalExecuted++;
 	pgstat_report_resgroup(bypassedGroup->groupId);
 	bypassedSlot.group = groupInfo.group;
 	bypassedSlot.groupId = groupInfo.groupId;

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass.out
@@ -276,6 +276,24 @@ SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
 1q: ... <quitting>
 2q: ... <quitting>
 
+-- verify the increment of num_executed in gp_toolkit.gp_resgroup_status
+1: SET ROLE role_bypass;
+SET
+1: SELECT num_executed INTO temporary temp_num1 FROM gp_toolkit.gp_resgroup_status WHERE groupname='rg_bypass';
+SELECT 1
+1: SELECT num_executed INTO temporary temp_num2 FROM gp_toolkit.gp_resgroup_status WHERE groupname='rg_bypass';
+SELECT 1
+1: SELECT temp_num2.num_executed - temp_num1.num_executed AS delta FROM temp_num1, temp_num2;
+ delta 
+-------
+ 1     
+(1 row)
+1: DROP TABLE temp_num1;
+DROP
+1: DROP TABLE temp_num2;
+DROP
+1q: ... <quitting>
+
 -- cleanup
 -- start_ignore
 DROP TABLE t_bypass;

--- a/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
@@ -133,6 +133,15 @@ SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
 1q:
 2q:
 
+-- verify the increment of num_executed in gp_toolkit.gp_resgroup_status
+1: SET ROLE role_bypass;
+1: SELECT num_executed INTO temporary temp_num1 FROM gp_toolkit.gp_resgroup_status WHERE groupname='rg_bypass';
+1: SELECT num_executed INTO temporary temp_num2 FROM gp_toolkit.gp_resgroup_status WHERE groupname='rg_bypass';
+1: SELECT temp_num2.num_executed - temp_num1.num_executed AS delta FROM temp_num1, temp_num2;
+1: DROP TABLE temp_num1;
+1: DROP TABLE temp_num2;
+1q:
+
 -- cleanup
 -- start_ignore
 DROP TABLE t_bypass;


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

### What does this PR do?

Fix the issue of duplicate counting of num_executed in gp_toolkit.gp_resgroup_status
This is a defect of the original GPDB.
When enabling resource group management and the transaction switches from "Assigned" to "Bypass" state, the "num_executed" counter is repeatedly counted.

**Reproducing test cases:**

1. Enable resource group: set gp_resource_manager to "group".

2. Log in with the default superuser.

3. Execute gp_toolkit.gp_resgroup_status twice.

```sql
SELECT groupname, num_executed FROM gp_toolkit.gp_resgroup_status WHERE groupname='admin_group';
 groupname   | num_executed 
-------------+--------------
 admin_group | 31           
(1 row)
SELECT groupname, num_executed FROM gp_toolkit.gp_resgroup_status WHERE groupname='admin_group';
 groupname   | num_executed 
-------------+--------------
 admin_group | 33           
(1 row)
```

The test case has been added to:

‎src/test/isolation2/sql/resgroup/resgroup_bypass.sql

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
