### PR TITLE
Fix assert failure triggered by "CREATE INDEX CONCURRENTLY"

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -5445,6 +5445,17 @@ static inline void
 set_indexsafe_procflags(void)
 {
 	/*
+	 * A catalog snapshot taken earlier in this transaction (for example, by
+	 * resource-group slot assignment during StartTransaction) leaves a valid
+	 * xmin advertised in MyProc.  Drop it here so the assertion below holds;
+	 * CREATE INDEX CONCURRENTLY phases must not hold any snapshot at this
+	 * point anyway.
+	 */
+	if (MyProc->xid != InvalidTransactionId ||
+		MyProc->xmin != InvalidTransactionId)
+		InvalidateCatalogSnapshot();
+
+	/*
 	 * This should only be called before installing xid or xmin in MyProc;
 	 * otherwise, concurrent processes could see an Xmin that moves backwards.
 	 */

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -34,6 +34,7 @@
 #include "commands/resgroupcmds.h"
 #include "miscadmin.h"
 #include "nodes/pg_list.h"
+#include "storage/proc.h"
 #include "utils/builtins.h"
 #include "utils/datetime.h"
 #include "utils/fmgroids.h"
@@ -716,10 +717,17 @@ GetResGroupIdForRole(Oid roleid)
 	HeapTuple	tuple;
 	Oid			groupId;
 	bool		isNull;
+	bool		releaseSnapshot;
 	Relation	rel;
 	ScanKeyData	key;
 	SysScanDesc	 sscan;
 
+	/*
+	 * StartTransaction() might hold a catalog snapshot with a valid xmin.
+	 * As this fails the "CREATE INDEX CONCURRENTLY" status checks, explicitly
+	 * release the snapshot.
+	 */
+	releaseSnapshot = MyProc->xmin == InvalidTransactionId;
 	rel = table_open(AuthIdRelationId, AccessShareLock);
 
 	ScanKeyInit(&key,
@@ -756,6 +764,9 @@ GetResGroupIdForRole(Oid roleid)
 	 * resource group slot
 	 */
 	table_close(rel, AccessShareLock);
+
+	if (releaseSnapshot)
+		InvalidateCatalogSnapshot();
 
 	if (!OidIsValid(groupId))
 		groupId = InvalidOid;

--- a/src/test/isolation2/expected/resgroup/resgroup_transaction.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_transaction.out
@@ -237,3 +237,16 @@ DROP
 -- cleanup
 DROP VIEW rg_test_monitor;
 DROP
+
+-- ----------------------------------------------------------------------
+-- Test: "CREATE INDEX CONCURRENTLY" when compiled with enable-cassert
+-- ----------------------------------------------------------------------
+
+CREATE TABLE t(a text, b text);
+CREATE
+CREATE INDEX CONCURRENTLY t_idx ON t(a, b);
+CREATE
+DROP INDEX CONCURRENTLY t_idx;
+DROP
+DROP TABLE t;
+DROP

--- a/src/test/isolation2/sql/resgroup/resgroup_transaction.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_transaction.sql
@@ -134,3 +134,12 @@ DROP FUNCTION rg_drop_func();
 
 -- cleanup
 DROP VIEW rg_test_monitor;
+
+-- ----------------------------------------------------------------------
+-- Test: "CREATE INDEX CONCURRENTLY" when compiled with enable-cassert
+-- ----------------------------------------------------------------------
+
+CREATE TABLE t(a text, b text);
+CREATE INDEX CONCURRENTLY t_idx ON t(a, b);
+DROP INDEX CONCURRENTLY t_idx;
+DROP TABLE t;


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

When resource groups are enabled, StartTransaction() may have taken a catalog snapshot
within GetResGroupIdForRole, and xmin is not InvalidTransactionId. Therefore, it does
not meet the status requirements for "CREATE INDEX CONCURRENTLY".

Reproduction method:

1. Compile Debug version and enable assert.
```
./configure --enable-debug --enable-cassert
```

2. Enable resource group management.

```
gp_resource_manager='group'
```

3. Test Case
```
create table t(a text, b text);
-- crash:
create index concurrently t_idx on t(a, b);
-- "ERROR:  relation "t_idx" already exists". Indicates that the transaction has been successfully committed.
create index concurrently t_idx on t(a, b);
```

4. Test Results

```
[fairyfar@bogon cloudberry]$ psql postgres
psql (16.9, server 16.9)
Type "help" for help.

postgres=# create table t(a text, b text);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
postgres=# create index concurrently t_idx on t(a, b);
FATAL:  Unexpected internal error (assert.c:46)
DETAIL:  ("MyProc->xid == InvalidTransactionId && MyProc->xmin == InvalidTransactionId", File: "indexcmds.c", Line: 5459)
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
The connection to the server was lost. Attempting reset: Failed.
!?> \q

[fairyfar@bogon cloudberry]$ psql postgres
psql (16.9, server 16.9)
Type "help" for help.

postgres=# create index concurrently t_idx on t(a, b);
ERROR:  relation "t_idx" already exists
```

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
