### PR TITLE
Fix fault-injection sleep being shortened by stray signals

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -22,6 +22,7 @@
 #include "postgres.h"
 
 #include <signal.h>
+#include <sys/time.h>
 
 #include "access/xact.h"
 #include "catalog/pg_type.h"
@@ -402,14 +403,41 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 			break;
 
 		case FaultInjectorTypeSleep:
-			ereport(LOG,
-					(errcode(ERRCODE_FAULT_INJECT),
-					 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
-							entryLocal->faultName,
-							FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));	
-			
-			pg_usleep(entryLocal->extraArg * 1000000L);
-			break;
+			{
+				struct timeval start;
+				int64		total_us = (int64) entryLocal->extraArg * 1000000L;
+				int64		elapsed_us = 0;
+
+				ereport(LOG,
+						(errcode(ERRCODE_FAULT_INJECT),
+						 errmsg("fault triggered, fault name:'%s' fault type:'%s' ",
+								entryLocal->faultName,
+								FaultInjectorTypeEnumToString[entryLocal->faultInjectorType])));
+
+				/*
+				 * pg_usleep() is a single select() and returns early on any
+				 * signal (e.g. SIGALRM from a registered timeout such as
+				 * GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT). A bare call
+				 * therefore can't guarantee the requested duration, which
+				 * defeats the purpose of fault-injection 'sleep' (tests
+				 * rely on it as a deterministic blocking window). Loop on
+				 * the wallclock until the requested time has fully elapsed.
+				 * A genuine cancel (SIGINT) or termination still aborts the
+				 * sleep via CHECK_FOR_INTERRUPTS.
+				 */
+				gettimeofday(&start, NULL);
+				while (elapsed_us < total_us)
+				{
+					struct timeval now;
+
+					pg_usleep(total_us - elapsed_us);
+					CHECK_FOR_INTERRUPTS();
+					gettimeofday(&now, NULL);
+					elapsed_us = (int64) (now.tv_sec - start.tv_sec) * 1000000L
+						+ (now.tv_usec - start.tv_usec);
+				}
+				break;
+			}
 
 		case FaultInjectorTypeFatal:
 			/*


### PR DESCRIPTION
pg_usleep() is a single select() that returns early on any signal. When a SIGALRM-based registered timeout fires (e.g. the periodic GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT armed by DECLARE PARALLEL RETRIEVE CURSOR), it interrupts an in-progress fault sleep and the test loses the deterministic blocking window it relied on. This caused isolation2 test parallel_retrieve_cursor/status_check Test6.1 to flake: the gp_wait_parallel_retrieve_cursor() UDF returned 'f' within milliseconds instead of sleeping for the configured second, so the follow-up SIGINT had no in-flight statement to cancel.

Loop pg_usleep() against a wallclock deadline so the requested duration is fully observed regardless of asynchronous signal arrivals. CHECK_FOR_INTERRUPTS still allows a genuine cancel or termination request to break out via ERROR.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
