### PR TITLE
ORCA: Fix use-after-free in CXformSplitWindowFunc

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformSplitWindowFunc.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSplitWindowFunc.cpp
@@ -375,12 +375,25 @@ CXformSplitWindowFunc::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CExpression *pexprLocalSelect =
 		GPOS_NEW(mp) CExpression(mp, pSelectCopy, pexprLocal, pexprScalarCmp);
 
+	// the global SequenceProject below takes ownership of one reference each to
+	// pds, pdrgpos and pdrgpwf, just like the local SequenceProject above. Only
+	// a single AddRef() was issued for each of them, so add the matching
+	// references here; otherwise the reference count underflows, these objects
+	// are freed while still in use, and the dangling memory later crashes the
+	// DXL-to-PlStmt translation (use-after-free)
+	pds->AddRef();
+	pdrgpos->AddRef();
+	pdrgpwf->AddRef();
+
 	CExpression *pexprGlobal = GPOS_NEW(mp)
 		CExpression(mp,
 					GPOS_NEW(mp) CLogicalSequenceProject(
 						mp, COperator::ESPType::EsptypeGlobalTwoStep, pds,
 						pdrgpos, pdrgpwf),
 					pexprLocalSelect, pexprProjectListGlobal);
+
+	pexpr->Pop()->AddRef();
+	pexprScalarCmp->AddRef();
 
 	CExpression *pexprGlobalSelect =
 		GPOS_NEW(mp) CExpression(mp, pexpr->Pop(), pexprGlobal, pexprScalarCmp);


### PR DESCRIPTION
CXformSplitWindowFunc::Transform() builds a local and a global CLogicalSequenceProject, and each constructor takes ownership of one reference to the window's distribution spec (pds), order specs (pdrgpos) and frames (pdrgpwf). Only a single AddRef() was issued for each object, so once both SequenceProjects and the original are released the reference count underflows and the objects are freed while still in use.

The dangling memory later surfaces as a corrupt (unaligned) scalar DXL node while translating a table scan filter, crashing the coordinator with SIGSEGV at CTranslatorDXLToScalar.cpp:111 during DXL-to-PlStmt translation. This reproduces on window-function queries (e.g. TPC-DS query 44) when optimizer_force_split_window_function is on; the transform is only enabled under that GUC, which is why the crash disappears when it is off.

Add the missing AddRef() for pds, pdrgpos and pdrgpwf before building the global SequenceProject, and for the Select operator and its scalar comparison before reusing them in the global Select, so every owner holds its own reference.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
