### PR TITLE
Fix test modules compile-time issues

### DIFF
--- a/src/test/heap_checksum/heap_checksum_helper.c
+++ b/src/test/heap_checksum/heap_checksum_helper.c
@@ -6,13 +6,13 @@
 *	src/test/heap_checksum/heap_checksum_helper.c
 *--------------------------------------------------------------------------
 */
-#include "c.h"
 #include "postgres.h"
 #include "funcapi.h"
 #include "nodes/pg_list.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "access/xlog.h"
+#include "access/xlogutils.h"
 
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -25,17 +25,17 @@ Datum
 invalidate_buffers(PG_FUNCTION_ARGS)
 {
 	SMgrRelation reln = (SMgrRelation) palloc(sizeof(SMgrRelationData));
-	RelFileNodeBackend  rnodebackend;
+	RelFileLocatorBackend  rnodebackend;
 	ForkNumber forknum = MAIN_FORKNUM;
 	BlockNumber firstDelBlock = 0;
 
-	rnodebackend.node.spcNode = PG_GETARG_OID(0);
-	rnodebackend.node.dbNode  = PG_GETARG_OID(1);
-	rnodebackend.node.relNode = PG_GETARG_OID(2);
+	rnodebackend.locator.spcOid = PG_GETARG_OID(0);
+	rnodebackend.locator.dbOid  = PG_GETARG_OID(1);
+	rnodebackend.locator.relNumber = PG_GETARG_OID(2);
 
 	rnodebackend.backend = InvalidBackendId; /* not temporary/local */
 	Assert(!InRecovery); /* can't be used in recovery mode */
-	reln->smgr_rnode = rnodebackend;
+	reln->smgr_rlocator = rnodebackend;
 
 	DropRelFileNodeBuffers(reln, &forknum, 1, &firstDelBlock);
 	pfree(reln);

--- a/src/test/modules/test_copy_callbacks/test_copy_callbacks.c
+++ b/src/test/modules/test_copy_callbacks/test_copy_callbacks.c
@@ -35,12 +35,12 @@ test_copy_to_callback(PG_FUNCTION_ARGS)
 {
 	Relation	rel = table_open(PG_GETARG_OID(0), AccessShareLock);
 	CopyToState cstate;
-	int64		processed;
+	uint64		processed;
 
 	cstate = BeginCopyTo(NULL, rel, NULL, RelationGetRelid(rel), NULL, false,
 						 to_cb, NIL, NIL);
 	processed = DoCopyTo(cstate);
-	EndCopyTo(cstate);
+	EndCopyTo(cstate, &processed);
 
 	ereport(NOTICE, (errmsg("COPY TO callback has processed %lld rows",
 							(long long) processed)));

--- a/src/test/modules/test_ddl_deparse/test_ddl_deparse.c
+++ b/src/test/modules/test_ddl_deparse/test_ddl_deparse.c
@@ -151,6 +151,7 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "SET COMPRESSION";
 				break;
 			case AT_DropColumn:
+			case AT_DropColumnRecurse:
 				strtype = "DROP COLUMN";
 				break;
 			case AT_AddIndex:
@@ -160,6 +161,7 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "(re) ADD INDEX";
 				break;
 			case AT_AddConstraint:
+			case AT_AddConstraintRecurse:
 				strtype = "ADD CONSTRAINT";
 				break;
 			case AT_ReAddConstraint:
@@ -172,12 +174,14 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				strtype = "ALTER CONSTRAINT";
 				break;
 			case AT_ValidateConstraint:
+			case AT_ValidateConstraintRecurse:
 				strtype = "VALIDATE CONSTRAINT";
 				break;
 			case AT_AddIndexConstraint:
 				strtype = "ADD CONSTRAINT (using index)";
 				break;
 			case AT_DropConstraint:
+			case AT_DropConstraintRecurse:
 				strtype = "DROP CONSTRAINT";
 				break;
 			case AT_ReAddComment:
@@ -314,6 +318,43 @@ get_altertable_subcmdinfo(PG_FUNCTION_ARGS)
 				break;
 			case AT_ReAddStatistics:
 				strtype = "(re) ADD STATS";
+				break;
+			/* Cloudberry addons */
+			case AT_SetDistributedBy:
+				strtype = "SET DISTRIBUTED BY";
+				break;
+			case AT_ExpandTable:
+				strtype = "EXPAND TABLE";
+				break;
+			case AT_ExpandPartitionTablePrepare:
+				strtype = "EXPAND PARTITION TABLE PREPARE";
+				break;
+			case AT_ShrinkTable:
+				strtype = "SHRINK TABLE";
+				break;
+			case AT_PartAdd:
+				strtype = "PART ADD";
+				break;
+			case AT_PartAlter:
+				strtype = "PART ALTER";
+				break;
+			case AT_PartDrop:
+				strtype = "PART DROP";
+				break;
+			case AT_PartExchange:
+				strtype = "PART EXCHANGE";
+				break;
+			case AT_PartRename:
+				strtype = "PART RENAME";
+				break;
+			case AT_PartSetTemplate:
+				strtype = "PART SET TEMPLATE";
+				break;
+			case AT_PartSplit:
+				strtype = "PART SPLIT";
+				break;
+			case AT_PartTruncate:
+				strtype = "PART TRUNCATE";
 				break;
 		}
 

--- a/src/test/modules/test_planner/src/planner_test_helpers.c
+++ b/src/test/modules/test_planner/src/planner_test_helpers.c
@@ -12,9 +12,9 @@ get_parsetree_for(const char *query_string)
 }
 
 static Query *
