### PR TITLE
task: fix intermittent "tuple concurrently updated" in DROP TASK CI

### DIFF
--- a/src/backend/catalog/pg_task_run_history.c
+++ b/src/backend/catalog/pg_task_run_history.c
@@ -37,6 +37,9 @@
 #include "utils/builtins.h"
 #include "utils/rel.h"
 #include "utils/timestamp.h"
+#include "access/heapam.h"
+#include "access/tableam.h"
+#include "miscadmin.h"
 
 /*
  * TaskRunHistoryCreate
@@ -198,8 +201,6 @@ void
 RemoveTaskRunHistoryByJobId(Oid jobid)
 {
     Relation    pg_task_run_history;
-    HeapTuple   tup;
-    SysScanDesc scanDescriptor = NULL;
     ScanKeyData scanKey[1];
 
     pg_task_run_history = table_open(TaskRunHistoryRelationId, RowExclusiveLock);
@@ -207,14 +208,62 @@ RemoveTaskRunHistoryByJobId(Oid jobid)
     ScanKeyInit(&scanKey[0], Anum_pg_task_run_history_jobid, BTEqualStrategyNumber,
                 F_OIDEQ, ObjectIdGetDatum(jobid));
 
-    scanDescriptor = systable_beginscan(pg_task_run_history, TaskRunHistoryJobIdIndexId,
-                                        true, NULL, 1, scanKey);
-
-    while (HeapTupleIsValid(tup = systable_getnext(scanDescriptor)))
+    /*
+     * Restart the scan after each delete so we always see the latest
+     * committed version of every tuple.  Using heap_delete directly
+     * (instead of CatalogTupleDelete) lets us handle concurrent updates
+     * gracefully.
+     */
+    for (;;)
     {
-        CatalogTupleDelete(pg_task_run_history, &tup->t_self);
+        SysScanDesc    scanDescriptor;
+        HeapTuple      tup;
+        TM_Result      result;
+        TM_FailureData tmfd;
+
+        scanDescriptor = systable_beginscan(pg_task_run_history,
+                                            TaskRunHistoryJobIdIndexId,
+                                            true, NULL, 1, scanKey);
+
+        tup = systable_getnext(scanDescriptor);
+
+        if (!HeapTupleIsValid(tup))
+        {
+            systable_endscan(scanDescriptor);
+            break;
+        }
+
+        result = heap_delete(pg_task_run_history, &tup->t_self,
+                            GetCurrentCommandId(true),
+                            InvalidSnapshot,
+                            true /* wait for commit */,
+                            &tmfd,
+                            false /* changingPart */);
+
+        systable_endscan(scanDescriptor);
+
+        switch (result)
+        {
+            case TM_Ok:
+                /* deleted successfully; loop to find next row */
+                break;
+            case TM_Updated:
+            case TM_Deleted:
+                /*
+                 * The cron daemon concurrently modified this row.
+                 * Loop back to re-scan and pick up the updated version.
+                 */
+                break;
+            case TM_SelfModified:
+                elog(ERROR, "task run history tuple self-modified during DROP TASK");
+                break;
+            default:
+                elog(ERROR, "unexpected heap_delete status: %u", result);
+                break;
+        }
+
+        CommandCounterIncrement();
     }
 
-    systable_endscan(scanDescriptor);
     table_close(pg_task_run_history, RowExclusiveLock);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

### What does this PR do?

Fixes an intermittent `tuple concurrently updated` error in the `task` regression test (`ic-orca-parallel` CI job).

**CI failure:**
```
diff -U3 .../expected/task.out .../results/task.out
@@ -111,6 +111,7 @@
 drop user task_cron;
 drop task vacuum_db;
 drop task valid_task_1;
+ERROR:  tuple concurrently updated (heapam.c:3112)
 drop task valid_task_2;
```

### Type of Change
- [x] Bug fix (non-breaking change)

### Root Cause

`DROP TASK` performs two deletions:

```
DropTask()
├── UnscheduleCronJob()           → DELETE FROM pg_task
└── RemoveTaskRunHistoryByJobId() → DELETE FROM pg_task_run_history  ← race here
```

`RemoveTaskRunHistoryByJobId` used `CatalogTupleDelete` (wrapping `simple_heap_delete`) to bulk-delete `pg_task_run_history` rows. When `heap_delete` encounters a tuple concurrently updated by a committed transaction, it returns `TM_Updated` and `simple_heap_delete` raises `ERROR: tuple concurrently updated`.

The concurrent updater is the **pg_cron launcher daemon**, which records task execution results by INSERTing and UPDATEing `pg_task_run_history` rows for the same jobid. This race is CloudberryDB-specific: the original pg_cron extension does not delete run history during `unschedule`.

### Race Timeline

```
Timeline              DROP TASK (session A)          cron daemon (session B)
─────────────────────────────────────────────────────────────────────────────
T1   UnscheduleCronJob → DELETE pg_task row ✓
     SIGHUP sent to daemon (not yet processed)

T2                                                      daemon fires task (job list not reloaded yet)
                                                        TaskRunHistoryCreate → INSERT run_history row
                                                        Execute task SQL
                                                        UpdateJobRunDetail → UPDATE run_history row
                                                        COMMIT

T3   RemoveTaskRunHistoryByJobId:
     scan finds run_history row (old tuple version)
     ↓ daemon already UPDATEd this row at T2 (committed)
     heap_delete(old t_self) → TM_Updated
     ERROR: tuple concurrently updated
```

Even after `UnscheduleCronJob` deletes the `pg_task` row and sends SIGHUP, the daemon may fire one more execution before reloading its job list. During this window, the daemon UPDATE races with `RemoveTaskRunHistoryByJobId` DELETE.

The 1-second schedule (`valid_task_1`) maximizes collision probability.

### Fix

Replace `CatalogTupleDelete` with direct `heap_delete` calls and handle `TM_Updated`/`TM_Deleted` gracefully:

- Switch from single-pass while-loop to restart-scan `for(;;)` pattern: after each delete, restart scan to see the latest committed tuple version.
- `TM_Updated`/`TM_Deleted` → retry (re-scan picks up updated tuple)
- `TM_Ok` → success
- `TM_SelfModified` / unexpected → ERROR

Safe because `UnscheduleCronJob` already deleted the `pg_task` entry — run-history rows are orphan data cleaned up best-effort.

### Breaking Changes

None.

### Test Plan
- [x] Passed `make installcheck` for task regression test locally (15 consecutive runs, 0 failures)
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact

**Performance:** Minimal — restart-scan loop is O(n²) but n (run-history rows per job) is typically small.

**User-facing changes:** None — DROP TASK behavior unchanged, only more reliable.

**Dependencies:** None.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [x] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation