### PR TITLE
Fix various c23 compile errors

### DIFF
--- a/contrib/extprotocol/gpextprotocol.c
+++ b/contrib/extprotocol/gpextprotocol.c
@@ -299,7 +299,7 @@ DemoUri *ParseDemoUri(const char *uri_str)
 	/*
 	 * parse protocol
 	 */
-	char *post_protocol = strstr(uri_str, "://");
+	const char *post_protocol = strstr(uri_str, "://");
 		
 	if(!post_protocol)
 	{

--- a/gpcontrib/pg_hint_plan/pg_hint_plan.c
+++ b/gpcontrib/pg_hint_plan/pg_hint_plan.c
@@ -2003,7 +2003,7 @@ get_hints_from_comment(const char *p)
 {
 	const char *hint_head;
 	char	   *head;
-	char	   *tail;
+	const char	   *tail;
 	int			len;
 
 	if (p == NULL)
@@ -2050,7 +2050,7 @@ get_hints_from_comment(const char *p)
 	}
 
 	/* We don't support nested block comments. */
-	if ((head = strstr(p, BLOCK_COMMENT_START)) != NULL && head < tail)
+	if ((head = (char *)strstr(p, BLOCK_COMMENT_START)) != NULL && head < tail)
 	{
 		hint_ereport(head, ("Nested block comments are not supported."));
 		return NULL;

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1473,7 +1473,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyFormatOptions *opts)
 	{
 		/* use empty message */
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDS, "");
-		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDSIZE, 0);
+		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDSIZE, 0L);
 
 		/* post away and check response, retry if failed (timeout or * connect error) */
 		gp_perform_backoff_and_check_response(file, easy_perform_work);
@@ -1932,7 +1932,7 @@ gp_proto0_write_done(URL_CURL_FILE *file)
 
 	/* use empty message */
 	CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDS, "");
-	CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDSIZE, 0);
+	CURL_EASY_SETOPT(file->curl->handle, CURLOPT_POSTFIELDSIZE, 0L);
 
 	/* post away! */
 	gp_perform_backoff_and_check_response(file, easy_perform_work);

--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -1074,7 +1074,7 @@ char *
 makeMultirangeTypeName(const char *rangeTypeName, Oid typeNamespace)
 {
 	char	   *buf;
-	char	   *rangestr;
+	const char	   *rangestr;
 
 	/*
 	 * If the range type name contains "range" then change that to

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -142,6 +142,7 @@ typedef struct
  * Forward Declarations
  */
 static Node *fix_outer_query_motions_mutator(Node *node, decorate_subplans_with_motions_context *context);
+static Node *fix_outer_query_motions_mutator_adapter(Node *node, void *context);
 static Plan *fix_subplan_motion(PlannerInfo *root, Plan *subplan, Flow *outer_query_flow);
 static bool build_slice_table_walker(Node *node, build_slice_table_context *context);
 static void adjust_top_path_for_parallel_retrieve_cursor(Path *path, PlanSlice *slice);
@@ -852,7 +853,7 @@ fix_outer_query_motions_mutator(Node *node, decorate_subplans_with_motions_conte
 	/* An expression node might have subtrees containing plans to be mutated. */
 	if (!is_plan_node(node))
 	{
-		node = plan_tree_mutator(node, fix_outer_query_motions_mutator, context, false);
+		node = plan_tree_mutator(node, fix_outer_query_motions_mutator_adapter, context, false);
 
 		/*
 		 * If we see a SubPlan, remember the context where we saw it. We memorize
@@ -912,7 +913,7 @@ fix_outer_query_motions_mutator(Node *node, decorate_subplans_with_motions_conte
 		context->sliceDepth++;
 
 		plan = (Plan *) plan_tree_mutator((Node *) plan,
-										  fix_outer_query_motions_mutator,
+										  fix_outer_query_motions_mutator_adapter,
 										  context,
 										  false);
 		motion = (Motion *) plan;
@@ -991,11 +992,18 @@ fix_outer_query_motions_mutator(Node *node, decorate_subplans_with_motions_conte
 		saveCurrentPlanFlow = context->currentPlanFlow;
 		if (plan->flow != NULL && plan->flow->locustype != CdbLocusType_OuterQuery)
 			context->currentPlanFlow = plan->flow;
-		newnode = plan_tree_mutator(node, fix_outer_query_motions_mutator, context, false);
+		newnode = plan_tree_mutator(node, fix_outer_query_motions_mutator_adapter, context, false);
 		context->currentPlanFlow = saveCurrentPlanFlow;
 	}
 
 	return newnode;
+}
+
+static Node *
+fix_outer_query_motions_mutator_adapter(Node *node, void *context)
+{
+	return fix_outer_query_motions_mutator(
+		node, (decorate_subplans_with_motions_context *) context);
 }
 
 /*
@@ -1271,6 +1279,14 @@ cdbllize_build_slice_table(PlannerInfo *root, Plan *top_plan,
 }
 
 static bool
+build_slice_table_walker(Node *node, build_slice_table_context *context);
+static bool
+build_slice_table_walker_adapter(Node *node, void *context)
+{
+	return build_slice_table_walker(node, (build_slice_table_context *) context);
+}
+
+static bool
 build_slice_table_walker(Node *node, build_slice_table_context *context)
 {
 	PlannerInfo *root = (PlannerInfo *) context->base.node;
@@ -1312,9 +1328,9 @@ build_slice_table_walker(Node *node, build_slice_table_context *context)
 			root->glob->subplan_sliceIds[plan_id - 1] = context->currentSliceIndex;
 
 			result = plan_tree_walker(node,
-									  build_slice_table_walker,
-									  context,
-									  true);
+								  build_slice_table_walker_adapter,
+								  context,
+								  true);
 
 			context->currentSliceIndex = save_currentSliceIndex;
 
@@ -1372,7 +1388,7 @@ build_slice_table_walker(Node *node, build_slice_table_context *context)
 		}
 
 		result = plan_tree_walker((Node *) motion,
-								  build_slice_table_walker,
+								  build_slice_table_walker_adapter,
 								  context,
 								  false);
 
@@ -1382,7 +1398,7 @@ build_slice_table_walker(Node *node, build_slice_table_context *context)
 	}
 
 	return plan_tree_walker(node,
-							build_slice_table_walker,
+							build_slice_table_walker_adapter,
 							context,
 							false);
 }
@@ -1435,6 +1451,14 @@ typedef struct aware_result_t
 								 * plan_tree_walker/mutator */
 	int			nnodes;
 } aware_result_t;
+
+static bool
+motion_sanity_walker(Node *node, sanity_result_t *result);
+static bool
+motion_sanity_walker_adapter(Node *node, void *result)
+{
+	return motion_sanity_walker(node, (sanity_result_t *) result);
+}
 
 static bool
 motion_sanity_walker(Node *node, sanity_result_t *result)
@@ -1542,12 +1566,12 @@ motion_sanity_walker(Node *node, sanity_result_t *result)
 		case T_Sort:
 		case T_Material:
 		case T_ForeignScan:
-			if (plan_tree_walker(node, motion_sanity_walker, result, true))
+			if (plan_tree_walker(node, motion_sanity_walker_adapter, result, true))
 				return true;
 			break;
 
 		case T_Motion:
-			if (plan_tree_walker(node, motion_sanity_walker, result, true))
+			if (plan_tree_walker(node, motion_sanity_walker_adapter, result, true))
 				return true;
 			result->flags |= SANITY_MOTION;
 			elog(DEBUG5, "   found motion");

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -61,6 +61,7 @@ typedef struct
  */
 static Node *pre_dispatch_function_evaluation_mutator(Node *node,
 										 pre_dispatch_function_evaluation_context *context);
+static Node *pre_dispatch_function_evaluation_mutator_adapter(Node *node, void *context);
 static bool replace_shareinput_targetlists_walker(Node *node, PlannerInfo *root, bool fPop);
 
 
@@ -239,6 +240,14 @@ typedef struct ctid_inventory_context
 } ctid_inventory_context;
 
 static bool
+ctid_inventory_walker(Node *node, ctid_inventory_context *inv);
+static bool
+ctid_inventory_walker_adapter(Node *node, void *inv)
+{
+	return ctid_inventory_walker(node, (ctid_inventory_context *) inv);
+}
+
+static bool
 ctid_inventory_walker(Node *node, ctid_inventory_context *inv)
 {
 	if (node == NULL)
@@ -259,7 +268,7 @@ ctid_inventory_walker(Node *node, ctid_inventory_context *inv)
 		}
 		return false;
 	}
-	return plan_tree_walker(node, ctid_inventory_walker, inv, true);
+	return plan_tree_walker(node, ctid_inventory_walker_adapter, inv, true);
 }
 
 void
@@ -1182,6 +1191,14 @@ typedef struct ParamWalkerContext
 } ParamWalkerContext;
 
 static bool
+param_walker(Node *node, ParamWalkerContext *context);
+static bool
+param_walker_adapter(Node *node, void *context)
+{
+	return param_walker(node, (ParamWalkerContext *) context);
+}
+
+static bool
 param_walker(Node *node, ParamWalkerContext *context)
 {
 	PlannerInfo *root = (PlannerInfo *) context->base.node;
@@ -1277,7 +1294,7 @@ param_walker(Node *node, ParamWalkerContext *context)
 			break;
 	}
 
-	return plan_tree_walker(node, param_walker, context, false);
+	return plan_tree_walker(node, param_walker_adapter, context, false);
 }
 
 /*
@@ -1344,6 +1361,14 @@ rte_param_walker(List *rtable, ParamWalkerContext *context)
 }
 
 static bool
+initplan_walker(Node *node, ParamWalkerContext *context);
+static bool
+initplan_walker_adapter(Node *node, void *context)
+{
+	return initplan_walker(node, (ParamWalkerContext *) context);
+}
+
+static bool
 initplan_walker(Node *node, ParamWalkerContext *context)
 {
 	PlannerInfo *root;
@@ -1406,7 +1431,7 @@ initplan_walker(Node *node, ParamWalkerContext *context)
 		plan->initPlan = new_initplans;
 	}
 
-	return plan_tree_walker(node, initplan_walker, context, true);
+	return plan_tree_walker(node, initplan_walker_adapter, context, true);
 }
 
 /*
@@ -1779,11 +1804,18 @@ pre_dispatch_function_evaluation_mutator(Node *node,
 	 * simplify its arguments (if any) using this routine.
 	 */
 	new_node = plan_tree_mutator(node,
-								 pre_dispatch_function_evaluation_mutator,
+								 pre_dispatch_function_evaluation_mutator_adapter,
 								 (void *) context,
 								 true);
 
 	return new_node;
