### PR TITLE
Fix greenplum_path.sh GPHOME resolution under relative symlinks

### DIFF
--- a/gpMgmt/bin/generate-cloudberry-env.sh
+++ b/gpMgmt/bin/generate-cloudberry-env.sh
@@ -17,13 +17,15 @@ fi
 if test -z "$SCRIPT_PATH"; then
     echo "The shell cannot be identified. \$GPHOME may not be set correctly." >&2
 fi
-SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
 
-if [ ! -L "${SCRIPT_DIR}" ]; then
-    GPHOME=${SCRIPT_DIR}
-else
-    GPHOME=$(readlink "${SCRIPT_DIR}")
-fi
+# downstream PATH / PYTHONPATH / LD_LIBRARY_PATH derivations stay valid
+# even when GPHOME is reached via a symlink whose target is a relative
+# path (e.g. /opt/database -> database-2.1.0).  `pwd -P` resolves every
+# symlink component, returning the physical absolute path.  This replaces
+# an earlier branch that ran bare `readlink` on the script's directory,
+# which would return the symlink target verbatim and break with relative
+# targets (PYTHONPATH became relative, gppylib import failed).
+GPHOME="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd -P)"
 EOF
 
 cat <<"EOF"


### PR DESCRIPTION
When GPHOME is reached via a symlink whose target is stored as a relative path (e.g. /opt/database -> database-2.1.0), the previous logic ran a bare `readlink` on the script's directory and accepted the link target verbatim.  `readlink` returns the symlink's target string as-is; for a relative target this leaves GPHOME as a relative path, so PYTHONPATH becomes `database-2.1.0/lib/python` and gpstart fails with ModuleNotFoundError: No module named 'gppylib' the moment the shell's cwd is anything other than the symlink's parent.

Replace the symlink-vs-not branch with a single `pwd -P`, which resolves every symlink component and returns the canonical absolute path regardless of how the user reached the directory.  This also removes the unnecessary `[ -L ... ]` test and the dependency on GNU readlink semantics.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
