### PR TITLE
PAX: fix SIGSEGV in SUM stats merge during DELETE on minmax columns

### DIFF
--- a/contrib/pax_storage/expected/delete_sum_stats.out
+++ b/contrib/pax_storage/expected/delete_sum_stats.out
@@ -1,0 +1,53 @@
+-- Verify that DELETE statistics refresh uses the SUM result type when
+-- deserializing and merging stats. In particular, sum(bigint) returns numeric.
+set pax.max_tuples_per_group = 25;
+create table pax_delete_sum_stats (
+  dist_key int,
+  id bigint,
+  int_amount int,
+  bigint_amount bigint,
+  numeric_amount numeric
+)
+using pax
+with (minmax_columns = 'int_amount,bigint_amount,numeric_amount')
+distributed by (dist_key);
+insert into pax_delete_sum_stats
+select 1, i, i, i, i::numeric * 2
+from generate_series(1, 1000) i;
+select count(*) as rows,
+       sum(int_amount) as int_sum,
+       sum(bigint_amount) as bigint_sum,
+       sum(numeric_amount) as numeric_sum
+from pax_delete_sum_stats;
+ rows | int_sum | bigint_sum | numeric_sum 
+------+---------+------------+-------------
+ 1000 |  500500 |     500500 |     1001000
+(1 row)
+
+delete from pax_delete_sum_stats where id between 1 and 100;
+select count(*) as rows,
+       sum(int_amount) as int_sum,
+       sum(bigint_amount) as bigint_sum,
+       sum(numeric_amount) as numeric_sum
+from pax_delete_sum_stats;
+ rows | int_sum | bigint_sum | numeric_sum 
+------+---------+------------+-------------
+  900 |  495450 |     495450 |      990900
+(1 row)
+
+insert into pax_delete_sum_stats
+select 1, i, i, i, i::numeric * 2
+from generate_series(1001, 1100) i;
+delete from pax_delete_sum_stats where id between 301 and 400;
+select count(*) as rows,
+       sum(int_amount) as int_sum,
+       sum(bigint_amount) as bigint_sum,
+       sum(numeric_amount) as numeric_sum
+from pax_delete_sum_stats;
+ rows | int_sum | bigint_sum | numeric_sum 
+------+---------+------------+-------------
+  900 |  565450 |     565450 |     1130900
+(1 row)
+
+drop table pax_delete_sum_stats;
+reset pax.max_tuples_per_group;

--- a/contrib/pax_storage/pax_schedule
+++ b/contrib/pax_storage/pax_schedule
@@ -10,6 +10,7 @@ test: statistics_bloom_filter
 test: filter_tree filter_tree_arithmetic
 test: filter_tree_root_quals
 test: statistics/statistics 
+test: delete_sum_stats
 test: statistics/min_max_time_types statistics/min_max_text_types statistics/min_max_other_types statistics/min_max_net_types statistics/min_max_int_types statistics/min_max_geo_types statistics/min_max_float_types statistics/min_max_bit_byte_types
 
 

--- a/contrib/pax_storage/sql/delete_sum_stats.sql
+++ b/contrib/pax_storage/sql/delete_sum_stats.sql
@@ -1,0 +1,47 @@
+-- Verify that DELETE statistics refresh uses the SUM result type when
+-- deserializing and merging stats. In particular, sum(bigint) returns numeric.
+set pax.max_tuples_per_group = 25;
+
+create table pax_delete_sum_stats (
+  dist_key int,
+  id bigint,
+  int_amount int,
+  bigint_amount bigint,
+  numeric_amount numeric
+)
+using pax
+with (minmax_columns = 'int_amount,bigint_amount,numeric_amount')
+distributed by (dist_key);
+
+insert into pax_delete_sum_stats
+select 1, i, i, i, i::numeric * 2
+from generate_series(1, 1000) i;
+
+select count(*) as rows,
+       sum(int_amount) as int_sum,
+       sum(bigint_amount) as bigint_sum,
+       sum(numeric_amount) as numeric_sum
+from pax_delete_sum_stats;
+
+delete from pax_delete_sum_stats where id between 1 and 100;
+
+select count(*) as rows,
+       sum(int_amount) as int_sum,
+       sum(bigint_amount) as bigint_sum,
+       sum(numeric_amount) as numeric_sum
+from pax_delete_sum_stats;
+
+insert into pax_delete_sum_stats
+select 1, i, i, i, i::numeric * 2
+from generate_series(1001, 1100) i;
+
+delete from pax_delete_sum_stats where id between 301 and 400;
+
+select count(*) as rows,
+       sum(int_amount) as int_sum,
+       sum(bigint_amount) as bigint_sum,
+       sum(numeric_amount) as numeric_sum
+from pax_delete_sum_stats;
+
+drop table pax_delete_sum_stats;
+reset pax.max_tuples_per_group;

