### PR TITLE
Fix ORCA fallback for unsafe targetlist functions

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -225,9 +225,10 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL(
 		CheckSirvFuncsWithoutFromClause(query);
 	}
 
-	// Add a separate guard for targetlist functions that are unsafe to
-	// execute on the coordinator.
-	CheckUnsafeSirvFuncsInTargetList(query);
+	// Add a separate guard for targetlist expressions that mix SIRV
+	// functions with current-level Vars from the FROM clause. Those
+	// expressions are row-dependent and must stay on the QEs.
+	CheckSirvFuncsWithCurrentLevelVarsInTargetList(query);
 
 	// first normalize the query
 	m_query =
@@ -267,37 +268,6 @@ CTranslatorQueryToDXL::QueryToDXLInstance(CMemoryPool *mp,
 							  false,   // is_top_query_dml
 							  nullptr  // query_level_to_cte_map
 		);
-}
-
-static BOOL
-HasUnsafeCoordinatorFunc(Oid funcid)
-{
-	HeapTuple	proctup;
-	HeapTuple	langtup;
-	Form_pg_proc procform;
-	Form_pg_language langform;
-	BOOL		is_unsafe;
-
-	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
-	if (!HeapTupleIsValid(proctup))
-		elog(ERROR, "cache lookup failed for function %u", funcid);
-
-	procform = (Form_pg_proc) GETSTRUCT(proctup);
-	langtup = SearchSysCache1(LANGOID, ObjectIdGetDatum(procform->prolang));
-	if (!HeapTupleIsValid(langtup))
-	{
-		ReleaseSysCache(proctup);
-		elog(ERROR, "cache lookup failed for language %u", procform->prolang);
-	}
-
-	langform = (Form_pg_language) GETSTRUCT(langtup);
-	is_unsafe = (strcmp(NameStr(langform->lanname), "internal") != 0 &&
-				 strcmp(NameStr(langform->lanname), "c") != 0);
-
-	ReleaseSysCache(langtup);
-	ReleaseSysCache(proctup);
-
-	return is_unsafe;
 }
 
 //---------------------------------------------------------------------------
@@ -400,8 +370,7 @@ CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause(Query *query)
 	{
 		// see if we have SIRV functions in the immediate target list
 		if (HasSirvFunctions((Node *) query->targetList,
-							 false /*descend_into_subqueries*/,
-							 false /*check_coordinator_safety*/))
+							 false /*descend_into_subqueries*/))
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 					   GPOS_WSZ_LIT("SIRV functions"));
@@ -434,37 +403,46 @@ CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause(Query *query)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::CheckUnsafeSirvFuncsInTargetList
+//		CTranslatorQueryToDXL::CheckSirvFuncsWithCurrentLevelVarsInTargetList
 //
 //	@doc:
-//		Check for SIRV functions in the target list that may be unsafe to
-//		execute on the coordinator and throw an exception when found.
+//		Check for target list expressions that contain both SIRV functions and
+//		current-level Vars from the FROM clause, and throw an exception when
+//		found.
 //
 //		ORCA can place target list projections above a Motion and execute
-//		them on the coordinator. That is unsafe for procedural or SQL-language
-//		SIRV functions because they may perform SPI, dispatch, or other
-//		volatile work that must not be moved to the coordinator in a
-//		distributed query. Only inspect the immediate target list expression
-//		tree here; functions inside nested subqueries are planned within their
-//		own query context and should not force a fallback for the outer query.
+//		them on the coordinator. If a SIRV expression also depends on columns
+//		produced by the current query's FROM clause, it is row-dependent and
+//		must stay on the segment workers alongside those rows. Only inspect
+//		the immediate target list expression tree here; functions or Vars
+//		inside nested subqueries are planned within their own query context
+//		and should not force a fallback for the outer query.
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorQueryToDXL::CheckUnsafeSirvFuncsInTargetList(Query *query)
+CTranslatorQueryToDXL::CheckSirvFuncsWithCurrentLevelVarsInTargetList(
+	Query *query)
 {
+	ListCell *lc = nullptr;
+
 	// if target list is empty, look no further
 	if (NIL == query->targetList)
 	{
 		return;
 	}
 
-	// see if we have unsafe coordinator functions in the target list
-	if (HasSirvFunctions((Node *) query->targetList,
-						 false /*descend_into_subqueries*/,
-						 true /*check_coordinator_safety*/))
+	ForEach(lc, query->targetList)
 	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("SIRV functions"));
