### PR TITLE
ORCA: keep HAVING above a scalar GbAgg in CNormalizer::FPushable

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CNormalizer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CNormalizer.cpp
@@ -18,6 +18,7 @@
 #include "gpopt/base/CUtils.h"
 #include "gpopt/operators/CLogical.h"
 #include "gpopt/operators/CLogicalConstTableGet.h"
+#include "gpopt/operators/CLogicalGbAgg.h"
 #include "gpopt/operators/CLogicalInnerJoin.h"
 #include "gpopt/operators/CLogicalLeftOuterCorrelatedApply.h"
 #include "gpopt/operators/CLogicalLeftOuterJoin.h"
@@ -122,6 +123,18 @@ CNormalizer::FPushable(CExpression *pexprLogical, CExpression *pexprPred)
 	// while it processes each row
 	if (COperator::EopLogicalGbAgg == pexprLogical->Pop()->Eopid() &&
 		(CPredicateUtils::FContainsVolatileFunction(pexprPred)))
+	{
+		return false;
+	}
+
+	// do not push predicates below a scalar (plain) aggregate, i.e. one with
+	// no grouping columns. A scalar aggregate produces exactly one output row
+	// regardless of input cardinality, so a predicate above it (HAVING clause)
+	// must be evaluated against that output row, not the aggregate's input.
+	// Pushing e.g. "HAVING false" below would leave the agg emitting one row
+	// (e.g. count = 0) instead of zero rows.
+	if (COperator::EopLogicalGbAgg == pexprLogical->Pop()->Eopid() &&
+		0 == CLogicalGbAgg::PopConvert(pexprLogical->Pop())->Pdrgpcr()->Size())
 	{
 		return false;
 	}

--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -958,6 +958,25 @@ explain (costs off)
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- HAVING with constant-false predicate on an empty grouping set must emit
+-- zero rows, not the default scalar-aggregate row.
+select count(*) from gstest2 group by grouping sets (()) having false;
+ count 
+-------
+(0 rows)
+
+explain (costs off)
+  select count(*) from gstest2 group by grouping sets (()) having false;
+             QUERY PLAN
+-------------------------------------
+ Aggregate
+   Group Key: ()
+   Filter: false
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(6 rows)
+
 -- HAVING with GROUPING queries
 select ten, grouping(ten) from onek
 group by grouping sets(ten) having grouping(ten) >= 0

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -975,6 +975,22 @@ explain (costs off)
  Optimizer: GPORCA
 (13 rows)
 
+-- HAVING with constant-false predicate on an empty grouping set must emit
+-- zero rows, not the default scalar-aggregate row.
+select count(*) from gstest2 group by grouping sets (()) having false;
+ count 
+-------
+(0 rows)
+
+explain (costs off)
+  select count(*) from gstest2 group by grouping sets (()) having false;
+        QUERY PLAN
+--------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: GPORCA
+(3 rows)
+
 -- HAVING with GROUPING queries
 select ten, grouping(ten) from onek
 group by grouping sets(ten) having grouping(ten) >= 0

--- a/src/test/regress/sql/groupingsets.sql
+++ b/src/test/regress/sql/groupingsets.sql
@@ -353,6 +353,12 @@ explain (costs off)
   select v.c, (select count(*) from gstest2 group by () having v.c)
     from (values (false),(true)) v(c) order by v.c;
 
+-- HAVING with constant-false predicate on an empty grouping set must emit
+-- zero rows, not the default scalar-aggregate row.
+select count(*) from gstest2 group by grouping sets (()) having false;
+explain (costs off)
+  select count(*) from gstest2 group by grouping sets (()) having false;
+
 -- HAVING with GROUPING queries
 select ten, grouping(ten) from onek
 group by grouping sets(ten) having grouping(ten) >= 0


### PR DESCRIPTION
A scalar (plain) aggregate with no grouping columns always emits exactly one row regardless of input cardinality. Predicates above it (from a HAVING clause) filter that output row, so they cannot be moved onto the aggregate's input without changing semantics:

  SELECT count(*) FROM t HAVING false      -- 0 rows
  SELECT count(*) FROM t WHERE  false      -- 1 row (count=0)

CNormalizer::FPushable previously only blocked pushing volatile predicates below a GbAgg. Any other predicate -- including a constant false -- was considered pushable because its used-column set was trivially contained in the aggregate's output columns. The normalizer then routed the Select's predicate through the GbAgg and down into its logical child, dropping HAVING semantics for scalar aggregates.


Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
