### PR TITLE
Fix parallel retrieve cursor check timeout never going quiet

### DIFF
--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -599,3 +599,16 @@ enable_parallel_retrieve_cursor_check_timeout(void)
 							 GP_PARALLEL_RETRIEVE_CURSOR_CHECK_PERIOD_MS);
 	}
 }
+
+/*
+ * Disable the timeout of parallel retrieve cursor check.
+ *
+ * Safe to call unconditionally; disable_timeout() is a no-op when the
+ * timeout is not active.
+ */
+void
+disable_parallel_retrieve_cursor_check_timeout(void)
+{
+	if (Gp_role == GP_ROLE_DISPATCH)
+		disable_timeout(GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT, false);
+}

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -393,8 +393,8 @@ PortalCleanup(Portal portal)
 		}
 	}
 
-	/* 
-	 * If resource scheduling is enabled, release the resource lock. 
+	/*
+	 * If resource scheduling is enabled, release the resource lock.
 	 */
 	if (IsResQueueLockedForPortal(portal))
 	{
@@ -410,6 +410,18 @@ PortalCleanup(Portal portal)
 	{
 		BackoffBackendEntryExit();
 	}
+
+	/*
+	 * If this was a PARALLEL RETRIEVE CURSOR and no others remain, stop
+	 * the periodic check timer immediately rather than waiting for the
+	 * next stray SIGALRM to find a zero count and quiet itself.
+	 * queryDesc was set to NULL above, so the now-cleaned portal is no
+	 * longer counted by GetNumOfParallelRetrieveCursors().
+	 */
+	if (PortalIsParallelRetrieveCursor(portal) &&
+		Gp_role == GP_ROLE_DISPATCH &&
+		GetNumOfParallelRetrieveCursors() == 0)
+		disable_parallel_retrieve_cursor_check_timeout();
 }
 
 /*

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1894,20 +1894,22 @@ GpParallelRetrieveCursorCheckTimeoutHandler(void)
 
 		/* It calls cdbdisp_checkForCancel(), which doesn't raise error */
 		gp_check_parallel_retrieve_cursor_error();
-		int num = GetNumOfParallelRetrieveCursors();
-
-		/* Reset the alarm to check after a timeout */
-		if (num > 0)
-		{
-			elog(DEBUG1, "There are still %d parallel retrieve cursors alive", num);
-			enable_parallel_retrieve_cursor_check_timeout();
-		}
 	}
 	else
 	{
 		elog(DEBUG1, "DoingCommandRead is false, check parallel cursor timeout delay");
-		enable_parallel_retrieve_cursor_check_timeout();
 	}
+
+	/*
+	 * Only re-arm the periodic check while parallel retrieve cursors are
+	 * still alive. Re-arming unconditionally (the previous behavior) kept
+	 * a SIGALRM firing every GP_PARALLEL_RETRIEVE_CURSOR_CHECK_PERIOD_MS
+	 * for the rest of the backend's life, which interfered with unrelated
+	 * code paths -- most visibly truncating fault-injection 'sleep'
+	 * windows used by isolation2 tests.
+	 */
+	if (GetNumOfParallelRetrieveCursors() > 0)
+		enable_parallel_retrieve_cursor_check_timeout();
 }
 
 /*

--- a/src/include/cdb/cdbendpoint.h
+++ b/src/include/cdb/cdbendpoint.h
@@ -137,6 +137,7 @@ extern void AtAbort_EndpointExecState(void);
 extern void allocEndpointExecState(void);
 extern bool gp_check_parallel_retrieve_cursor_error(void);
 extern void enable_parallel_retrieve_cursor_check_timeout(void);
+extern void disable_parallel_retrieve_cursor_check_timeout(void);
 
 /*
  * Below functions should run on Endpoints(QE/Entry DB).


### PR DESCRIPTION
GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT was armed by every DECLARE PARALLEL RETRIEVE CURSOR but had no path to ever be disabled: the handler re-armed it unconditionally in the !DoingCommandRead branch, and no portal-drop path ever called disable_timeout(). The result was a SIGALRM firing every 10 seconds for the rest of the backend's life even when no parallel retrieve cursors remained, which interfered with unrelated code paths (e.g. truncating pg_usleep-based fault sleeps that tests rely on).

Tighten this in two ways:
  - The handler now only re-arms when GetNumOfParallelRetrieveCursors() is still positive, so the timer naturally quiets after the last cursor is gone.
  - PortalCleanup() proactively calls disable_timeout() when the last parallel retrieve cursor in this backend is being torn down, avoiding even the single stray firing that the handler fallback would otherwise still produce.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
