### PR TITLE
ORCA: handle INDF predicate in PdxlnMergeJoin

### DIFF
--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -4964,41 +4964,46 @@ CTranslatorExprToDXL::PdxlnMergeJoin(CExpression *pexprMJ,
 		// At this point, they all better be merge joinable
 		GPOS_ASSERT(CPhysicalJoin::FMergeJoinCompatible(
 			pexprPred, pexprOuterChild, pexprInnerChild));
-		CExpression *pexprPredOuter = (*pexprPred)[0];
-		CExpression *pexprPredInner = (*pexprPred)[1];
 
-		// align extracted columns with outer and inner children of the join
-		CColRefSet *pcrsOuterChild = pexprOuterChild->DeriveOutputColumns();
-		CColRefSet *pcrsPredInner = pexprPredInner->DeriveUsedColumns();
+		// Extract the two key columns out of pexprPred.  Plain equality
+		// is `a = b` (binary ScalarCmp) but NULL-safe equality (INDF) is
+		// `NOT (a IS DISTINCT FROM b)`, a *unary* NOT around the binary
+		// IsDistinctFrom.  Indexing [0]/[1] directly works for equality
+		// but accesses out of bounds for INDF.
+		CExpression *pexprPredOuter = nullptr;
+		CExpression *pexprPredInner = nullptr;
+		IMDId *mdid_scop = nullptr;
+		CPhysicalJoin::AlignJoinKeyOuterInner(pexprPred, pexprOuterChild,
+											  pexprInnerChild, &pexprPredOuter,
+											  &pexprPredInner, &mdid_scop);
+
 #ifdef GPOS_DEBUG
+		CColRefSet *pcrsOuterChild = pexprOuterChild->DeriveOutputColumns();
 		CColRefSet *pcrsInnerChild = pexprInnerChild->DeriveOutputColumns();
 		CColRefSet *pcrsPredOuter = pexprPredOuter->DeriveUsedColumns();
-#endif
-
-		if (pcrsOuterChild->ContainsAll(pcrsPredInner))
-		{
-			GPOS_ASSERT(pcrsInnerChild->ContainsAll(pcrsPredOuter));
-			std::swap(pexprPredOuter, pexprPredInner);
-#ifdef GPOS_DEBUG
-			std::swap(pcrsPredOuter, pcrsPredInner);
-#endif
-
-			pexprPredOuter->AddRef();
-			pexprPredInner->AddRef();
-			pexprPred =
-				CUtils::PexprScalarEqCmp(m_mp, pexprPredOuter, pexprPredInner);
-		}
-		else
-		{
-			pexprPred->AddRef();
-		}
-
+		CColRefSet *pcrsPredInner = pexprPredInner->DeriveUsedColumns();
 		GPOS_ASSERT(pcrsOuterChild->ContainsAll(pcrsPredOuter) &&
 					pcrsInnerChild->ContainsAll(pcrsPredInner) &&
 					"merge join keys are not aligned with children");
+#endif
 
-		dxlnode_merge_conds->AddChild(PdxlnScalar(pexprPred));
-		pexprPred->Release();
+		pexprPredOuter->AddRef();
+		pexprPredInner->AddRef();
+		CExpression *pexprPredNew;
+		if (CPredicateUtils::IsEqualityOp(pexprPred))
+		{
+			pexprPredNew = CUtils::PexprScalarCmp(m_mp, pexprPredOuter,
+												  pexprPredInner, mdid_scop);
+		}
+		else
+		{
+			GPOS_ASSERT(CPredicateUtils::FINDF(pexprPred));
+			pexprPredNew = CUtils::PexprINDF(m_mp, pexprPredOuter,
+											 pexprPredInner, mdid_scop);
+		}
+
+		dxlnode_merge_conds->AddChild(PdxlnScalar(pexprPredNew));
+		pexprPredNew->Release();
 	}
 	pdrgpexprPredicates->Release();
 


### PR DESCRIPTION
PdxlnMergeJoin extracted merge-key operands via blind indexing:

    CExpression *pexprPredOuter = (*pexprPred)[0];
    CExpression *pexprPredInner = (*pexprPred)[1];

That works for plain equality `a = b` (binary ScalarCmp) but a NULL- safe equality clause is `NOT (a IS DISTINCT FROM b)` -- a *unary* NOT wrapping the binary IsDistinctFrom.  Indexing [1] on the NOT walks off the end of its 1-element child array, then DeriveUsedColumns on the garbage pointer segfaults.

Use CPhysicalJoin::AlignJoinKeyOuterInner -- the same helper PdxlnHashJoin already uses (line 5139) -- which handles both equality and INDF shapes and strips binary-coercible casts.  Reconstruct the DXL predicate from the aligned operands via PexprScalarCmp / PexprINDF so the downstream PG translator sees an operand order matching the children we emit.


Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