+		TargetEntry *target_entry = (TargetEntry *) lfirst(lc);
+
+		if (HasSirvFunctions((Node *) target_entry->expr,
+							 false /*descend_into_subqueries*/) &&
+			HasCurrentLevelVars((Node *) target_entry->expr,
+								false /*descend_into_subqueries*/))
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					   GPOS_WSZ_LIT("SIRV functions"));
+		}
 	}
 }
 
@@ -478,8 +456,7 @@ CTranslatorQueryToDXL::CheckUnsafeSirvFuncsInTargetList(Query *query)
 //---------------------------------------------------------------------------
 BOOL
 CTranslatorQueryToDXL::HasSirvFunctions(Node *node,
-										bool descend_into_subqueries,
-										bool check_coordinator_safety) const
+										bool descend_into_subqueries) const
 {
 	GPOS_ASSERT(nullptr != node);
 
@@ -492,9 +469,7 @@ CTranslatorQueryToDXL::HasSirvFunctions(Node *node,
 	{
 		FuncExpr *func_expr = (FuncExpr *) lfirst(lc);
 		if (CTranslatorUtils::IsSirvFunc(m_mp, m_md_accessor,
-										 func_expr->funcid) &&
-			(!check_coordinator_safety ||
-			 HasUnsafeCoordinatorFunc(func_expr->funcid)))
+										 func_expr->funcid))
 		{
 			has_sirv = true;
 			break;
@@ -503,6 +478,41 @@ CTranslatorQueryToDXL::HasSirvFunctions(Node *node,
 	gpdb::ListFree(function_list);
 
 	return has_sirv;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorQueryToDXL::HasCurrentLevelVars
+//
+//	@doc:
+//		Check for Vars from the current query level in the tree rooted at the
+//		given node
+//
+//---------------------------------------------------------------------------
+BOOL
+CTranslatorQueryToDXL::HasCurrentLevelVars(Node *node,
+										   bool descend_into_subqueries) const
+{
+	GPOS_ASSERT(nullptr != node);
+
+	List *var_list = gpdb::ExtractNodesExpression(node, T_Var,
+												  descend_into_subqueries);
+	ListCell *lc = nullptr;
+
+	BOOL has_current_level_var = false;
+	ForEach(lc, var_list)
+	{
+		Var *var = (Var *) lfirst(lc);
+
+		if (0 == var->varlevelsup)
+		{
+			has_current_level_var = true;
+			break;
+		}
+	}
+	gpdb::ListFree(var_list);
+
+	return has_current_level_var;
 }
 
 //---------------------------------------------------------------------------
@@ -4018,8 +4028,7 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 	// check if arguments contain SIRV functions
 	if (NIL != funcexpr->args &&
 		HasSirvFunctions((Node *) funcexpr->args,
-						 true /*descend_into_subqueries*/,
-						 false /*check_coordinator_safety*/))
+						 true /*descend_into_subqueries*/))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("SIRV functions"));

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -216,8 +216,18 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL(
 	// check if the query has any unsupported node types
 	CheckUnsupportedNodeTypes(query);
 
-	// check if the query has SIRV functions in the targetlist
-	CheckSirvFuncsInTargetList(query);
+	// Preserve the historical fallback for SIRV functions in targetlists
+	// without a FROM clause for statement-level and derived-table queries.
+	// Scalar subqueries use a copied outer var mapping and should retain
+	// ORCA's existing handling for expressions such as nested random().
+	if (nullptr == var_colid_mapping)
+	{
+		CheckSirvFuncsWithoutFromClause(query);
+	}
+
+	// Add a separate guard for targetlist functions that are unsafe to
+	// execute on the coordinator.
+	CheckUnsafeSirvFuncsInTargetList(query);
 
 	// first normalize the query
 	m_query =
@@ -371,20 +381,76 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes(Query *query)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::CheckSirvFuncsInTargetList
+//		CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause
 //
 //	@doc:
-//		Check for SIRV functions in the target list, and throw an exception
-//		when found.
-//
-//		ORCA can place target list projections above a Motion and execute
-//		them on the coordinator. That is unsafe for SIRV functions because
-//		they may perform SPI, dispatch, or other volatile work that must not
-//		be moved to the coordinator in a distributed query.
+//		Check for SIRV functions in the target list without a FROM clause, and
+//		throw an exception when found
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorQueryToDXL::CheckSirvFuncsInTargetList(Query *query)
+CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause(Query *query)
+{
+	ListCell *lc = nullptr;
+
+	// if there is a FROM clause or if target list is empty, look no further
+	if (!((nullptr != query->jointree &&
+		   0 < gpdb::ListLength(query->jointree->fromlist)) ||
+		  NIL == query->targetList))
+	{
+		// see if we have SIRV functions in the immediate target list
+		if (HasSirvFunctions((Node *) query->targetList,
+							 false /*descend_into_subqueries*/,
+							 false /*check_coordinator_safety*/))
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					   GPOS_WSZ_LIT("SIRV functions"));
+		}
+	}
+
+	// Derived tables should keep the legacy fallback behavior, but scalar
+	// subqueries in targetlist expressions are handled separately and must
+	// not force an outer-query fallback.
+	ForEach(lc, query->rtable)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+
+		if (RTE_SUBQUERY == rte->rtekind && nullptr != rte->subquery)
+		{
+			CheckSirvFuncsWithoutFromClause(rte->subquery);
+		}
+	}
+
+	ForEach(lc, query->cteList)
+	{
+		CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+
+		if (nullptr != cte->ctequery)
+		{
+			CheckSirvFuncsWithoutFromClause((Query *) cte->ctequery);
+		}
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorQueryToDXL::CheckUnsafeSirvFuncsInTargetList
+//
+//	@doc:
+//		Check for SIRV functions in the target list that may be unsafe to
+//		execute on the coordinator and throw an exception when found.
+//
+//		ORCA can place target list projections above a Motion and execute
+//		them on the coordinator. That is unsafe for procedural or SQL-language
+//		SIRV functions because they may perform SPI, dispatch, or other
+//		volatile work that must not be moved to the coordinator in a
+//		distributed query. Only inspect the immediate target list expression
+//		tree here; functions inside nested subqueries are planned within their
+//		own query context and should not force a fallback for the outer query.
+//
+//---------------------------------------------------------------------------
+void
+CTranslatorQueryToDXL::CheckUnsafeSirvFuncsInTargetList(Query *query)
 {
 	// if target list is empty, look no further
 	if (NIL == query->targetList)
@@ -392,8 +458,10 @@ CTranslatorQueryToDXL::CheckSirvFuncsInTargetList(Query *query)
 		return;
 	}
 
-	// see if we have SIRV functions in the target list
-	if (HasSirvFunctions((Node *) query->targetList))
+	// see if we have unsafe coordinator functions in the target list
+	if (HasSirvFunctions((Node *) query->targetList,
+						 false /*descend_into_subqueries*/,
+						 true /*check_coordinator_safety*/))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("SIRV functions"));
@@ -405,20 +473,18 @@ CTranslatorQueryToDXL::CheckSirvFuncsInTargetList(Query *query)
 //		CTranslatorQueryToDXL::HasSirvFunctions
 //
 //	@doc:
-//		Check for SIRV functions in the tree rooted at the given node that
-//		might be unsafe to execute on the coordinator. ORCA already handles
-//		volatile built-in/internal functions like random(), but procedural
-//		or SQL-language functions can execute SPI and must not be moved above
-//		a Motion.
+//		Check for SIRV functions in the tree rooted at the given node
 //
 //---------------------------------------------------------------------------
 BOOL
-CTranslatorQueryToDXL::HasSirvFunctions(Node *node) const
+CTranslatorQueryToDXL::HasSirvFunctions(Node *node,
+										bool descend_into_subqueries,
+										bool check_coordinator_safety) const
 {
 	GPOS_ASSERT(nullptr != node);
 
 	List *function_list = gpdb::ExtractNodesExpression(
-		node, T_FuncExpr, true /*descendIntoSubqueries*/);
+		node, T_FuncExpr, descend_into_subqueries);
 	ListCell *lc = nullptr;
 
 	BOOL has_sirv = false;
@@ -427,7 +493,8 @@ CTranslatorQueryToDXL::HasSirvFunctions(Node *node) const
 		FuncExpr *func_expr = (FuncExpr *) lfirst(lc);
 		if (CTranslatorUtils::IsSirvFunc(m_mp, m_md_accessor,
 										 func_expr->funcid) &&
-			HasUnsafeCoordinatorFunc(func_expr->funcid))
+			(!check_coordinator_safety ||
+			 HasUnsafeCoordinatorFunc(func_expr->funcid)))
 		{
 			has_sirv = true;
 			break;
@@ -3949,7 +4016,10 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 	FuncExpr *funcexpr = (FuncExpr *) rtfunc->funcexpr;
 
 	// check if arguments contain SIRV functions
-	if (NIL != funcexpr->args && HasSirvFunctions((Node *) funcexpr->args))
+	if (NIL != funcexpr->args &&
+		HasSirvFunctions((Node *) funcexpr->args,
+						 true /*descend_into_subqueries*/,
+						 false /*check_coordinator_safety*/))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 				   GPOS_WSZ_LIT("SIRV functions"));

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -20,12 +20,15 @@ extern "C" {
 #include "access/sysattr.h"
 #include "catalog/heap.h"
 #include "catalog/pg_class.h"
+#include "catalog/pg_language.h"
+#include "catalog/pg_proc.h"
 #include "nodes/makefuncs.h"
 #include "nodes/parsenodes.h"
 #include "nodes/plannodes.h"
 #include "optimizer/walkers.h"
 #include "utils/guc.h"
 #include "utils/rel.h"
+#include "utils/syscache.h"
 }
 
 #include "gpos/base.h"