+}
+
+static Node *
+pre_dispatch_function_evaluation_mutator_adapter(Node *node, void *context)
+{
+	return pre_dispatch_function_evaluation_mutator(
+		node, (pre_dispatch_function_evaluation_context *) context);
 }
 
 /*

--- a/src/backend/cdb/cdbplan.c
+++ b/src/backend/cdb/cdbplan.c
@@ -30,9 +30,9 @@
 #include "utils/lsyscache.h"
 
 
-static void mutate_plan_fields(Plan *newplan, Plan *oldplan, Node *(*mutator) (), void *context);
-static void mutate_join_fields(Join *newplan, Join *oldplan, Node *(*mutator) (), void *context);
-static void mutate_sort_fields(Sort* newplan, Sort* oldplan, Node *(*mutator) (), void *context);
+static void mutate_plan_fields(Plan *newplan, Plan *oldplan, Node *(*mutator) (Node *, void *), void *context);
+static void mutate_join_fields(Join *newplan, Join *oldplan, Node *(*mutator) (Node *, void *), void *context);
+static void mutate_sort_fields(Sort* newplan, Sort* oldplan, Node *(*mutator) (Node *, void *), void *context);
 
 
 
@@ -107,7 +107,7 @@ static void mutate_sort_fields(Sort* newplan, Sort* oldplan, Node *(*mutator) ()
 
 Node *
 plan_tree_mutator(Node *node,
-				  Node *(*mutator) (),
+				  Node *(*mutator) (Node *, void *),
 				  void *context,
 				  bool recurse_into_subplans)
 {
@@ -1101,7 +1101,7 @@ plan_tree_mutator(Node *node,
  *
  */
 static void
