### PR TITLE
Fix gppkg --clean error: 'SyncPackages' object has no attribute 'ret'.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -230,7 +230,7 @@ class OperationWorkerPool(WorkerPool):
         if operations is not None:
             for operation in operations:
                 self._spoof_operation(operation)
-        super(OperationWorkerPool, self).__init__(numWorkers, operations)
+        super(OperationWorkerPool, self).__init__(numWorkers, items=operations)
 
     def check_results(self):
         raise NotImplementedError("OperationWorkerPool has no means of verifying success.")


### PR DESCRIPTION
The command `gppkg --clean` fails with the following error:  
```bash
gpadmin@master:~$ gppkg --clean
20260502:20:46:20:008305 gppkg:master:gpadmin-[INFO]:-Starting gppkg with args: --clean
20260502:20:46:20:008305 gppkg:master:gpadmin-[ERROR]:-gppkg error: SyncPackages failed:
'SyncPackages' object has no attribute 'ret'
...
```

This occurs because `operations` was being passed positionally during the OperationWorkerPool initialization, which incorrectly bound it to the `should_stop` argument instead of `items` in the base WorkerPool class.

The solution is to  pass `operations` as a keyword argument.