@@ -213,8 +216,8 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL(
 	// check if the query has any unsupported node types
 	CheckUnsupportedNodeTypes(query);
 
-	// check if the query has SIRV functions in the targetlist without a FROM clause
-	CheckSirvFuncsWithoutFromClause(query);
+	// check if the query has SIRV functions in the targetlist
+	CheckSirvFuncsInTargetList(query);
 
 	// first normalize the query
 	m_query =
@@ -254,6 +257,37 @@ CTranslatorQueryToDXL::QueryToDXLInstance(CMemoryPool *mp,
 							  false,   // is_top_query_dml
 							  nullptr  // query_level_to_cte_map
 		);
+}
+
+static BOOL
+HasUnsafeCoordinatorFunc(Oid funcid)
+{
+	HeapTuple	proctup;
+	HeapTuple	langtup;
+	Form_pg_proc procform;
+	Form_pg_language langform;
+	BOOL		is_unsafe;
+
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(proctup))
+		elog(ERROR, "cache lookup failed for function %u", funcid);
+
+	procform = (Form_pg_proc) GETSTRUCT(proctup);
+	langtup = SearchSysCache1(LANGOID, ObjectIdGetDatum(procform->prolang));
+	if (!HeapTupleIsValid(langtup))
+	{
+		ReleaseSysCache(proctup);
+		elog(ERROR, "cache lookup failed for language %u", procform->prolang);
+	}
+
+	langform = (Form_pg_language) GETSTRUCT(langtup);
+	is_unsafe = (strcmp(NameStr(langform->lanname), "internal") != 0 &&
+				 strcmp(NameStr(langform->lanname), "c") != 0);
+
+	ReleaseSysCache(langtup);
+	ReleaseSysCache(proctup);
+
+	return is_unsafe;
 }
 
 //---------------------------------------------------------------------------