-mutate_plan_fields(Plan *newplan, Plan *oldplan, Node *(*mutator) (), void *context)
+mutate_plan_fields(Plan *newplan, Plan *oldplan, Node *(*mutator) (Node *, void *), void *context)
 {
 	/*
 	 * Scalar fields startup_cost total_cost plan_rows plan_width nParamExec
@@ -1128,7 +1128,7 @@ mutate_plan_fields(Plan *newplan, Plan *oldplan, Node *(*mutator) (), void *cont
  *
  */
 static void
-mutate_join_fields(Join *newjoin, Join *oldjoin, Node *(*mutator) (), void *context)
+mutate_join_fields(Join *newjoin, Join *oldjoin, Node *(*mutator) (Node *, void *), void *context)
 {
 	/* A Join node is a Plan node. */
 	mutate_plan_fields((Plan *) newjoin, (Plan *) oldjoin, mutator, context);
@@ -1146,7 +1146,7 @@ mutate_join_fields(Join *newjoin, Join *oldjoin, Node *(*mutator) (), void *cont
  *
  */
 static void
-mutate_sort_fields(Sort *newsort, Sort *oldsort, Node *(*mutator) (), void *context)
+mutate_sort_fields(Sort *newsort, Sort *oldsort, Node *(*mutator) (Node *, void *), void *context)
 {
 	/* A Join node is a Plan node. */
 	mutate_plan_fields((Plan *) newsort, (Plan *) oldsort, mutator, context);

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1655,6 +1655,14 @@ getExecParamsToDispatch(PlannedStmt *stmt, ParamExecData *intPrm)
  * list looking for a specific paramid, and returns its type.
  */
 static bool
+param_walker(Node *node, ParamWalkerContext *context);
+static bool
+param_walker_adapter(Node *node, void *context)
+{
+	return param_walker(node, (ParamWalkerContext *) context);
+}
+
+static bool
 param_walker(Node *node, ParamWalkerContext *context)
 {
 	if (node == NULL)
@@ -1670,7 +1678,7 @@ param_walker(Node *node, ParamWalkerContext *context)
 			return false;
 		}
 	}
-	return plan_tree_walker(node, param_walker, context, true);
+	return plan_tree_walker(node, param_walker_adapter, context, true);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -167,7 +167,7 @@ AllocateGang(CdbDispatcherState *ds, GangType type, List *segments)
 bool
 segment_failure_due_to_recovery(const char *error_message)
 {
-	char	   *fatal = NULL,
+	const char	   *fatal = NULL,
 			   *ptr = NULL;
 	int			fatal_len = 0;
 
@@ -210,7 +210,7 @@ segment_failure_due_to_recovery(const char *error_message)
 bool
 segment_failure_due_to_missing_writer(const char *error_message)
 {
-	char	   *fatal = NULL,
+	const char	   *fatal = NULL,
 			   *ptr = NULL;
 	int			fatal_len = 0;
 
@@ -232,7 +232,7 @@ segment_failure_due_to_missing_writer(const char *error_message)
 bool
 segment_failure_due_to_fault_injector(const char *error_message)
 {
-	char	   *fatal = NULL,
+	const char	   *fatal = NULL,
 			   *ptr = NULL;
 	int			fatal_len = 0;
 

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1632,7 +1632,7 @@ getCpuSetByRole(const char *cpuset)
 		splitcpuset = (char *)cpuset;
 	else
 	{
-		char *scpu = (char*)first + 1;
+		char *second = (char*)first + 1;
 
 		/* Get result cpuset by IS_QUERY_DISPATCHER(), on master or segment */
 		if (IS_QUERY_DISPATCHER())

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1567,8 +1567,8 @@ checkCpusetSyntax(const char *cpuset)
 extern void
 checkCpuSetByRole(const char *cpuset)
 {
-	char *first = NULL;
-	char *last = NULL;
+	const char *first = NULL;
+	const char *last = NULL;
 
 	if (cpuset == NULL)
 	{
@@ -1627,12 +1627,12 @@ getCpuSetByRole(const char *cpuset)
 				errmsg("Unexpected cpuset invalid in getCpuSetByRole")));
 	}
 
-	char *first = strchr(cpuset, ';');
+	const char *first = strchr(cpuset, ';');
 	if (first == NULL)
 		splitcpuset = (char *)cpuset;
 	else
 	{
-		char *second = first + 1;
+		char *scpu = (char*)first + 1;
 
 		/* Get result cpuset by IS_QUERY_DISPATCHER(), on master or segment */
 		if (IS_QUERY_DISPATCHER())
@@ -1649,6 +1649,6 @@ getCpuSetByRole(const char *cpuset)
 		}
 	}
 
-	return splitcpuset;
+	return (char *)splitcpuset;
 }
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2400,6 +2400,15 @@ typedef struct MotionFinderContext
  */
 static bool
 MotionFinderWalker(Plan *node,
+				  void *context);
+static bool
+MotionFinderWalker_adapter(Node *node, void *context)
+{
+	return MotionFinderWalker((Plan *) node, context);
+}
+
+static bool
+MotionFinderWalker(Plan *node,
 				  void *context)
 {
 	Assert(context);
@@ -2420,7 +2429,7 @@ MotionFinderWalker(Plan *node,
 	}
 
 	/* Continue walking */
-	return plan_tree_walker((Node*)node, MotionFinderWalker, ctx, true);
+	return plan_tree_walker((Node*)node, MotionFinderWalker_adapter, ctx, true);
 }
 
 /*

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -35,7 +35,7 @@ static bool planstate_walk_members(PlanState **planstates, int nplans,
 								   void *context);
 
 static Node *
-range_table_entry_mutator(RangeTblEntry *rte, Node *(*mutator)(), void *context, int flags);
+range_table_entry_mutator(RangeTblEntry *rte, Node *(*mutator)(Node *, void *), void *context, int flags);
 
 /*
  *	exprType -
@@ -3970,7 +3970,7 @@ query_tree_mutator_impl(Query *query,
 }
 
 static Node *
-range_table_entry_mutator(RangeTblEntry *rte, Node *(*mutator)(), void *context, int flags)
+range_table_entry_mutator(RangeTblEntry *rte, Node *(*mutator)(Node *, void *), void *context, int flags)
 {
 	RangeTblEntry *newrte;
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -9321,6 +9321,11 @@ contain_motion(PlannerInfo *root, Node *node)
 }
 
 static bool
+contain_motion_walk(Node *node, contain_motion_walk_context *ctx);
+static bool
+contain_motion_walk_adapter(Node *node, void *ctx);
+
+static bool
 contain_motion_walk(Node *node, contain_motion_walk_context *ctx)
 {
 	PlannerInfo *root = (PlannerInfo *) ctx->base.node;
@@ -9344,7 +9349,7 @@ contain_motion_walk(Node *node, contain_motion_walk_context *ctx)
 				return false;
 
 			Plan *plan = list_nth(root->glob->subplans, plan_id - 1);
-			return plan_tree_walker((Node *) plan, contain_motion_walk, ctx, true);
+			return plan_tree_walker((Node *) plan, contain_motion_walk_adapter, ctx, true);
 		}
 	}
 
@@ -9354,7 +9359,13 @@ contain_motion_walk(Node *node, contain_motion_walk_context *ctx)
 		return true;
 	}
 
-	return plan_tree_walker((Node *) node, contain_motion_walk, ctx, true);
+	return plan_tree_walker((Node *) node, contain_motion_walk_adapter, ctx, true);
+}
+
+static bool
+contain_motion_walk_adapter(Node *node, void *ctx)
+{
+	return contain_motion_walk(node, (contain_motion_walk_context *) ctx);
 }
 
 /*

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -4494,6 +4494,11 @@ cdb_extract_plan_dependencies(PlannerInfo *root, Plan *plan)
 }
 
 static bool
+cdb_extract_plan_dependencies_walker(Node *node, cdb_extract_plan_dependencies_context *context);
+static bool
+cdb_extract_plan_dependencies_walker_adapter(Node *node, void *context);
+
+static bool
 cdb_extract_plan_dependencies_walker(Node *node, cdb_extract_plan_dependencies_context *context)
 {
 	if (node == NULL)
@@ -4501,8 +4506,15 @@ cdb_extract_plan_dependencies_walker(Node *node, cdb_extract_plan_dependencies_c
 	/* Extract function dependencies and check for regclass Consts */
 	fix_expr_common(context->root, node);
 
-	return plan_tree_walker(node, cdb_extract_plan_dependencies_walker,
+	return plan_tree_walker(node, cdb_extract_plan_dependencies_walker_adapter,
 							(void *) context, true);
+}
+
+static bool
+cdb_extract_plan_dependencies_walker_adapter(Node *node, void *context)
+{
+	return cdb_extract_plan_dependencies_walker(
+		node, (cdb_extract_plan_dependencies_context *) context);
 }
 
 /*

--- a/src/backend/optimizer/util/predtest_valueset.c
+++ b/src/backend/optimizer/util/predtest_valueset.c
@@ -28,7 +28,7 @@
 #define INT32MAX (2147483647)
 #define INT32MIN (-2147483648)
 
-static HTAB *CreateNodeSetHashTable();
+static HTAB *CreateNodeSetHashTable(MemoryContext memoryContext);
 static void AddValue(PossibleValueSet *pvs, Const *valueToCopy);
 static void RemoveValue(PossibleValueSet *pvs, Const *value);
 static bool ContainsValue(PossibleValueSet *pvs, Const *value);

--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -36,8 +36,8 @@ void exec_init_plan_tree_base(plan_tree_base_prefix *base, PlannedStmt *stmt)
 	base->node = (Node*)stmt;
 }
 
-static bool walk_scan_node_fields(Scan *scan, bool (*walker) (), void *context);
-static bool walk_join_node_fields(Join *join, bool (*walker) (), void *context);
+static bool walk_scan_node_fields(Scan *scan, bool (*walker) (Node *, void *), void *context);
+static bool walk_join_node_fields(Join *join, bool (*walker) (Node *, void *), void *context);
 
 
 /* ----------------------------------------------------------------------- *
@@ -57,7 +57,7 @@ static bool walk_join_node_fields(Join *join, bool (*walker) (), void *context);
  */
 bool
 walk_plan_node_fields(Plan *plan,
-					  bool (*walker) (),
+					  bool (*walker) (Node *, void *),
 					  void *context)
 {
 	/* target list to be computed at this node */
@@ -101,7 +101,7 @@ walk_plan_node_fields(Plan *plan,
  */
 bool
 walk_scan_node_fields(Scan *scan,
-					  bool (*walker) (),
+					  bool (*walker) (Node *, void *),
 					  void *context)
 {
 	/* A Scan node is a kind of Plan node. */
@@ -126,7 +126,7 @@ walk_scan_node_fields(Scan *scan,
  */
 bool
 walk_join_node_fields(Join *join,
-					  bool (*walker) (),
+					  bool (*walker) (Node *, void *),
 					  void *context)
 {
 	/* A Join node is a kind of Plan node. */
@@ -149,7 +149,7 @@ walk_join_node_fields(Join *join,
  */
 bool
 plan_tree_walker(Node *node,
-				 bool (*walker) (),
+				 bool (*walker) (Node *, void *),
 				 void *context,
 				 bool recurse_into_subplans)
 {
@@ -252,18 +252,18 @@ plan_tree_walker(Node *node,
 		case T_DynamicForeignScan:
 			if (walk_scan_node_fields((Scan *) node, walker, context))
 				return true;
-			if (walker(((ForeignScan *) node)->fdw_exprs, context))
+			if (walker((Node *) ((ForeignScan *) node)->fdw_exprs, context))
 				return true;
 			break;
 
 		case T_CustomScan:
 			if (walk_scan_node_fields((Scan *) node, walker, context))
 				return true;
-			if (walker(((CustomScan *) node)->custom_plans, context))
-				return true;
-			if (walker(((CustomScan *) node)->custom_exprs, context))
-				return true;
-			if (walker(((CustomScan *) node)->custom_scan_tlist, context))
+		if (walker((Node *) ((CustomScan *) node)->custom_plans, context))
+			return true;
+		if (walker((Node *) ((CustomScan *) node)->custom_exprs, context))
+			return true;
+		if (walker((Node *) ((CustomScan *) node)->custom_scan_tlist, context))
 				return true;
 			break;
 
@@ -396,7 +396,7 @@ plan_tree_walker(Node *node,
 			break;
 
 		case T_DQAExpr:
-			if (walker(((DQAExpr *)node)->agg_filter, context))
+			if (walker((Node *) ((DQAExpr *)node)->agg_filter, context))
 				return true;
 			/* Other fields are simple items and lists of simple items. */
 			break;
@@ -711,6 +711,11 @@ List *extract_nodes_plan(Plan *pl, int nodeTag, bool descendIntoSubqueries)
 }
 
 static bool
+extract_nodes_walker(Node *node, extract_context *context);
+static bool
+extract_nodes_walker_adapter(Node *node, void *context);
+
+static bool
 extract_nodes_walker(Node *node, extract_context *context)
 {
 	if (node == NULL)
@@ -758,9 +763,15 @@ extract_nodes_walker(Node *node, extract_context *context)
 		return false;
 	}
 
-	return plan_tree_walker(node, extract_nodes_walker,
+	return plan_tree_walker(node, extract_nodes_walker_adapter,
 							(void *) context,
 							true);
+}
+
+static bool
+extract_nodes_walker_adapter(Node *node, void *context)
+{
+	return extract_nodes_walker(node, (extract_context *) context);
 }
 
 /**

--- a/src/backend/task/entry.c
+++ b/src/backend/task/entry.c
@@ -230,13 +230,14 @@ parse_cron_entry(char *schedule)
 	return NULL;
 }
 
-static int
-get_list(bits, low, high, names, ch, file)
-	bitstr_t	*bits;		/* one bit per flag, default=FALSE */
-	int			low, high;	/* bounds, impl. offset for bitstr */
-	char		*names[];	/* NULL or *[] of names for these elements */
-	int			ch;			/* current character being processed */
-	FILE		*file;		/* file being read */
+static int get_list(
+    bitstr_t *bits,      /* one bit per flag, default = false */
+    int low,
+    int high,            /* bounds, implementation offset for bitstr */
+    char *names[],       /* NULL or array of element names */
+    int ch,              /* current character being processed */
+    FILE *file           /* file being read */
+)
 {
 	register int	done;
 
@@ -273,14 +274,18 @@ get_list(bits, low, high, names, ch, file)
 	return ch;
 }
 
+
+/*
+*
+* bits		 one bit per flag, default=FALSE 
+* low,
+* high;		bounds, impl. offset for bitstr
+* names[];	 NULL or names of elements 
+* ch;			current character being processed 
+* file;		 file being read
+*/
 static int
-get_range(bits, low, high, names, ch, file)
-	bitstr_t	*bits;		/* one bit per flag, default=FALSE */
-	int			low,
-				high;		/* bounds, impl. offset for bitstr */
-	char		*names[];	/* NULL or names of elements */
-	int			ch;			/* current character being processed */
-	FILE 		*file;		/* file being read */
+get_range(bitstr_t *bits, int low, int high, char *names[], int ch, FILE * file)
 {
 	/* range = number | number "-" number [ "/" number ] */
 	register int	i;
@@ -370,13 +375,15 @@ get_range(bits, low, high, names, ch, file)
 	return ch;
 }
 
+/*
+	int		*numptr;	where does the result go? 
+	int		low;		offset applied to result if symbolic enum used 
+	char	*names[];	symbolic names, if any, for enums 
+	int		ch;			current character
+	FILE 	*file;		source
+*/
 static int
-get_number(numptr, low, names, ch, file)
-	int		*numptr;	/* where does the result go? */
-	int		low;		/* offset applied to result if symbolic enum used */
-	char	*names[];	/* symbolic names, if any, for enums */
-	int		ch;			/* current character */
-	FILE 	*file;		/* source */
+get_number(int *numptr, int low, char *names[], int ch, FILE *file)
 {
 	char	temp[MAX_TEMPSTR], *pc;
 	int	len, i, all_digits;
@@ -427,12 +434,11 @@ get_number(numptr, low, names, ch, file)
 	return EOF;
 }
 
+/*
+	bitstr_t	*bits; 	 one bit per flag, default=FALSE
+*/
 static int
-set_element(bits, low, high, number)
-	bitstr_t	*bits; 		/* one bit per flag, default=FALSE */
-	int			low;
-	int			high;
-	int			number;
+set_element(bitstr_t *bits, int low, int high, int number)
 {
 	Debug(DPARS|DEXT, ("set_element(?,%d,%d,%d)\n", low, high, number))
 

--- a/src/backend/task/misc.c
+++ b/src/backend/task/misc.c
@@ -34,8 +34,7 @@
  * get_char(file) : like getc() but increment LineNumber on newlines
  */
 int
-get_char(file)
-	FILE	*file;
+get_char(FILE *file)
 {
 	int	ch;
 
@@ -75,9 +74,7 @@ get_char(file)
  * unget_char(ch, file) : like ungetc but do LineNumber processing
  */
 void
-unget_char(ch, file)
-	int		ch;
-	FILE	*file;
+unget_char(int ch, FILE *file)
 {
 	/*
 	 * Sneaky hack: we wrapped an in-memory buffer into a FILE*
@@ -108,11 +105,7 @@ unget_char(ch, file)
  * (4) returns EOF or terminating character, whichever
  */
 int
-get_string(string, size, file, terms)
-	char	*string;
-	int	size;
-	FILE	*file;
-	char	*terms;
+get_string(char *string, int size, FILE *file, char *terms)
 {
 	int	ch;
 
@@ -133,8 +126,7 @@ get_string(string, size, file, terms)
  * skip_comments(file) : read past comment (if any)
  */
 void
-skip_comments(file)
-	FILE	*file;
+skip_comments(FILE *file)
 {
 	int	ch;
 

--- a/src/backend/utils/adt/xid8funcs.c
+++ b/src/backend/utils/adt/xid8funcs.c
@@ -227,7 +227,7 @@ is_visible_fxid(FullTransactionId value, const pg_snapshot *snap)
 #ifdef USE_BSEARCH_IF_NXIP_GREATER
 	else if (snap->nxip > USE_BSEARCH_IF_NXIP_GREATER)
 	{
-		void	   *res;
+		const void	   *res;
 
 		res = bsearch(&value, snap->xip, snap->nxip, sizeof(FullTransactionId),
 					  cmp_fxid);

--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -433,7 +433,7 @@ static int glob_path(fstream_t *fs, const char *path)
 		while (*path == ' ')
 			path++;
 
-		p = strchr(path, ' ');
+		p = (char *)strchr(path, ' ');
 
 		if (p)
 			*p++ = 0;

--- a/src/backend/utils/misc/uriparser.c
+++ b/src/backend/utils/misc/uriparser.c
@@ -70,7 +70,7 @@ ParseExternalTableUri(const char *uri_str)
 
 	else /* not recognized. treat it as a custom protocol */
 	{
-		char *post_protocol = strstr(uri_str, "://");
+		const char *post_protocol = strstr(uri_str, "://");
 		
 		if(!post_protocol)
 		{

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -287,6 +287,16 @@ IsRootOperatorInGroup(Node *node)
  * in a plan.
  */
 
+static bool PolicyAutoPrelimWalker(Node *node, PolicyAutoContext *context);
+static bool PolicyAutoAssignWalker(Node *node, PolicyAutoContext *context);
+static bool PolicyEagerFreePrelimWalker(Node *node, PolicyEagerFreeContext *context);
+static bool PolicyEagerFreeAssignWalker(Node *node, PolicyEagerFreeContext *context);
+
+static bool PolicyAutoPrelimWalker_adapter(Node *node, void *context);
+static bool PolicyAutoAssignWalker_adapter(Node *node, void *context);
+static bool PolicyEagerFreePrelimWalker_adapter(Node *node, void *context);
+static bool PolicyEagerFreeAssignWalker_adapter(Node *node, void *context);
+
 static bool PolicyAutoPrelimWalker(Node *node, PolicyAutoContext *context)
 {
 	if (node == NULL)
@@ -306,7 +316,7 @@ static bool PolicyAutoPrelimWalker(Node *node, PolicyAutoContext *context)
 			context->numNonMemIntensiveOperators++;
 		}
 	}
-	return plan_tree_walker(node, PolicyAutoPrelimWalker, context, true);
+	return plan_tree_walker(node, PolicyAutoPrelimWalker_adapter, context, true);
 }
 
 /**
@@ -350,7 +360,7 @@ static bool PolicyAutoAssignWalker(Node *node, PolicyAutoContext *context)
 			elog(GP_RESMANAGER_MEMORY_LOG_LEVEL, "assigning plan node memory = %dKB", (int )planNode->operatorMemKB);
 		}
 	}
-	return plan_tree_walker(node, PolicyAutoAssignWalker, context, true);
+	return plan_tree_walker(node, PolicyAutoAssignWalker_adapter, context, true);
 }
 
 /**
@@ -715,7 +725,7 @@ PolicyEagerFreePrelimWalker(Node *node, PolicyEagerFreeContext *context)
 		}
 	}
 
-	bool result = plan_tree_walker(node, PolicyEagerFreePrelimWalker, context, true);
+	bool result = plan_tree_walker(node, PolicyEagerFreePrelimWalker_adapter, context, true);
 	Assert(!result);
 
 	/*
@@ -820,7 +830,7 @@ PolicyEagerFreeAssignWalker(Node *node, PolicyEagerFreeContext *context)
 		}
 	}
 
-	bool result = plan_tree_walker(node, PolicyEagerFreeAssignWalker, context, true);
+	bool result = plan_tree_walker(node, PolicyEagerFreeAssignWalker_adapter, context, true);
 	Assert(!result);
 
 	/*
@@ -833,6 +843,30 @@ PolicyEagerFreeAssignWalker(Node *node, PolicyEagerFreeContext *context)
 	}
 
 	return result;
+}
+
+static bool
+PolicyAutoPrelimWalker_adapter(Node *node, void *context)
+{
+	return PolicyAutoPrelimWalker(node, (PolicyAutoContext *) context);
+}
+
+static bool
+PolicyAutoAssignWalker_adapter(Node *node, void *context)
+{
+	return PolicyAutoAssignWalker(node, (PolicyAutoContext *) context);
+}
+
+static bool
+PolicyEagerFreePrelimWalker_adapter(Node *node, void *context)
+{
+	return PolicyEagerFreePrelimWalker(node, (PolicyEagerFreeContext *) context);
+}
+
+static bool
+PolicyEagerFreeAssignWalker_adapter(Node *node, void *context)
+{
+	return PolicyEagerFreeAssignWalker(node, (PolicyEagerFreeContext *) context);
 }
 
 /*

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3774,7 +3774,7 @@ static int request_set_transform(request_t *r)
 	 */
 
 	char* param = "#transform=";
-	char* start = strstr(r->path, param);
+	char* start = (char*)strstr(r->path, param);
 	if (start)
 	{
 		/*

--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -160,7 +160,7 @@ create_fullpage_directory(char *path)
 static void
 split_path(const char *path, char **dir, char **fname)
 {
-	char	   *sep;
+	const char	   *sep;
 
 	/* split filepath into directory & filename */
 	sep = strrchr(path, '/');

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -6140,7 +6140,7 @@ findBuiltin(const char *name)
 static int
 parseScriptWeight(const char *option, char **script)
 {
-	char	   *sep;
+	const char	   *sep;
 	int			weight;
 
 	if ((sep = strrchr(option, WSEP)))

--- a/src/common/compression.c
+++ b/src/common/compression.c
@@ -425,7 +425,7 @@ validate_compress_specification(pg_compress_specification *spec)
 void
 parse_compress_options(const char *option, char **algorithm, char **detail)
 {
-	char	   *sep;
+	const char	   *sep;
 	char	   *endp;
 	long		result;
 

--- a/src/include/cdb/cdbplan.h
+++ b/src/include/cdb/cdbplan.h
@@ -18,7 +18,7 @@
 
 #include "optimizer/walkers.h"
 
-extern Node * plan_tree_mutator(Node *node, Node *(*mutator) (), void *context, bool recurse_into_subplans);
+extern Node * plan_tree_mutator(Node *node, Node *(*mutator) (Node *, void *), void *context, bool recurse_into_subplans);
 
 extern String *get_tle_name(TargetEntry *tle, List *rtable, const char *default_name);
 

--- a/src/include/optimizer/walkers.h
+++ b/src/include/optimizer/walkers.h
@@ -31,9 +31,9 @@ extern void exec_init_plan_tree_base(plan_tree_base_prefix *base, PlannedStmt *s
 extern Plan *plan_tree_base_subplan_get_plan(plan_tree_base_prefix *base, SubPlan *subplan);
 extern void plan_tree_base_subplan_put_plan(plan_tree_base_prefix *base, SubPlan *subplan, Plan *plan);
 
-extern bool walk_plan_node_fields(Plan *plan, bool (*walker) (), void *context);
+extern bool walk_plan_node_fields(Plan *plan, bool (*walker) (Node *, void *), void *context);
 
-extern bool plan_tree_walker(Node *node, bool (*walker) (), void *context, bool recurse_into_subplans);
+extern bool plan_tree_walker(Node *node, bool (*walker) (Node *, void *), void *context, bool recurse_into_subplans);
 
 /**
  * Useful functions that aggregate information from expressions or plans.

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -1187,8 +1187,8 @@ char *
 get_expectfile(const char *testname, const char *file, const char *default_expectfile)
 {
 	char		expectpath[MAXPGPATH];
-	char	   *file_type;
-	char	   *file_name;
+	const char	   *file_type;
+	const char	   *file_name;
 	char		base_file[MAXPGPATH];
 	_resultmap *rm;
 	char		buf[MAXPGPATH];
@@ -1219,7 +1219,7 @@ get_expectfile(const char *testname, const char *file, const char *default_expec
 	 * up to the last slash.
 	 */
 	{
-		char	   *p = strrchr(default_expectfile, '/');
+		const char	   *p = strrchr(default_expectfile, '/');
 
 		if (!p)
 			return NULL;

--- a/src/timezone/zic.c
+++ b/src/timezone/zic.c
@@ -2638,7 +2638,7 @@ doabbr(char *abbr, struct zone const *zp, char const *letters,
 	   bool isdst, zic_t save, bool doquotes)
 {
 	char	   *cp;
-	char	   *slashp;
+	const char	   *slashp;
 	size_t		len;
 	char const *format = zp->z_format;
 


### PR DESCRIPTION
There are several types of adjustments needed for >= C23.

1) . Replacing an unprototyped function pointer with a prototyped function pointer

```
      |                                                    _Bool (*)(Node *, sanity_result_t *)
../../../src/include/optimizer/walkers.h:36:49: note: expected ‘_Bool (*)(void)’ but argument is of type ‘_Bool (*)(Node *, sanity_result_t *)’
   36 | extern bool plan_tree_walker(Node *node, bool (*walker) (), void *context, bool recurse_into_subplans);
      |                                          ~~~~~~~^~~~~~~~~~
cdbllize.c:1440:1: note: ‘motion_sanity_walker’ declared here
 1440 | motion_sanity_walker(Node *node, sanity_result_t *result)
      | ^~~~~~~~~~~~~~~~~~~~
cdbllize.c:1550:52: error: passing argument 2 of ‘plan_tree_walker’ from incompatible pointer type [-Wincompatible-pointer-types]
 1550 |                         if (plan_tree_walker(node, motion_sanity_walker, result, true))
      |                                                    ^~~~~~~~~~~~~~~~~~~~
      |                                                    |
      |                                                    _Bool (*)(Node *, sanity_result_t *)
../../../src/include/optimizer/walkers.h:36:49: note: expected ‘_Bool (*)(void)’ but argument is of type ‘_Bool (*)(Node *, sanity_result_t *)’
   36 | extern bool plan_tree_walker(Node *node, bool (*walker) (), void *context, bool recurse_into_subplans);
      |                                          ~~~~~~~^~~~~~~~~~
cdbllize.c:1440:1: note: ‘motion_sanity_walker’ declared here
 1440 | motion_sanity_walker(Node *node, sanity_result_t *result)

```


I used proxy-functions approach like this:

```
static bool
contain_motion_walk_impl(Node *node, contain_motion_walk_context *context)
{
    /* code*/
}

static bool
contain_motion_walk_adapter(Node *node, void *context)
{
    return contain_motion_walk_impl(
        node,
        (contain_motion_walk_context *) context
    );
}

```

This minimizes diff. there are also others way to resolve this, but this is most nit for my taste

2.) K&R-style function definition removal
with C23 this no longer compiles
```
static int
get_list(bits, low, high, names, ch, file)
	bitstr_t	*bits;		/* one bit per flag, default=FALSE */
	int			low, high;	/* bounds, impl. offset for bitstr */
	char		*names[];	/* NULL or *[] of names for these elements */
	int			ch;			/* current character being processed */
	FILE		*file;		/* file being read */
```

3.) several const qualifications added.