### PR TITLE
fix: ExplainNode guard against NULL planstate on QE

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1557,13 +1557,12 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	int			motion_recv;
 	int			motion_snd;
 	ExecSlice  *parentSlice = NULL;
-	/* 
-	 * Guard if subtree on QE lives in another slice 
-	 * and not instantiated here.
-	*/
+	/*
+	 * Guard against the case where a subtree on the QE lives in another slice
+	 * and is not instantiated in this slice.
+	 */
 	if (planstate == NULL)
 		return;
-	
 	plan = planstate->plan;
 
 	/* Remember who called us. */

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1540,7 +1540,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			const char *relationship, const char *plan_name,
 			ExplainState *es)
 {
-	Plan	   *plan = planstate->plan;
+	Plan	   *plan;
 	PlanState  *parentplanstate;
 	ExecSlice  *save_currentSlice = es->currentSlice;    /* save */
 	const char *pname;			/* node type name for text output */
@@ -1557,6 +1557,14 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	int			motion_recv;
 	int			motion_snd;
 	ExecSlice  *parentSlice = NULL;
+	/* 
+	 * Guard if subtree on QE lives in another slice 
+	 * and not instantiated here.
+	*/
+	if (planstate == NULL)
+		return;
+	
+	plan = planstate->plan;
 
 	/* Remember who called us. */
 	parentplanstate = es->parentPlanState;
@@ -2945,8 +2953,11 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	/* lefttree */
 	if (outerPlan(plan) && !skip_outer)
 	{
-		ExplainNode(outerPlanState(planstate), ancestors,
-					"Outer", NULL, es);
+		if (outerPlanState(planstate))
+		{
+			ExplainNode(outerPlanState(planstate), ancestors, 
+						"Outer", NULL, es);
+		}
 	}
     else if (skip_outer)
     {


### PR DESCRIPTION
Fix segfault in ExplainNode() on a QE
A receiving Motion has no child PlanState when its child slice runs on
another gang.  ExplainNode() recursed into it anyway and crashed.
Return early when planstate is NULL.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
This change fixes a crash that occurs on the Query Executor (QE) when a subtree lives in a different slice.
The original code assumed that planstate is always non‑NULL and directly dereferenced planstate->plan.
When the subtree is not instantiated in the current slice, planstate can be NULL, leading to a segmentation fault.
The patch adds:

A NULL guard for planstate at the start of ExplainNode.
Moves the assignment plan = planstate->plan after the guard.
Additional guard when recursing into the outer plan to avoid calling ExplainNode with a NULL outerPlanState.
These changes make EXPLAIN robust across slice boundaries without altering any existing functionality.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
No breaking changes. The public API and plan execution behavior remain unchanged; only additional safety checks were added.

### Test Plan
Unit tests: No new unit tests were added because the fix is defensive and does not change the logical output of EXPLAIN.
Integration tests: Ran the full regression test suite, including parallel tests, and verified that the previously failing scenario no longer crashes.

- [x] Passed `make installcheck`
- [x] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
**Performance:**
Negligible impact – the added NULL checks are inexpensive branch predictions and do not affect the typical execution path.

**User-facing changes:**
ExplainPrintPlan now works on QE

**Dependencies:**
Nope

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [x] Added/updated documentation
- [x] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [x] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
ExplainNode was called from the QE side with a planstate that had not been instantiated because the subtree resides entirely in another slice.
