### PR TITLE
gpstate: fix false "Acting as Primary" report for hot standby mirrors

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -1039,6 +1039,9 @@ class GpSystemStateProgram:
 
         If segment is a mirror, peer should be set to its corresponding primary.
         Otherwise, peer is ignored.
+
+        Returns the raw replication state string from pg_stat_replication
+        (e.g. 'streaming', 'catchup'), or None if unavailable.
         """
         # Preload the mirror's replication info with Unknowns so that we'll
         # still have usable UI information on an early exit from this function.
@@ -1047,7 +1050,7 @@ class GpSystemStateProgram:
         # Even though this information is considered part of the mirror's state,
         # we have to connect to the primary to get it.
         if not primary.isSegmentUp():
-            return
+            return None
 
         # Query pg_stat_replication for the info we want.
         rows = []
@@ -1102,7 +1105,7 @@ class GpSystemStateProgram:
             logger.warning('could not query segment {} ({}:{})'.format(
                     primary.dbid, primary.hostname, primary.port
             ))
-            return
+            return None
 
         # Successfully queried pg_stat_replication. If there are any backup
         # or pg_rewind connections, mention them in the primary status.
@@ -1134,10 +1137,10 @@ class GpSystemStateProgram:
         standby_connections = [r for r in rows if r[0] == 'gp_walreceiver']
         if not standby_connections:
             logger.warning('pg_stat_replication shows no standby connections')
-            return
+            return None
         elif len(standby_connections) > 1:
             logger.warning('pg_stat_replication shows more than one standby connection')
-            return
+            return None
 
         row = standby_connections[0]
 
@@ -1153,6 +1156,8 @@ class GpSystemStateProgram:
             replay_lsn=row[5],
             replay_left=row[6],
         )
+
+        return row[1]
 
     @staticmethod
     def _set_mirror_replication_values(data, mirror, **kwargs):
@@ -1217,11 +1222,16 @@ class GpSystemStateProgram:
                 data.addValue(VALUE__MIRROR_STATUS, "Physical replication not configured")
 
         # Add replication info on a per-pair basis.
+        # mirrorReplState maps mirror dbid -> raw replication state from pg_stat_replication
+        # (e.g. 'streaming', 'catchup'), used below to detect hot standby false positives.
+        mirrorReplState = {}
         if gpArray.hasMirrors:
             for pair in gpArray.segmentPairs:
                 primary, mirror = pair.primaryDB, pair.mirrorDB
                 data.switchSegment(mirror)
-                self._add_replication_info(data, primary, mirror)
+                replState = self._add_replication_info(data, primary, mirror)
+                if replState is not None:
+                    mirrorReplState[mirror.getSegmentDbId()] = replState
 
         for seg in segments:
             data.switchSegment(seg)
@@ -1283,6 +1293,15 @@ class GpSystemStateProgram:
                 databaseStatusIsWarning = True
             else:
                 databaseStatus = segmentData[gp.SEGMENT_STATUS__GET_MIRROR_STATUS]["databaseStatus"]
+                # With hot_standby=on, a mirror in recovery returns PQPING_OK, causing
+                # gpgetstatususingtransition to report "Acting as Primary". Correct this
+                # by checking pg_stat_replication on the primary: if the mirror has an
+                # active WAL receiver connection (streaming/catchup), it is a legitimate
+                # hot standby and should be reported as "Up".
+                if (databaseStatus == "Acting as Primary"
+                        and seg.isSegmentMirror(current_role=True)
+                        and mirrorReplState.get(seg.getSegmentDbId()) in ('streaming', 'catchup')):
+                    databaseStatus = "Up"
                 databaseStatusIsWarning = databaseStatus != "Up"
 
             if seg.isSegmentMirror(current_role=True):


### PR DESCRIPTION
With hot_standby=on, mirrors accept SQL connections and return PQPING_OK
from pg_isready. The previous code unconditionally mapped PQPING_OK +
role=mirror to "Acting as Primary", causing gpstate -s to show a spurious
warning on every mirror.

Fix this in clsSystemState.__buildGpStateData() by cross-checking
pg_stat_replication on the primary: if the mirror has an active WAL
receiver connection in streaming or catchup state, it is a legitimate
hot standby and the status is corrected to "Up". Only fall through to
"Acting as Primary" when no such replication connection exists, meaning
the segment truly promoted itself to primary.

This approach reuses the existing primary connection already established
by _add_replication_info(), so no additional database connections are
required. _add_replication_info() is updated to return the raw
replication state string to make this information available to the
caller.

### What does this PR do?
Fixes a false positive in `gpstate -s` where every mirror segment is
reported as "Acting as Primary" when `hot_standby=on` is enabled.

Root cause:
- With `hot_standby=on`, mirrors accept read-only SQL connections and
  `pg_isready` returns `PQPING_OK(0)` instead of `PQPING_MIRROR_READY(64)`.
- The legacy logic in `gpgetstatususingtransition.py` assumed
  `PQPING_OK + role=mirror` could only mean "the mirror was promoted to
  primary", which is no longer true under hot standby.

Fix:
- In `clsSystemState.__buildGpStateData()`, cross-check the mirror's
  status against `pg_stat_replication` (already queried on the primary
  by `_add_replication_info()`).
- If the mirror has an active WAL receiver connection (`streaming` or
  `catchup`), it is a legitimate hot standby → corrected to `"Up"`.
- If no such replication connection exists, the mirror genuinely
  promoted itself → `"Acting as Primary"` is preserved.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
None. The fix only changes how the status string is derived in
`gpstate`; cluster configuration, replication behavior, and segment
behavior are unchanged.

### Test Plan
Tested on a 5-VM cluster (1 coordinator + 1 standby coordinator + 3
segment hosts, 6 primary / 6 mirror segments) with `hot_standby=on`:

**Before the fix:**
- Every mirror reported `Segment status = Acting as Primary`
- `gpstate -s` produced spurious warnings on every mirror
- `gp_segment_configuration`, replication state, and `gpstate -m` all
  showed the cluster as healthy — only the `gpstate -s` output was wrong

**After the fix:**
- Every mirror reports `Segment status = Up`
- No "Acting as Primary" entries appear on healthy mirrors
- No additional database connections are opened


### Impact
**Performance:**
No additional database connections. The fix consumes data that
`_add_replication_info()` already collects from the primary; only the
return value of that function is changed.

**User-facing changes:**
`gpstate -s` no longer reports false "Acting as Primary" warnings for
healthy hot-standby mirrors. Genuine promotion is still detected and
reported as before.

**Dependencies:**
None.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [x] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
An alternative approach considered was to call `pg_is_in_recovery()`
directly on each mirror inside `_get_segment_status()` in
`gpgetstatususingtransition.py`. That approach was rejected because:

1. It opens one additional DB connection per mirror on every `gpstate`
   invocation, which is undesirable in unhealthy-cluster scenarios
   where `gpstate` is run most frequently.
2. Mirror-side recovery state is a weaker source of truth than the
   primary's view of its replication connections.

The `pg_stat_replication` approach reuses an existing connection and is
authoritative from the primary's perspective.
