### PR TITLE
Fix: FDW OPTIONS encoding accepts symbolic names (issue #1726)

### DIFF
--- a/gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source
@@ -53,10 +53,16 @@ OPTIONS (format_type 'c', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'p', reject_limit '120');
 
--- Error, invalid encoding
+-- Error, invalid encoding (negative numeric ID)
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (format_type 'c', delimiter ',', encoding '-1',
+         location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
+
+-- Error, invalid encoding (unknown name)
+CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
+SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',', encoding 'bogus',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 
 -- OK, no execute_on | log_errors | encoding | is_writable option
@@ -79,3 +85,59 @@ SELECT urilocation FROM pg_exttable WHERE reloid = 'public.ext_special_uri'::reg
 SELECT ftoptions FROM pg_foreign_table WHERE ftrelid='public.ext_special_uri'::regclass;
 \a
 SELECT * FROM ext_special_uri ORDER BY a;
+
+-- ===================================================================
+-- Tests for issue #1726: FDW OPTIONS encoding accepts both numeric IDs
+-- and symbolic names (UTF8, utf-8, GBK, ...). Names previously parsed
+-- via atoi() and silently degraded to SQL_ASCII.
+-- ===================================================================
+
+-- Numeric form (baseline; worked before the fix as well).
+CREATE FOREIGN TABLE ext_enc_num (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding '6');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_num'::regclass;
+
+-- Symbolic name 'UTF8' — used to be silently SQL_ASCII (the bug).
+CREATE FOREIGN TABLE ext_enc_utf8 (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding 'UTF8');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_utf8'::regclass;
+
+-- Case + dash variant resolved by pg_char_to_encoding().
+CREATE FOREIGN TABLE ext_enc_utf8_dash (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding 'utf-8');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_utf8_dash'::regclass;
+
+-- Non-UTF8 symbolic name.
+CREATE FOREIGN TABLE ext_enc_gbk (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding 'GBK');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_gbk'::regclass;
+
+-- ALTER FOREIGN TABLE ... OPTIONS (SET encoding 'UTF8') — same code
+-- path, this proves the read-side resolution works after an ALTER too.
+CREATE FOREIGN TABLE ext_enc_alter (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding '0');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_alter'::regclass;
+ALTER FOREIGN TABLE ext_enc_alter OPTIONS (SET encoding 'UTF8');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_alter'::regclass;
+
+DROP FOREIGN TABLE ext_enc_num;
+DROP FOREIGN TABLE ext_enc_utf8;
+DROP FOREIGN TABLE ext_enc_utf8_dash;
+DROP FOREIGN TABLE ext_enc_gbk;
+DROP FOREIGN TABLE ext_enc_alter;

--- a/gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source
@@ -65,6 +65,14 @@ SERVER gp_exttable_server
 OPTIONS (format_type 'c', delimiter ',', encoding 'bogus',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 
+-- Error, mixed numeric+letters must not be silently truncated to a
+-- valid prefix (atoi('6abc') would return 6 = UTF8; strict parsing
+-- in parse_fdw_encoding_option() rejects it).
+CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
+SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',', encoding '6abc',
+         location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
+
 -- OK, no execute_on | log_errors | encoding | is_writable option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server

--- a/gpcontrib/gp_exttable_fdw/option.c
+++ b/gpcontrib/gp_exttable_fdw/option.c
@@ -135,11 +135,13 @@ gp_exttable_permission_check(PG_FUNCTION_ARGS)
 		}
 		else if(pg_strcasecmp(def->defname, "encoding") == 0)
 		{
-			char	*encoding = (char *) defGetString(def);
-			if (!PG_VALID_ENCODING(atoi(encoding)))
-				ereport(ERROR,
-				        (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
-				         errmsg("%s is not a valid encoding code", encoding)));
+			/*
+			 * Accept either a symbolic encoding name (e.g. 'UTF8', 'GBK')
+			 * or a numeric encoding ID. Reject anything else explicitly,
+			 * rather than letting atoi() silently mistranslate non-numeric
+			 * names to SQL_ASCII.
+			 */
+			(void) parse_fdw_encoding_option((char *) defGetString(def));
 		}
 	}
 

--- a/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
@@ -95,7 +95,7 @@ ftoptions
 (1 row)
 \a
 SELECT * FROM ext_special_uri ORDER BY a;
- a | b
+ a | b 
 ---+---
  1 | 1
  2 | 2
@@ -114,7 +114,7 @@ OPTIONS (format_type 'c', delimiter ',',
          encoding '6');
 SELECT pg_encoding_to_char(encoding) FROM pg_exttable
 WHERE  reloid = 'ext_enc_num'::regclass;
- pg_encoding_to_char
+ pg_encoding_to_char 
 ---------------------
  UTF8
 (1 row)
@@ -126,7 +126,7 @@ OPTIONS (format_type 'c', delimiter ',',
          encoding 'UTF8');
 SELECT pg_encoding_to_char(encoding) FROM pg_exttable
 WHERE  reloid = 'ext_enc_utf8'::regclass;
- pg_encoding_to_char
+ pg_encoding_to_char 
 ---------------------
  UTF8
 (1 row)
@@ -138,7 +138,7 @@ OPTIONS (format_type 'c', delimiter ',',
          encoding 'utf-8');
 SELECT pg_encoding_to_char(encoding) FROM pg_exttable
 WHERE  reloid = 'ext_enc_utf8_dash'::regclass;
- pg_encoding_to_char
+ pg_encoding_to_char 
 ---------------------
  UTF8
 (1 row)
@@ -150,7 +150,7 @@ OPTIONS (format_type 'c', delimiter ',',
          encoding 'GBK');
 SELECT pg_encoding_to_char(encoding) FROM pg_exttable
 WHERE  reloid = 'ext_enc_gbk'::regclass;
- pg_encoding_to_char
+ pg_encoding_to_char 
 ---------------------
  GBK
 (1 row)
@@ -163,7 +163,7 @@ OPTIONS (format_type 'c', delimiter ',',
          encoding '0');
 SELECT pg_encoding_to_char(encoding) FROM pg_exttable
 WHERE  reloid = 'ext_enc_alter'::regclass;
- pg_encoding_to_char
+ pg_encoding_to_char 
 ---------------------
  SQL_ASCII
 (1 row)
@@ -171,7 +171,7 @@ WHERE  reloid = 'ext_enc_alter'::regclass;
 ALTER FOREIGN TABLE ext_enc_alter OPTIONS (SET encoding 'UTF8');
 SELECT pg_encoding_to_char(encoding) FROM pg_exttable
 WHERE  reloid = 'ext_enc_alter'::regclass;
- pg_encoding_to_char
+ pg_encoding_to_char 
 ---------------------
  UTF8
 (1 row)

--- a/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
@@ -64,6 +64,14 @@ SERVER gp_exttable_server
 OPTIONS (format_type 'c', delimiter ',', encoding 'bogus',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
 ERROR:  "bogus" is not a valid encoding name or code
+-- Error, mixed numeric+letters must not be silently truncated to a
+-- valid prefix (atoi('6abc') would return 6 = UTF8; strict parsing
+-- in parse_fdw_encoding_option() rejects it).
+CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
+SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',', encoding '6abc',
+         location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
+ERROR:  "6abc" is not a valid encoding name or code
 -- OK, no execute_on | log_errors | encoding | is_writable option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server

--- a/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
@@ -52,12 +52,18 @@ OPTIONS (format_type 'c', delimiter ',',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv',
          reject_limit_type 'p', reject_limit '120');
 ERROR:  segment reject limit in PERCENT must be between 1 and 100 (got 120)  (seg1 127.0.0.1:7003 pid=5173)
--- Error, invalid encoding
+-- Error, invalid encoding (negative numeric ID)
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
 OPTIONS (format_type 'c', delimiter ',', encoding '-1',
          location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
-ERROR:  -1 is not a valid encoding code  (seg0 127.0.0.1:7002 pid=8289)
+ERROR:  "-1" is not a valid encoding name or code
+-- Error, invalid encoding (unknown name)
+CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
+SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',', encoding 'bogus',
+         location_uris 'file://@hostname@@abs_srcdir@/data/tableless.csv');
+ERROR:  "bogus" is not a valid encoding name or code
 -- OK, no execute_on | log_errors | encoding | is_writable option
 CREATE FOREIGN TABLE tableless_ext_fdw(a int, b int)
 SERVER gp_exttable_server
@@ -89,10 +95,90 @@ ftoptions
 (1 row)
 \a
 SELECT * FROM ext_special_uri ORDER BY a;
- a | b 
+ a | b
 ---+---
  1 | 1
  2 | 2
  3 | 3
 (3 rows)
+
+-- ===================================================================
+-- Tests for issue #1726: FDW OPTIONS encoding accepts both numeric IDs
+-- and symbolic names (UTF8, utf-8, GBK, ...). Names previously parsed
+-- via atoi() and silently degraded to SQL_ASCII.
+-- ===================================================================
+-- Numeric form (baseline; worked before the fix as well).
+CREATE FOREIGN TABLE ext_enc_num (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding '6');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_num'::regclass;
+ pg_encoding_to_char
+---------------------
+ UTF8
+(1 row)
+
+-- Symbolic name 'UTF8' — used to be silently SQL_ASCII (the bug).
+CREATE FOREIGN TABLE ext_enc_utf8 (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding 'UTF8');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_utf8'::regclass;
+ pg_encoding_to_char
+---------------------
+ UTF8
+(1 row)
+
+-- Case + dash variant resolved by pg_char_to_encoding().
+CREATE FOREIGN TABLE ext_enc_utf8_dash (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding 'utf-8');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_utf8_dash'::regclass;
+ pg_encoding_to_char
+---------------------
+ UTF8
+(1 row)
+
+-- Non-UTF8 symbolic name.
+CREATE FOREIGN TABLE ext_enc_gbk (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding 'GBK');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_gbk'::regclass;
+ pg_encoding_to_char
+---------------------
+ GBK
+(1 row)
+
+-- ALTER FOREIGN TABLE ... OPTIONS (SET encoding 'UTF8') — same code
+-- path, this proves the read-side resolution works after an ALTER too.
+CREATE FOREIGN TABLE ext_enc_alter (a int) SERVER gp_exttable_server
+OPTIONS (format_type 'c', delimiter ',',
+         location_uris 'file:///tmp/ext_enc_ignored.csv',
+         encoding '0');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_alter'::regclass;
+ pg_encoding_to_char
+---------------------
+ SQL_ASCII
+(1 row)
+
+ALTER FOREIGN TABLE ext_enc_alter OPTIONS (SET encoding 'UTF8');
+SELECT pg_encoding_to_char(encoding) FROM pg_exttable
+WHERE  reloid = 'ext_enc_alter'::regclass;
+ pg_encoding_to_char
+---------------------
+ UTF8
+(1 row)
+
+DROP FOREIGN TABLE ext_enc_num;
+DROP FOREIGN TABLE ext_enc_utf8;
+DROP FOREIGN TABLE ext_enc_utf8_dash;
+DROP FOREIGN TABLE ext_enc_gbk;
+DROP FOREIGN TABLE ext_enc_alter;
 

--- a/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
+++ b/gpcontrib/gp_exttable_fdw/output/gp_exttable_fdw.source
@@ -181,4 +181,3 @@ DROP FOREIGN TABLE ext_enc_utf8;
 DROP FOREIGN TABLE ext_enc_utf8_dash;
 DROP FOREIGN TABLE ext_enc_gbk;
 DROP FOREIGN TABLE ext_enc_alter;
-

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -34,6 +34,47 @@
 
 static List *create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly);
 
+/*
+ * parse_fdw_encoding_option
+ *
+ * Parse the value of an "encoding" FDW OPTIONS entry (whether on creation,
+ * during validation, or when reading back stored ftoptions) into a numeric
+ * encoding ID. Accepts a symbolic encoding name (e.g. "UTF8", "utf-8", "GBK")
+ * resolved via pg_char_to_encoding(), or a strictly numeric string (e.g. "6")
+ * validated via PG_VALID_ENCODING(). Anything else raises ERROR.
+ *
+ * Note: atoi() is intentionally avoided in the numeric fallback. atoi("UTF8")
+ * silently returns 0 (= SQL_ASCII), which is exactly the bug this helper
+ * exists to fix. strtol() with end-of-string and range checks is strict.
+ */
+int
+parse_fdw_encoding_option(const char *value)
+{
+	int			encoding;
+	char	   *endptr;
+	long		n;
+
+	if (value == NULL || *value == '\0')
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+				 errmsg("encoding option must not be empty")));
+
+	encoding = pg_char_to_encoding(value);
+	if (encoding >= 0)
+		return encoding;
+
+	errno = 0;
+	n = strtol(value, &endptr, 10);
+	if (endptr != value && *endptr == '\0' && errno == 0 &&
+		n >= 0 && PG_VALID_ENCODING((int) n))
+		return (int) n;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+			 errmsg("\"%s\" is not a valid encoding name or code", value)));
+	return -1;					/* unreachable, keeps compiler happy */
+}
+
 void
 gfile_printf_then_putc_newline(const char *format,...)
 {
@@ -277,7 +318,7 @@ GetExtFromForeignTableOptions(List *ftoptons, Oid relid)
 
 		if (pg_strcasecmp(def->defname, "encoding") == 0)
 		{
-			extentry->encoding = atoi(defGetString(def));
+			extentry->encoding = parse_fdw_encoding_option(defGetString(def));
 			encoding_found = true;
 			continue;
 		}

--- a/src/include/access/external.h
+++ b/src/include/access/external.h
@@ -48,5 +48,10 @@ extern ExtTableEntry *GetExtFromForeignTableOptions(List *ftoptons, Oid relid);
 
 extern ExternalScanInfo *MakeExternalScanInfo(ExtTableEntry *extEntry);
 
+/*
+ * Parse an "encoding" FDW OPTIONS value (symbolic name or numeric string)
+ * into a numeric encoding ID. ereports on invalid input.
+ */
+extern int parse_fdw_encoding_option(const char *value);
 
 #endif   /* EXTERNAL_H */


### PR DESCRIPTION
<!-- ====================================================================
PR description draft for issue #1726 fix
==================================================================== -->

Fixes #1726

### What does this PR do?

Make the `gp_exttable_fdw` FDW accept both **symbolic encoding names** (`UTF8`, `utf-8`, `GBK`, …) and numeric encoding IDs in the `encoding` OPTIONS entry, mirroring what the legacy `CREATE EXTERNAL TABLE … ENCODING …` path has always accepted, and what the rest of PostgreSQL accepts everywhere else (`client_encoding`, `pg_dump`, `pg_conversion`, `CREATE DATABASE`, …).

Before this PR, both the FDW catalog reader (`src/backend/access/external/external.c:280`) and the option validator (`gpcontrib/gp_exttable_fdw/option.c:139,142`) parsed the value with `atoi()`. `atoi("UTF8")` silently returns `0` (`SQL_ASCII`) and `PG_VALID_ENCODING(0)` is true, so:

| OPTIONS spelling      | Before              | After                       |
| --------------------- | ------------------- | --------------------------- |
| `encoding '6'`        | UTF8 ✅             | UTF8 ✅ (unchanged)         |
| `encoding 'UTF8'`     | SQL_ASCII (silent ❌) | UTF8 ✅                     |
| `encoding 'utf-8'`    | SQL_ASCII (silent ❌) | UTF8 ✅                     |
| `encoding 'GBK'`      | SQL_ASCII (silent ❌) | GBK ✅                      |
| `encoding 'bogus'`    | SQL_ASCII (silent ❌) | ERROR — unrecognized ✅     |

Affected scope is `gp_exttable_fdw` (used by `gp_exttable_server`). The standalone `pxf_fdw` is unaffected — its validator routes `encoding` through `ProcessCopyOptions`, which is already name-aware.

#### Implementation

A small shared helper `parse_fdw_encoding_option(const char *)` is added in `src/backend/access/external/external.c` (declared in `src/include/access/external.h`):

1. Try `pg_char_to_encoding(value)` — the same translation the legacy `CREATE EXTERNAL TABLE` path uses.
2. Otherwise try a strict numeric form (`strtol` + end-of-string + `PG_VALID_ENCODING` checks). `atoi` is intentionally avoided: `atoi("UTF8")` silently mistranslates and that is the bug being fixed.
3. Otherwise `ereport(ERROR)`.

Both the FDW validator (`gp_exttable_permission_check`) and the read path (`GetExtFromForeignTableOptions`) call this helper. No on-disk format change: values are stored verbatim in `pg_foreign_table.ftoptions` exactly as the user wrote them, and resolved at read time. This keeps `pg_dump` output round-trip-safe and avoids silently rewriting catalog rows during upgrade.

The bypass on the runtime PXF error message ("`Define the external table with ENCODING UTF8...`") lives in the separate `apache/cloudberry-pxf-server` repository and will be addressed in a follow-up PR there.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [x] **Behavior change on upgrade** — see "User-facing changes" below
- [ ] Documentation update

### Test Plan

Added cases to `gpcontrib/gp_exttable_fdw/input/gp_exttable_fdw.source`:

- `encoding '6'` → resolves to UTF8 (control)
- `encoding 'UTF8'` / `encoding 'utf-8'` → resolves to UTF8 (the fix)
- `encoding 'GBK'` → resolves to GBK
- `encoding 'bogus'` → ereports
- `ALTER FOREIGN TABLE … OPTIONS (SET encoding 'UTF8')` on a table that
  was originally created with `encoding '0'` → reads as UTF8 after the ALTER

The pre-existing `encoding '-1'` ereport test was kept; only the error message text was updated to the new `"\"-1\" is not a valid encoding name or code"` form.

- [x] Unit tests added/updated (`gpcontrib/gp_exttable_fdw/`)
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck` *(to be run by reviewer / CI)*
- [ ] Passed `make -C src/test installcheck-cbdb-parallel` *(to be run)*

### Impact

**User-facing changes (release-note worthy ⚠️):**

Foreign tables that were created **before** this fix with a non-numeric `encoding` option (e.g. `encoding 'UTF8'`) had the literal name silently stored in `pg_foreign_table.ftoptions`. With the old `atoi()` reader they took effect as `SQL_ASCII`. After this fix, the same on-disk row is interpreted as the named encoding (e.g. `UTF8`) — i.e. the encoding actually requested by the user.

For most affected users this is the desired correction (data was already being silently mishandled). Operators who want to identify which existing tables are about to flip semantics can run:

```sql
SELECT n.nspname, c.relname,
       (SELECT split_part(opt, '=', 2)
        FROM   unnest(ftoptions) AS opt
        WHERE  opt LIKE 'encoding=%') AS stored_encoding
FROM   pg_foreign_table ft
JOIN   pg_class c ON c.oid = ft.ftrelid
JOIN   pg_namespace n ON n.oid = c.relnamespace
WHERE  ft.ftserver IN (SELECT oid FROM pg_foreign_server
                       WHERE  srvname IN ('gp_exttable_server'))
       AND EXISTS (
         SELECT 1 FROM unnest(ftoptions) AS opt
         WHERE  opt LIKE 'encoding=%'
                AND substring(opt FROM 'encoding=(.*)') !~ '^[0-9]+$'
       );
```

If a table appears that should *not* flip, the operator can pin it by re-issuing
`ALTER FOREIGN TABLE … OPTIONS (SET encoding '<numeric>')` before upgrade.

**Performance:** none. Two extra string compares + one syscache-free name lookup on each foreign-table read; same for validation.

**Dependencies:** none. `pg_char_to_encoding()` is already declared in `src/include/mb/pg_wchar.h:567` and used by the legacy path.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation (release-note line; doc PR not required)
- [x] Reviewed code for security implications (no new external input surfaces; helper ereports on invalid input)
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context

The design discussion in the issue (`#1726`) considered a write-time normalization variant via `ProcessUtility_hook`, where the option value would be rewritten to its numeric form *before* persisting into `ftoptions`. That approach was abandoned because the hook is only installed by the extension's `_PG_init`, which does not run until the first call into the extension's shared library — and on the very first `CREATE FOREIGN TABLE` of a fresh backend, the hook check has already been passed by the time the validator triggers `dlopen`. Adopting it would require listing `gp_exttable_fdw` in `session_preload_libraries`, which changes deployment expectations. The chosen read-side resolution works without any preload requirement.
