### PR TITLE
Fix for CBDB expand with concurrent distributed tx

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -493,6 +493,17 @@ redoDistributedCommitRecord(DistributedTransactionId gxid)
 	int			i;
 	bool 			is_hot_standby_qd = IS_HOT_STANDBY_QD();
 
+	/*
+	 * The coordinator may execute write DTX during gpexpand, so the newly
+	 * added segment may contain DTX info in checkpoint XLOG. However, this step
+	 * is useless and should be avoided for segments, or fatal may be thrown since
+	 * max_tm_gxacts is 0 in segments. See also fc8aab88d
+	*/
+	if (ConvertMasterDataDirToSegment && !IS_QUERY_DISPATCHER())
+	{
+		return;
+	}
+
 	/* 
 	 * Only the startup process can be modifying shmNumCommittedGxacts
 	 * and shmCommittedGxidArray. So should be OK reading the value w/o lock.


### PR DESCRIPTION
fixes https://github.com/apache/cloudberry/issues/1800

gpexpand currently fails when we have distributed transaction in coordinator WAL, bacause we create new segment as copy of coordinator datadir

Don't care of distributed tx redo in case of first startup after gpexpand.

newly created segment may contain records from primary in xlog, so skip them.