@@ -337,20 +371,23 @@ CTranslatorQueryToDXL::CheckUnsupportedNodeTypes(Query *query)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause
+//		CTranslatorQueryToDXL::CheckSirvFuncsInTargetList
 //
 //	@doc:
-//		Check for SIRV functions in the target list without a FROM clause, and
-//		throw an exception when found
+//		Check for SIRV functions in the target list, and throw an exception
+//		when found.
+//
+//		ORCA can place target list projections above a Motion and execute
+//		them on the coordinator. That is unsafe for SIRV functions because
+//		they may perform SPI, dispatch, or other volatile work that must not
+//		be moved to the coordinator in a distributed query.
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause(Query *query)
+CTranslatorQueryToDXL::CheckSirvFuncsInTargetList(Query *query)
 {
-	// if there is a FROM clause or if target list is empty, look no further
-	if ((nullptr != query->jointree &&
-		 0 < gpdb::ListLength(query->jointree->fromlist)) ||
-		NIL == query->targetList)
+	// if target list is empty, look no further
+	if (NIL == query->targetList)
 	{
 		return;
 	}
@@ -368,7 +405,11 @@ CTranslatorQueryToDXL::CheckSirvFuncsWithoutFromClause(Query *query)
 //		CTranslatorQueryToDXL::HasSirvFunctions
 //
 //	@doc:
-//		Check for SIRV functions in the tree rooted at the given node
+//		Check for SIRV functions in the tree rooted at the given node that
+//		might be unsafe to execute on the coordinator. ORCA already handles
+//		volatile built-in/internal functions like random(), but procedural
+//		or SQL-language functions can execute SPI and must not be moved above
+//		a Motion.
 //
 //---------------------------------------------------------------------------
 BOOL
@@ -385,7 +426,8 @@ CTranslatorQueryToDXL::HasSirvFunctions(Node *node) const
 	{
 		FuncExpr *func_expr = (FuncExpr *) lfirst(lc);
 		if (CTranslatorUtils::IsSirvFunc(m_mp, m_md_accessor,
-										 func_expr->funcid))
+										 func_expr->funcid) &&
+			HasUnsafeCoordinatorFunc(func_expr->funcid))
 		{
 			has_sirv = true;
 			break;

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -150,12 +150,17 @@ private:
 	// walker to check if SUBLINK node is present in the security quals
 	static BOOL CheckSublinkInSecurityQuals(Node *node, void *context);
 
-	// check for SIRV functions in the targetlist and throw an exception
-	// when found
-	void CheckSirvFuncsInTargetList(Query *query);
+	// check for SIRV functions in the targetlist without a FROM clause and
+	// throw an exception when found
+	void CheckSirvFuncsWithoutFromClause(Query *query);
+
+	// check for targetlist SIRV functions that may be unsafe to execute on the
+	// coordinator, and throw an exception when found
+	void CheckUnsafeSirvFuncsInTargetList(Query *query);
 
 	// check for SIRV functions in the tree rooted at the given node
-	BOOL HasSirvFunctions(Node *node) const;
+	BOOL HasSirvFunctions(Node *node, bool descend_into_subqueries,
+						  bool check_coordinator_safety) const;
 
 	// translate FromExpr (in the GPDB query) into a CDXLLogicalJoin or CDXLLogicalGet
 	CDXLNode *TranslateFromExprToDXL(FromExpr *from_expr);

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -150,9 +150,9 @@ private:
 	// walker to check if SUBLINK node is present in the security quals
 	static BOOL CheckSublinkInSecurityQuals(Node *node, void *context);
 
-	// check for SIRV functions in the targetlist without a FROM clause and
-	// throw an exception when found
-	void CheckSirvFuncsWithoutFromClause(Query *query);
+	// check for SIRV functions in the targetlist and throw an exception
+	// when found
+	void CheckSirvFuncsInTargetList(Query *query);
 
 	// check for SIRV functions in the tree rooted at the given node
 	BOOL HasSirvFunctions(Node *node) const;

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -154,13 +154,16 @@ private:
 	// throw an exception when found
 	void CheckSirvFuncsWithoutFromClause(Query *query);
 
-	// check for targetlist SIRV functions that may be unsafe to execute on the
-	// coordinator, and throw an exception when found
-	void CheckUnsafeSirvFuncsInTargetList(Query *query);
+	// check for targetlist expressions that contain both SIRV functions and
+	// current-level Vars from the query's FROM clause, and throw an exception
+	// when found
+	void CheckSirvFuncsWithCurrentLevelVarsInTargetList(Query *query);
 
 	// check for SIRV functions in the tree rooted at the given node
-	BOOL HasSirvFunctions(Node *node, bool descend_into_subqueries,
-						  bool check_coordinator_safety) const;
+	BOOL HasSirvFunctions(Node *node, bool descend_into_subqueries) const;
+
+	// check for Vars from the current query level in the given tree
+	BOOL HasCurrentLevelVars(Node *node, bool descend_into_subqueries) const;
 
 	// translate FromExpr (in the GPDB query) into a CDXLLogicalJoin or CDXLLogicalGet
 	CDXLNode *TranslateFromExprToDXL(FromExpr *from_expr);


### PR DESCRIPTION
Fixes #1660

### What does this PR do?
This PR fixes an ORCA planning issue where unsafe target list functions, such as the PL/pgSQL function used in the reported reproduction, could be planned in a way that made them execute on the coordinator instead of the expected worker path.

To address that, the change teaches ORCA to fall back to the Postgres planner when the target list contains an unsafe SIRV function implemented in a non-`internal` and non-`c` language. This keeps the fallback narrowly scoped so built-in volatile functions that ORCA already handles correctly are unaffected, while PL/pgSQL and similar procedural functions no longer get placed above Motion nodes in unsafe ways.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
None.

### Test Plan
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

How this was tested:
- Synced to the latest `upstream/main` before making changes.
- Built a fresh local Cloudberry sandbox image from this branch using the repo’s Docker sandbox workflow.
- Started a patched cluster from that image and reproduced the reported `test_conv(...)` / UTF-8 verification scenario with `optimizer=on`.
- Confirmed the query no longer fails under ORCA mode and instead falls back to the Postgres planner for this unsafe target list function shape.
- Re-ran the same reproduction with `optimizer=off` to confirm the expected control behavior matched.
- Re-ran the `optimizer=on` reproduction a second time to verify the result was stable.
- Verified that ordinary queries still use GPORCA, so the fallback remains narrowly targeted.
- Ran `git diff --check` to confirm there were no whitespace or formatting issues.

### Impact
**Performance:**
The impact should be minimal and limited to queries whose target lists contain unsafe SIRV functions in non-`internal` and non-`c` languages. Those queries will now fall back to the Postgres planner instead of being handled by ORCA. Normal ORCA-planned queries are unaffected.

**User-facing changes:**
Users will no longer hit the incorrect coordinator execution path for the function shape described in #1660. Queries of that form now execute successfully through a safe planner fallback.

**Dependencies:**
No new dependencies were added to the codebase.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [x] Reviewed code for security implications
- [x] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
This fix intentionally keeps the fallback as narrow as possible.

An earlier broad approach would have caused ORCA to fall back for built-in volatile functions such as `random()`, which existing optimizer coverage already handles correctly. The final change avoids that by only treating non-`internal` and non-`c` target list SIRV functions as unsafe for ORCA in this context.

Files changed:
- `src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp`
- `src/include/gpopt/translate/CTranslatorQueryToDXL.h`
