### PR TITLE
Revert "Fix copy to replicated table display copy number is incorrect."

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -432,11 +432,6 @@ DoCopy(ParseState *pstate, const CopyStmt *stmt,
 			else
 				*processed = CopyFrom(cstate);	/* copy from file to database */
 
-			/* Handle copy to replicated table returns processed number */
-			if (Gp_role == GP_ROLE_DISPATCH &&
-				GpPolicyIsReplicated(cstate->rel->rd_cdbpolicy))
-				*processed = *processed / cstate->rel->rd_cdbpolicy->numsegments;
-
 			/*
 			 * Update view info if we actualy copy data from other place.
 			 */

--- a/src/test/isolation2/expected/ao_unique_index.out
+++ b/src/test/isolation2/expected/ao_unique_index.out
@@ -390,12 +390,12 @@ CREATE
 1: BEGIN;
 BEGIN
 1: COPY unique_index_ao_row FROM PROGRAM 'seq 1 10';
-COPY 10
+COPY 30
 -- concurrent tx inserting conflicting row should block.
 2&: COPY unique_index_ao_row FROM PROGRAM 'seq 1 1';  <waiting ...>
 -- concurrent tx inserting non-conflicting rows should be successful.
 3: COPY unique_index_ao_row FROM PROGRAM 'seq 11 20';
-COPY 10
+COPY 30
 -- inserting a conflicting row in the same transaction should ERROR out.
 1: COPY unique_index_ao_row FROM PROGRAM 'seq 1 1';
 ERROR:  duplicate key value violates unique constraint "unique_index_ao_row_a_key"
@@ -403,7 +403,7 @@ DETAIL:  Key (a)=(1) already exists.
 CONTEXT:  COPY unique_index_ao_row, line 1
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:  <... completed>
-COPY 1
+COPY 3
 1: END;
 END
 

--- a/src/test/isolation2/expected/aocs_unique_index.out
+++ b/src/test/isolation2/expected/aocs_unique_index.out
@@ -390,12 +390,12 @@ CREATE
 1: BEGIN;
 BEGIN
 1: COPY unique_index_ao_column FROM PROGRAM 'seq 1 10';
-COPY 10
+COPY 30
 -- concurrent tx inserting conflicting row should block.
 2&: COPY unique_index_ao_column FROM PROGRAM 'seq 1 1';  <waiting ...>
 -- concurrent tx inserting non-conflicting rows should be successful.
 3: COPY unique_index_ao_column FROM PROGRAM 'seq 11 20';
-COPY 10
+COPY 30
 -- inserting a conflicting row in the same transaction should ERROR out.
 1: COPY unique_index_ao_column FROM PROGRAM 'seq 1 1';
 ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"
@@ -403,7 +403,7 @@ DETAIL:  Key (a)=(1) already exists.
 CONTEXT:  COPY unique_index_ao_column, line 1
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:  <... completed>
-COPY 1
+COPY 3
 1: END;
 END
 


### PR DESCRIPTION
This reverts commit cfd2ce478fea76f6cfc355aa58ea1e90a069221e.

The reverted change normalizes COPY FROM row counts on replicated tables by dividing by the number of segments. This causes inconsistent and misleading completion tags (e.g. COPY TO reports N*segments while COPY FROM reports N for the same replicated data).

It also produces arbitrary results in ON SEGMENT workflows used by backup/restore. For example, on a 4-segment cluster, loading three 100-row files and one empty file can report 75 rows ((100*3)/4), which is not a meaningful load count.

Restore Greenplum-compatible behavior by reporting aggregated completed rows.

Refs:
- https://github.com/apache/cloudberry/issues/1298
- https://github.com/apache/cloudberry-backup/pull/36