--- a/contrib/pax_storage/src/cpp/storage/micro_partition_stats.cc
+++ b/contrib/pax_storage/src/cpp/storage/micro_partition_stats.cc
@@ -758,7 +758,7 @@ void MicroPartitionStats::MergeRawInfo(
     } else if (sum_stat->status == STATUS_NEED_UPDATE) {
       sum_result =
           FromValue(stats_info->columnstats(column_index).datastats().sum(),
-                    typlen, typbyval, column_index);
+                    sum_stat->rettyplen, sum_stat->rettypbyval, column_index);
       Datum newval = cbdb::FunctionCall2Coll(&sum_stat->add_func, InvalidOid,
                                              sum_stat->result, sum_result);
       if (!sum_stat->rettypbyval && newval != sum_stat->result &&
@@ -766,11 +766,11 @@ void MicroPartitionStats::MergeRawInfo(
         cbdb::Pfree(cbdb::DatumToPointer(sum_stat->result));
       }
       sum_stat->result =
-          cbdb::datumCopy(newval, sum_stat->rettyplen, sum_stat->rettypbyval);
+          cbdb::datumCopy(newval, sum_stat->rettypbyval, sum_stat->rettyplen);
     } else if (sum_stat->status == STATUS_MISSING_INIT_VAL) {
       sum_result =
           FromValue(stats_info->columnstats(column_index).datastats().sum(),
-                    typlen, typbyval, column_index);
+                    sum_stat->rettyplen, sum_stat->rettypbyval, column_index);
       sum_stat->result = cbdb::datumCopy(sum_result, sum_stat->rettypbyval,
                                          sum_stat->rettyplen);
       sum_stat->status = STATUS_NEED_UPDATE;
@@ -966,8 +966,8 @@ void MicroPartitionStats::MergeTo(MicroPartitionStats *stats) {
           left_sum_stat->result) {
         cbdb::Pfree(cbdb::DatumToPointer(left_sum_stat->result));
       }
-      left_sum_stat->result = cbdb::datumCopy(newval, left_sum_stat->rettyplen,
-                                              left_sum_stat->rettypbyval);
+      left_sum_stat->result = cbdb::datumCopy(
+          newval, left_sum_stat->rettypbyval, left_sum_stat->rettyplen);
     } else if (left_sum_stat->status == STATUS_MISSING_INIT_VAL) {
       left_sum_stat->result =
           cbdb::datumCopy(right_sum_stat->result, left_sum_stat->rettypbyval,


### PR DESCRIPTION
Fixes #1767

### What does this PR do?

Fixes a segment crash (SIGSEGV) that occurs when PAX tables with `minmax_columns` containing numeric types (int, bigint, numeric) undergo repeated DELETE operations. The crash happens in `datumCopy()` during the visibility-map statistics refresh path (`MicroPartitionStats::MergeRawInfo()`).

Two bugs are fixed in `contrib/pax_storage/src/cpp/storage/micro_partition_stats.cc`:

1. **Wrong type metadata in `FromValue()`**: The serialized SUM value was deserialized using the column's physical type (`typlen`/`typbyval`) instead of the SUM aggregate's return type (`rettyplen`/`rettypbyval`). For example, `sum(bigint)` returns `numeric`, so the stored SUM datum must be interpreted as `numeric`, not as `int8`. This mismatch produced an invalid `Datum` that crashed in `datumCopy()`.

2. **Swapped arguments in `datumCopy()`**: The call passed `(value, typlen, typbyval)` but the wrapper signature is `datumCopy(value, typByVal, typLen)`. This swapped pass-by-value/pass-by-reference flags, leading to memory corruption.

### Type of Change
- [x] Bug fix (non-breaking change)

### Breaking Changes
None.

### Test Plan
- [x] Unit tests added/updated — new regression test `delete_sum_stats` covering DELETE + INSERT + DELETE on int, bigint, and numeric columns with `minmax_columns` enabled
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact

**Performance:**
None — fix only affects correctness of stats merging, not the hot path.

**User-facing changes:**
Fixes a crash that users could hit with DELETE on PAX tables with minmax_columns.

**Dependencies:**
None.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [x] Added/updated documentation (regression test included)
- [x] Reviewed code for security implications
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context

Root cause analysis and reproduction steps are documented in issue #1767. The crash stack trace shows the failure path:

```
libpostgres.so datumCopy
pax.so cbdb::datumCopy
pax.so pax::MicroPartitionStats::MergeRawInfo
pax.so pax::MicroPartitionStatsUpdater::Update
pax.so pax::TableDeleter::UpdateStatsInAuxTable
pax.so pax::TableDeleter::DeleteWithVisibilityMap
```