-get_query_for_parsetree(Node *parsetree, const char *query_string)
+get_query_for_parsetree(RawStmt *parsetree, const char *query_string)
 {
-	List *querytree_list = pg_analyze_and_rewrite(parsetree, query_string, NULL, 0, NULL);
+	List *querytree_list = pg_analyze_and_rewrite_fixedparams(parsetree, query_string, NULL, 0, NULL);
 	ListCell *querytree = list_head(querytree_list);
 	return (Query *)lfirst(querytree);
 }
@@ -22,7 +22,7 @@ get_query_for_parsetree(Node *parsetree, const char *query_string)
 Query *
 make_query(const char *query_string)
 {
-	Node *parsetree = get_parsetree_for(query_string);
+	RawStmt *parsetree = get_parsetree_for(query_string);
 
 	return get_query_for_parsetree(parsetree, query_string);
 }


### PR DESCRIPTION
before:
```
reshke@oheijweoij:~/cloudberry/src/test/heap_checksum$ make -j32 install
make -C ../../../src/backend generated-headers
/usr/bin/mkdir -p '/usr/local/gpdb/lib/postgresql'
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-but-set-variable -Werror=implicit-fallthrough=3 -Wno-format-truncation -Wno-stringop-truncation -g -O3 -fPIC  -DUSE_INTERNAL_FTS=1  -Werror=uninitialized -Werror=implicit-function-declaration -Werror -fPIC -fvisibility=hidden -I. -I. -I../../../src/include   -D_GNU_SOURCE -I/usr/include/libxml2   -c -o heap_checksum_helper.o heap_checksum_helper.c -MMD -MP -MF .deps/heap_checksum_helper.Po
make[1]: Entering directory '/home/reshke/cloudberry/src/backend'
make -C catalog distprep generated-header-symlinks
make -C utils distprep generated-header-symlinks
make[2]: Entering directory '/home/reshke/cloudberry/src/backend/utils'
make[2]: Nothing to be done for 'distprep'.
make -C adt jsonpath_gram.h
make[2]: Entering directory '/home/reshke/cloudberry/src/backend/catalog'
make[2]: Nothing to be done for 'distprep'.
make[2]: Nothing to be done for 'generated-header-symlinks'.
make[2]: Leaving directory '/home/reshke/cloudberry/src/backend/catalog'
make[3]: Entering directory '/home/reshke/cloudberry/src/backend/utils/adt'
make[3]: 'jsonpath_gram.h' is up to date.
make[3]: Leaving directory '/home/reshke/cloudberry/src/backend/utils/adt'
make[2]: Leaving directory '/home/reshke/cloudberry/src/backend/utils'
make[1]: Leaving directory '/home/reshke/cloudberry/src/backend'
heap_checksum_helper.c: In function ‘invalidate_buffers’:
heap_checksum_helper.c:28:9: error: unknown type name ‘RelFileNodeBackend’; did you mean ‘RelFileLocatorBackend’?
   28 |         RelFileNodeBackend  rnodebackend;
      |         ^~~~~~~~~~~~~~~~~~
      |         RelFileLocatorBackend
heap_checksum_helper.c:32:21: error: request for member ‘node’ in something not a structure or union
   32 |         rnodebackend.node.spcNode = PG_GETARG_OID(0);
      |                     ^
heap_checksum_helper.c:33:21: error: request for member ‘node’ in something not a structure or union
   33 |         rnodebackend.node.dbNode  = PG_GETARG_OID(1);
      |                     ^
heap_checksum_helper.c:34:21: error: request for member ‘node’ in something not a structure or union
   34 |         rnodebackend.node.relNode = PG_GETARG_OID(2);
      |                     ^
heap_checksum_helper.c:36:21: error: request for member ‘backend’ in something not a structure or union
   36 |         rnodebackend.backend = InvalidBackendId; /* not temporary/local */
      |                     ^
In file included from heap_checksum_helper.c:9:
heap_checksum_helper.c:37:17: error: ‘InRecovery’ undeclared (first use in this function)
   37 |         Assert(!InRecovery); /* can't be used in recovery mode */
      |                 ^~~~~~~~~~
../../../src/include/c.h:947:23: note: in definition of macro ‘Assert’
  947 |                 if (!(condition)) \
      |                       ^~~~~~~~~
heap_checksum_helper.c:37:17: note: each undeclared identifier is reported only once for each function it appears in
   37 |         Assert(!InRecovery); /* can't be used in recovery mode */
      |                 ^~~~~~~~~~
../../../src/include/c.h:947:23: note: in definition of macro ‘Assert’
  947 |                 if (!(condition)) \
      |                       ^~~~~~~~~
heap_checksum_helper.c:38:15: error: ‘SMgrRelationData’ has no member named ‘smgr_rnode’; did you mean ‘smgr_ao’?
   38 |         reln->smgr_rnode = rnodebackend;
      |               ^~~~~~~~~~
      |               smgr_ao




src/planner_test_helpers.c:17:32: error: implicit declaration of function ‘pg_analyze_and_rewrite’; did you mean ‘pg_analyze_and_rewrite_withcb’? [-Werror=implicit-function-declaration]
   17 |         List *querytree_list = pg_analyze_and_rewrite(parsetree, query_string, NULL, 0, NULL);
      |                                ^~~~~~~~~~~~~~~~~~~~~~
      |                                pg_analyze_and_rewrite_withcb
src/planner_test_helpers.c:17:32: error: initialization of ‘List *’ from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion]
src/planner_test_helpers.c: In function ‘make_query’:
src/planner_test_helpers.c:25:27: error: initialization of ‘Node *’ from incompatible pointer type ‘RawStmt *’ [-Werror=incompatible-pointer-types]
   25 |         Node *parsetree = get_parsetree_for(query_string);
      |                           ^~~~~~~~~~~~~~~~~
test_copy_callbacks.c: In function ‘test_copy_to_callback’:
test_copy_callbacks.c:43:9: error: too few arguments to function ‘EndCopyTo’
   43 |         EndCopyTo(cstate);
      |         ^~~~~~~~~
In file included from test_copy_callbacks.c:18:
../../../../src/include/commands/copy.h:208:13: note: declared here
  208 | extern void EndCopyTo(CopyToState cstate, uint64 *processed);
      |             ^~~~~~~~~
make[1]: *** [../../../../src/Makefile.global:1058: test_copy_callbacks.o] Error 1
```

and so on

