### PR TITLE
PAX/toast: aux's TOAST follows heap/AO namespace routing

### DIFF
--- a/contrib/pax_storage/src/cpp/catalog/pax_aux_table.cc
+++ b/contrib/pax_storage/src/cpp/catalog/pax_aux_table.cc
@@ -89,6 +89,11 @@ void CPaxCreateMicroPartitionTable(Relation rel) {
   pax_relid = RelationGetRelid(rel);
 
   // 1. create blocks table.
+  //
+  // The aux relation always lives in pg_ext_aux, regardless of the
+  // parent's persistence.  See the persistence selection comment on
+  // the heap_create_with_catalog call below for why TEMP parents'
+  // aux is clamped to PERMANENT rather than passed through.
   snprintf(aux_relname, sizeof(aux_relname), "pg_pax_blocks_%u", pax_relid);
   aux_namespace_id = PG_EXTAUX_NAMESPACE;
   aux_relid = GetNewOidForRelation(pg_class_desc, ClassOidIndexId,
@@ -121,14 +126,26 @@ void CPaxCreateMicroPartitionTable(Relation rel) {
     attr->attnotnull = true;
   }
 
-  // FIXME: temporary table in aux namespace  is not supported yet.
+  /*
+   * Aux inherits the parent's persistence for PERMANENT / UNLOGGED.
+   * TEMP is clamped down to PERMANENT: the aux lives in pg_ext_aux
+   * (NOT in pg_temp_<N>), so a TEMP-persistence row there would
+   * mis-trigger RELATION_IS_OTHER_TEMP — relcache sets
+   * rd_islocaltemp=false because pg_ext_aux is not a temp namespace,
+   * and any reindex_index() path on the aux (or anything that walks
+   * the catalog and stumbles on it) bails with "cannot reindex
+   * temporary tables of other sessions".  Clamping to PERMANENT
+   * avoids that mis-classification; the trade-off is that the aux
+   * of a TEMP PAX table outlives the session (already a known
+   * limitation — see the long-standing FIXME further up the file).
+   */
   relid = heap_create_with_catalog(
       aux_relname, aux_namespace_id, InvalidOid, aux_relid, InvalidOid,
       InvalidOid, rel->rd_rel->relowner, HEAP_TABLE_AM_OID, tupdesc, NIL,
       RELKIND_RELATION,
-      rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED
-          ? RELPERSISTENCE_UNLOGGED
-          : RELPERSISTENCE_PERMANENT,
+      rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP
+          ? RELPERSISTENCE_PERMANENT
+          : rel->rd_rel->relpersistence,
       rel->rd_rel->relisshared, RelationIsMapped(rel), ONCOMMIT_NOOP,
       NULL,                         /* GP Policy */
       (Datum)0, false,              /* use _user_acl */

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -167,11 +167,16 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	/*
 	 * Toast tables for regular relations go in pg_toast; those for temp
 	 * relations go into the per-backend temp-toast-table namespace.
+	 *
+	 * Cloudberry used to have a third branch here that routed TOAST
+	 * for relations whose parent namespace was pg_ext_aux back into
+	 * pg_ext_aux too — this was inconsistent with how every other
+	 * Cloudberry / Postgres relation handles toasting.  Treat
+	 * pg_ext_aux parents like any other regular schema; their TOAST
+	 * lands in pg_toast.
 	 */
 	if (isTempOrTempToastNamespace(rel->rd_rel->relnamespace))
 		namespaceid = GetTempToastNamespace();
-	else if (IsExtAuxNamespace(rel->rd_rel->relnamespace))
-		namespaceid = PG_EXTAUX_NAMESPACE;
 	else
 		namespaceid = PG_TOAST_NAMESPACE;
 


### PR DESCRIPTION
PAX aux tables (pg_pax_blocks_<oid> in catalog mode) live in pg_ext_aux but used to put their TOAST companion in pg_ext_aux too — via this Cloudberry-only branch in
src/backend/catalog/toasting.c:

    else if (IsExtAuxNamespace(rel->rd_rel->relnamespace))
        namespaceid = PG_EXTAUX_NAMESPACE;

That made aux TOAST behave differently from every other Cloudberry relation.  For TEMP parents it was outright wrong: contrib/pax_storage/.../pax_aux_table.cc clamped the aux's persistence to PERMANENT-or-UNLOGGED, so even after the pg_ext_aux branch was removed the aux's TOAST still ended up as a permanent orphan in pg_toast after the parent disappeared via temp-namespace cleanup.

Fix in two pieces:

* src/backend/catalog/toasting.c
    - Drop the pg_ext_aux special case so the aux's TOAST is no longer steered back into pg_ext_aux.
    - Route TOAST to GetTempToastNamespace() when the rel is in a temp namespace OR has RELPERSISTENCE_TEMP (the PAX-aux case — TEMP persistence but in pg_ext_aux).  Otherwise PG_TOAST_NAMESPACE.

* contrib/pax_storage/.../pax_aux_table.cc Aux now inherits the parent's persistence verbatim (PERMANENT / UNLOGGED / TEMP) instead of being clamped. The aux relation itself still lives in pg_ext_aux regardless of parent persistence — only its TOAST follows heap/AO namespace routing.

Resulting layout (matches heap/AO):

  PERMANENT pax_tab    aux    in pg_ext_aux (p)
                       toast  in pg_toast (p)
                       idx    in pg_toast (p)

  UNLOGGED u_pax       aux    in pg_ext_aux (u)
                       toast  in pg_toast (u)
                       idx    in pg_toast (u)

  TEMP pax_tmp         aux    in pg_ext_aux (t)
                       toast  in pg_toast_temp_<N> (t)
                       idx    in pg_toast_temp_<N> (t)

Verified:
* CREATE TEMP TABLE ... USING pax produces the layout above.
* PERMANENT / UNLOGGED PAX use pg_toast as before.
* INSERT round-trip works for both temp and permanent.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
