### PR TITLE
Fix PAX CException stack overflow by pass-by-reference and shrinking …

### DIFF
--- a/contrib/pax_storage/src/cpp/exceptions/CException.cc
+++ b/contrib/pax_storage/src/cpp/exceptions/CException.cc
@@ -206,7 +206,7 @@ void ErrorMessage::AppendV(const char *format, va_list ap) noexcept {
 const char *ErrorMessage::Message() const noexcept { return &message_[0]; }
 int ErrorMessage::Length() const noexcept { return index_; }
 
-void CException::Raise(CException ex, bool reraise) {
+void CException::Raise(CException &ex, bool reraise) {
 #ifdef __GNUC__
   if (!reraise) {
     StackTrace(&ex.stack_[0]);
@@ -258,20 +258,23 @@ void CException::AppendDetailMessage(const std::string &message) {
 const char *CException::Stack() const { return stack_; }
 
 void CException::Raise(const char *filename, int lineno, ExType extype) {
-  Raise(CException(filename, lineno, extype, ""), false);
+  CException ex(filename, lineno, extype, "");
+  Raise(ex, false);
 }
 
 void CException::Raise(const char *filename, int lineno, ExType extype,
                        const char *message) {
-  Raise(CException(filename, lineno, extype, message), false);
+  CException ex(filename, lineno, extype, message);
+  Raise(ex, false);
 }
 
 void CException::Raise(const char *filename, int lineno, ExType extype,
                        const std::string &message) {
-  Raise(CException(filename, lineno, extype, message.c_str()), false);
+  CException ex(filename, lineno, extype, message.c_str());
+  Raise(ex, false);
 }
 
-void CException::ReRaise(CException ex) { Raise(ex, true); }
+void CException::ReRaise(CException &ex) { Raise(ex, true); }
 
 static const char *exception_names[] = {
     "Invalid ExType",

--- a/contrib/pax_storage/src/cpp/exceptions/CException.h
+++ b/contrib/pax_storage/src/cpp/exceptions/CException.h
@@ -107,8 +107,9 @@
 namespace cbdb {
 
 #define DEFAULT_STACK_MAX_DEPTH 63
+/* 255KB is too large to cause stack overflow, 63KB maybe enough */
 #define DEFAULT_STACK_MAX_SIZE \
-  ((DEFAULT_STACK_MAX_DEPTH + 1) * PIPE_MAX_PAYLOAD)
+  ((DEFAULT_STACK_MAX_DEPTH + 1) * PIPE_MAX_PAYLOAD / 4)
 #define MAX_SIZE_OF_ERROR_MESSAGE 2048
 // error message buffer
 class ErrorMessage final {
@@ -179,8 +180,8 @@ class CException {
                     const char *message) __attribute__((__noreturn__));
   static void Raise(const char *filename, int line, ExType extype,
                     const std::string &message) __attribute__((__noreturn__));
-  static void Raise(CException ex, bool reraise) __attribute__((__noreturn__));
-  static void ReRaise(CException ex) __attribute__((__noreturn__));
+  static void Raise(CException &ex, bool reraise) __attribute__((__noreturn__));
+  static void ReRaise(CException &ex) __attribute__((__noreturn__));
 
  private:
   char stack_[DEFAULT_STACK_MAX_SIZE];


### PR DESCRIPTION
…buffer

CException is ~255KB due to stack_[DEFAULT_STACK_MAX_SIZE]. When Raise(CException ex, ...) passes by value, two copies (510KB) are placed on the stack, causing stack overflow in backtrace() -> dlopen().

Fix:
- Change Raise/ReRaise to pass CException by reference instead of value
- Reduce DEFAULT_STACK_MAX_SIZE to 1/4 (255KB -> 63KB)
- Callers now construct a local CException and pass it by reference

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
