### PR TITLE
Fix subselect_gp2 intermittent failure due to parallel test conflict

### DIFF
--- a/contrib/pax_storage/src/test/regress/expected/subselect_gp2.out
+++ b/contrib/pax_storage/src/test/regress/expected/subselect_gp2.out
@@ -44,22 +44,22 @@ explain select * from generate_series(1,2) s1 join pg_class on true where s1=(se
 (7 rows)
 
 -- Planner test: constant folding in subplan testexpr  produces no error
-create table subselect_t1 (a int, b int, c int) distributed by (a);
-create table subselect_t2 (a int, b int, c int) distributed by (a);
-insert into subselect_t1 values (1,1,1);
-insert into subselect_t2 values (1,1,1);
-select * from subselect_t1 where NULL in (select c from subselect_t2);
+create table subselect_gp2_t1 (a int, b int, c int) distributed by (a);
+create table subselect_gp2_t2 (a int, b int, c int) distributed by (a);
+insert into subselect_gp2_t1 values (1,1,1);
+insert into subselect_gp2_t2 values (1,1,1);
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2);
  a | b | c 
 ---+---+---
 (0 rows)
 
-select * from subselect_t1 where NULL in (select c from subselect_t2) and exists (select generate_series(1,2));
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2) and exists (select generate_series(1,2));
  a | b | c 
 ---+---+---
 (0 rows)
 
 -- Planner test to make sure initplan is removed when no param is used
-select * from subselect_t2 where false and exists (select generate_series(1,2));
+select * from subselect_gp2_t2 where false and exists (select generate_series(1,2));
  a | b | c 
 ---+---+---
 (0 rows)

--- a/contrib/pax_storage/src/test/regress/sql/subselect_gp2.sql
+++ b/contrib/pax_storage/src/test/regress/sql/subselect_gp2.sql
@@ -25,17 +25,17 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 explain select * from generate_series(1,2) s1 join pg_class on true where s1=(select pg_backend_pid());
 
 -- Planner test: constant folding in subplan testexpr  produces no error
-create table subselect_t1 (a int, b int, c int) distributed by (a);
-create table subselect_t2 (a int, b int, c int) distributed by (a);
+create table subselect_gp2_t1 (a int, b int, c int) distributed by (a);
+create table subselect_gp2_t2 (a int, b int, c int) distributed by (a);
 
-insert into subselect_t1 values (1,1,1);
-insert into subselect_t2 values (1,1,1);
+insert into subselect_gp2_t1 values (1,1,1);
+insert into subselect_gp2_t2 values (1,1,1);
 
-select * from subselect_t1 where NULL in (select c from subselect_t2);
-select * from subselect_t1 where NULL in (select c from subselect_t2) and exists (select generate_series(1,2));
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2);
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2) and exists (select generate_series(1,2));
 
 -- Planner test to make sure initplan is removed when no param is used
-select * from subselect_t2 where false and exists (select generate_series(1,2));
+select * from subselect_gp2_t2 where false and exists (select generate_series(1,2));
 
 
 --

--- a/src/test/regress/expected/subselect_gp2.out
+++ b/src/test/regress/expected/subselect_gp2.out
@@ -44,22 +44,22 @@ explain select * from generate_series(1,2) s1 join pg_class on true where s1=(se
 (7 rows)
 
 -- Planner test: constant folding in subplan testexpr  produces no error
-create table subselect_t1 (a int, b int, c int) distributed by (a);
-create table subselect_t2 (a int, b int, c int) distributed by (a);
-insert into subselect_t1 values (1,1,1);
-insert into subselect_t2 values (1,1,1);
-select * from subselect_t1 where NULL in (select c from subselect_t2);
+create table subselect_gp2_t1 (a int, b int, c int) distributed by (a);
+create table subselect_gp2_t2 (a int, b int, c int) distributed by (a);
+insert into subselect_gp2_t1 values (1,1,1);
+insert into subselect_gp2_t2 values (1,1,1);
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2);
  a | b | c 
 ---+---+---
 (0 rows)
 
-select * from subselect_t1 where NULL in (select c from subselect_t2) and exists (select generate_series(1,2));
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2) and exists (select generate_series(1,2));
  a | b | c 
 ---+---+---
 (0 rows)
 
 -- Planner test to make sure initplan is removed when no param is used
-select * from subselect_t2 where false and exists (select generate_series(1,2));
+select * from subselect_gp2_t2 where false and exists (select generate_series(1,2));
  a | b | c 
 ---+---+---
 (0 rows)

--- a/src/test/regress/sql/subselect_gp2.sql
+++ b/src/test/regress/sql/subselect_gp2.sql
@@ -25,17 +25,17 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 2;
 explain select * from generate_series(1,2) s1 join pg_class on true where s1=(select pg_backend_pid());
 
 -- Planner test: constant folding in subplan testexpr  produces no error
-create table subselect_t1 (a int, b int, c int) distributed by (a);
-create table subselect_t2 (a int, b int, c int) distributed by (a);
+create table subselect_gp2_t1 (a int, b int, c int) distributed by (a);
+create table subselect_gp2_t2 (a int, b int, c int) distributed by (a);
 
-insert into subselect_t1 values (1,1,1);
-insert into subselect_t2 values (1,1,1);
+insert into subselect_gp2_t1 values (1,1,1);
+insert into subselect_gp2_t2 values (1,1,1);
 
-select * from subselect_t1 where NULL in (select c from subselect_t2);
-select * from subselect_t1 where NULL in (select c from subselect_t2) and exists (select generate_series(1,2));
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2);
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2) and exists (select generate_series(1,2));
 
 -- Planner test to make sure initplan is removed when no param is used
-select * from subselect_t2 where false and exists (select generate_series(1,2));
+select * from subselect_gp2_t2 where false and exists (select generate_series(1,2));
 
 
 --

--- a/src/test/singlenode_regress/expected/subselect_gp2.out
+++ b/src/test/singlenode_regress/expected/subselect_gp2.out
@@ -45,22 +45,22 @@ explain select * from generate_series(1,2) s1 join pg_class on true where s1=(se
 (7 rows)
 
 -- Planner test: constant folding in subplan testexpr  produces no error
-create table subselect_t1 (a int, b int, c int);
-create table subselect_t2 (a int, b int, c int);
-insert into subselect_t1 values (1,1,1);
-insert into subselect_t2 values (1,1,1);
-select * from subselect_t1 where NULL in (select c from subselect_t2);
+create table subselect_gp2_t1 (a int, b int, c int);
+create table subselect_gp2_t2 (a int, b int, c int);
+insert into subselect_gp2_t1 values (1,1,1);
+insert into subselect_gp2_t2 values (1,1,1);
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2);
  a | b | c 
 ---+---+---
 (0 rows)
 
-select * from subselect_t1 where NULL in (select c from subselect_t2) and exists (select generate_series(1,2));
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2) and exists (select generate_series(1,2));
  a | b | c 
 ---+---+---
 (0 rows)
 
 -- Planner test to make sure initplan is removed when no param is used
-select * from subselect_t2 where false and exists (select generate_series(1,2));
+select * from subselect_gp2_t2 where false and exists (select generate_series(1,2));
  a | b | c 
 ---+---+---
 (0 rows)

--- a/src/test/singlenode_regress/sql/subselect_gp2.sql
+++ b/src/test/singlenode_regress/sql/subselect_gp2.sql
@@ -26,17 +26,17 @@ where (select count(*) from echotable as i where i.c2 = o.c2) >= 1;
 explain select * from generate_series(1,2) s1 join pg_class on true where s1=(select pg_backend_pid());
 
 -- Planner test: constant folding in subplan testexpr  produces no error
-create table subselect_t1 (a int, b int, c int);
-create table subselect_t2 (a int, b int, c int);
+create table subselect_gp2_t1 (a int, b int, c int);
+create table subselect_gp2_t2 (a int, b int, c int);
 
-insert into subselect_t1 values (1,1,1);
-insert into subselect_t2 values (1,1,1);
+insert into subselect_gp2_t1 values (1,1,1);
+insert into subselect_gp2_t2 values (1,1,1);
 
-select * from subselect_t1 where NULL in (select c from subselect_t2);
-select * from subselect_t1 where NULL in (select c from subselect_t2) and exists (select generate_series(1,2));
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2);
+select * from subselect_gp2_t1 where NULL in (select c from subselect_gp2_t2) and exists (select generate_series(1,2));
 
 -- Planner test to make sure initplan is removed when no param is used
-select * from subselect_t2 where false and exists (select generate_series(1,2));
+select * from subselect_gp2_t2 where false and exists (select generate_series(1,2));
 
 
 --


### PR DESCRIPTION
subselect_gp and subselect_gp2 run in the same parallel test group. subselect_gp dropped and recreated tables named subselect_t1/t2, which are also created by subselect_gp2. The race caused subselect_gp2's SELECT to fail with "relation does not exist" after a successful INSERT.

Rename the tables in subselect_gp2 to subselect_gp2_t1/t2 to eliminate the naming conflict. Update all copies of the test across regress, singlenode_regress, vectorization, and pax_storage test suites.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
