### PR TITLE
ORCA: fix CTE column-pruning misalignment across consumers

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalCTEConsumer.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalCTEConsumer.cpp
@@ -13,6 +13,7 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/base/CCTEInfo.h"
 #include "gpopt/base/CCTEMap.h"
 #include "gpopt/base/COptCtxt.h"
 #include "gpopt/operators/CExpression.h"
@@ -45,12 +46,30 @@ CPhysicalCTEConsumer::CPhysicalCTEConsumer(CMemoryPool *mp, ULONG id,
 	m_pdrgpcr = GPOS_NEW(mp) CColRefArray(mp);
 	m_pidxmap = GPOS_NEW(mp) ULongPtrArray(mp);
 
+	// ShareInputScan does not project, so the producer finalizes its shared-scan
+	// output as the union of all consumers' required columns (see
+	// CTranslatorDXLToExpr::PruneCTEs). Therefore every consumer must expose
+	// exactly the producer's surviving columns: it can neither read a column the
+	// producer pruned (that would run past the shared tuple) nor decide what to
+	// keep from its own per-column usage. Drive the consumer's kept set from the
+	// producer's used mask, which is the single source of truth. When the
+	// producer was not pruned (mask is NULL) fall back to the previous behavior.
+	CCTEInfo *pcteinfo = COptCtxt::PoctxtFromTLS()->Pcteinfo();
+	CLogicalCTEProducer *popProducer =
+		CLogicalCTEProducer::PopConvert(pcteinfo->PexprCTEProducer(m_id)->Pop());
+	BOOL *producer_umask = popProducer->UsedMask();
+	GPOS_ASSERT_IMP(nullptr != producer_umask,
+					popProducer->Pdrgpcr()->Size() == colref_size);
+
 	for (ULONG index = 0; index < colref_size; index++) {
 		CColRef *col_ref = (*colref_array)[index];
-		if (col_ref->GetUsage(true, true) == CColRef::EUsed) {
+		BOOL kept = (nullptr != producer_umask)
+						? producer_umask[index]
+						: (col_ref->GetUsage(true, true) == CColRef::EUsed);
+		if (kept) {
 			m_pdrgpcr->Append(col_ref);
 			m_pidxmap->Append(GPOS_NEW(m_mp) ULONG(index));
-		} 
+		}
 	}
 
 	if (m_pidxmap->Size() == colref_size) {

--- a/src/test/regress/expected/cte_prune_multi_consumer.out
+++ b/src/test/regress/expected/cte_prune_multi_consumer.out
@@ -1,0 +1,189 @@
+--
+-- Multi-consumer CTE column pruning (ORCA).
+--
+-- A CTE referenced by several consumers has its shared-scan output pruned to the
+-- union of all consumers' required columns. Because ShareInputScan does not
+-- project, every consumer must expose exactly the producer's surviving columns.
+-- A consumer that projects a superset (e.g. SELECT *) and is referenced directly
+-- with a join key used to keep an identity column map and read the shared tuple
+-- by stale positions, producing wrong results (join key read from the wrong slot
+-- -> LEFT JOIN yields NULLs) and "invalid attnum N for relation shareX_refY" in
+-- EXPLAIN. See CPhysicalCTEConsumer. These queries assert correct results under
+-- both optimizers.
+--
+create schema cte_mc;
+set search_path = cte_mc;
+create table policy(pr_id text, pied_id text, p_id text, amnt numeric(18,2),
+                    guarantee_period text, main_risk text, premium numeric(18,2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'pr_id' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table mid(p_id text, tenant_id text, act_premium numeric(18,2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'p_id' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into policy values('pr1','k1','p1',300000,'1','Y',290);
+insert into mid values('p1','t1',290);
+analyze policy;
+analyze mid;
+-- The "info" consumer projects SELECT * but only p_id/amnt/main_risk are needed
+-- outside; the producer prunes pr_id/pied_id/guarantee_period. i.amnt and i.p_id
+-- must not come back NULL. EXPLAIN previously raised "invalid attnum".
+explain (costs off)
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where main_risk='Y' and p_id='p1'),
+     unused as (select 1 from mid)
+select i.amnt, m.tenant_id, m.p_id, i.p_id, d.p_id, d.premium, m.act_premium
+from mid m
+left join det  d on d.p_id=m.p_id and d.premium=m.act_premium
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3,4;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i.amnt, m.tenant_id, i.p_id
+   ->  Sort
+         Sort Key: i.amnt, m.tenant_id, i.p_id
+         ->  Nested Loop Left Join
+               ->  Hash Right Join
+                     Hash Cond: ((sum(agent.premium)) = m.act_premium)
+                     ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                           Hash Key: 'p1'::text
+                           ->  GroupAggregate
+                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                       ->  Subquery Scan on agent
+                                             ->  Seq Scan on policy
+                                                   Filter: (p_id = 'p1'::text)
+                     ->  Hash
+                           ->  Seq Scan on mid m
+                                 Filter: (p_id = 'p1'::text)
+               ->  Materialize
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: 'p1'::text
+                           ->  Subquery Scan on i
+                                 ->  Seq Scan on policy policy_1
+                                       Filter: ((main_risk = 'Y'::text) AND (p_id = 'p1'::text))
+ Optimizer: Postgres query optimizer
+(24 rows)
+
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where main_risk='Y' and p_id='p1'),
+     unused as (select 1 from mid)
+select i.amnt, m.tenant_id, m.p_id, i.p_id, d.p_id, d.premium, m.act_premium
+from mid m
+left join det  d on d.p_id=m.p_id and d.premium=m.act_premium
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3,4;
+   amnt    | tenant_id | p_id | p_id | p_id | premium | act_premium 
+-----------+-----------+------+------+------+---------+-------------
+ 300000.00 | t1        | p1   | p1   | p1   |  290.00 |      290.00
+(1 row)
+
+-- Variant: project a different surviving column (main_risk) from the SELECT *
+-- consumer to exercise a different pruned layout.
+explain (costs off)
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where p_id='p1')
+select m.p_id, i.main_risk, i.amnt, d.premium
+from mid m
+left join det  d on d.p_id=m.p_id
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i.main_risk, i.amnt
+   ->  Sort
+         Sort Key: i.main_risk, i.amnt
+         ->  Nested Loop Left Join
+               ->  Nested Loop Left Join
+                     ->  Seq Scan on mid m
+                           Filter: (p_id = 'p1'::text)
+                     ->  Materialize
+                           ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                                 Hash Key: 'p1'::text
+                                 ->  Subquery Scan on d
+                                       ->  GroupAggregate
+                                             ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                   ->  Subquery Scan on agent
+                                                         ->  Seq Scan on policy
+                                                               Filter: (p_id = 'p1'::text)
+               ->  Materialize
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: 'p1'::text
+                           ->  Subquery Scan on i
+                                 ->  Seq Scan on policy policy_1
+                                       Filter: (p_id = 'p1'::text)
+ Optimizer: Postgres query optimizer
+(24 rows)
+
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where p_id='p1')
+select m.p_id, i.main_risk, i.amnt, d.premium
+from mid m
+left join det  d on d.p_id=m.p_id
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3;
+ p_id | main_risk |   amnt    | premium 
+------+-----------+-----------+---------
+ p1   | Y         | 300000.00 |  290.00
+(1 row)
+
+-- Three consumers, each needing a different subset (join key on each).
+explain (costs off)
+with agent as (select p_id, amnt, main_risk, premium from policy)
+select x.p_id, y.amnt, z.main_risk
+from agent x
+join agent y on x.p_id=y.p_id
+join agent z on x.p_id=z.p_id
+order by 1,2,3;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: x.p_id, y.amnt, z.main_risk
+   ->  Sort
+         Sort Key: x.p_id, y.amnt, z.main_risk
+         ->  Hash Join
+               Hash Cond: (x.p_id = z.p_id)
+               ->  Hash Join
+                     Hash Cond: (x.p_id = y.p_id)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: x.p_id
+                           ->  Subquery Scan on x
+                                 ->  Seq Scan on policy
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: y.p_id
+                                 ->  Subquery Scan on y
+                                       ->  Seq Scan on policy policy_1
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                           Hash Key: z.p_id
+                           ->  Subquery Scan on z
+                                 ->  Seq Scan on policy policy_2
+ Optimizer: Postgres query optimizer
+(23 rows)
+
+with agent as (select p_id, amnt, main_risk, premium from policy)
+select x.p_id, y.amnt, z.main_risk
+from agent x
+join agent y on x.p_id=y.p_id
+join agent z on x.p_id=z.p_id
+order by 1,2,3;
+ p_id |   amnt    | main_risk 
+------+-----------+-----------
+ p1   | 300000.00 | Y
+(1 row)
+
+-- start_ignore
+drop schema cte_mc cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table policy
+drop cascades to table mid
+-- end_ignore

--- a/src/test/regress/expected/cte_prune_multi_consumer_optimizer.out
+++ b/src/test/regress/expected/cte_prune_multi_consumer_optimizer.out
@@ -1,0 +1,194 @@
+--
+-- Multi-consumer CTE column pruning (ORCA).
+--
+-- A CTE referenced by several consumers has its shared-scan output pruned to the
+-- union of all consumers' required columns. Because ShareInputScan does not
+-- project, every consumer must expose exactly the producer's surviving columns.
+-- A consumer that projects a superset (e.g. SELECT *) and is referenced directly
+-- with a join key used to keep an identity column map and read the shared tuple
+-- by stale positions, producing wrong results (join key read from the wrong slot
+-- -> LEFT JOIN yields NULLs) and "invalid attnum N for relation shareX_refY" in
+-- EXPLAIN. See CPhysicalCTEConsumer. These queries assert correct results under
+-- both optimizers.
+--
+create schema cte_mc;
+set search_path = cte_mc;
+create table policy(pr_id text, pied_id text, p_id text, amnt numeric(18,2),
+                    guarantee_period text, main_risk text, premium numeric(18,2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'pr_id' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table mid(p_id text, tenant_id text, act_premium numeric(18,2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'p_id' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into policy values('pr1','k1','p1',300000,'1','Y',290);
+insert into mid values('p1','t1',290);
+analyze policy;
+analyze mid;
+-- The "info" consumer projects SELECT * but only p_id/amnt/main_risk are needed
+-- outside; the producer prunes pr_id/pied_id/guarantee_period. i.amnt and i.p_id
+-- must not come back NULL. EXPLAIN previously raised "invalid attnum".
+explain (costs off)
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where main_risk='Y' and p_id='p1'),
+     unused as (select 1 from mid)
+select i.amnt, m.tenant_id, m.p_id, i.p_id, d.p_id, d.premium, m.act_premium
+from mid m
+left join det  d on d.p_id=m.p_id and d.premium=m.act_premium
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3,4;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: share0_ref3.amnt, m.tenant_id, m.p_id, share0_ref3.p_id
+   ->  Sort
+         Sort Key: share0_ref3.amnt, m.tenant_id, m.p_id, share0_ref3.p_id
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: policy.p_id
+                           ->  Seq Scan on policy
+               ->  Hash Left Join
+                     Hash Cond: ((m.p_id = share0_ref2.p_id) AND (m.act_premium = (sum(share0_ref2.premium))))
+                     ->  Hash Left Join
+                           Hash Cond: (m.p_id = share0_ref3.p_id)
+                           ->  Seq Scan on mid m
+                                 Filter: (p_id = 'p1'::text)
+                           ->  Hash
+                                 ->  Result
+                                       Filter: ((share0_ref3.main_risk = 'Y'::text) AND (share0_ref3.p_id = 'p1'::text) AND (share0_ref3.p_id = 'p1'::text))
+                                       ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  Result
+                                 Filter: (share0_ref2.p_id = 'p1'::text)
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref2.p_id
+                                       ->  Sort
+                                             Sort Key: share0_ref2.p_id
+                                             ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(28 rows)
+
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where main_risk='Y' and p_id='p1'),
+     unused as (select 1 from mid)
+select i.amnt, m.tenant_id, m.p_id, i.p_id, d.p_id, d.premium, m.act_premium
+from mid m
+left join det  d on d.p_id=m.p_id and d.premium=m.act_premium
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3,4;
+   amnt    | tenant_id | p_id | p_id | p_id | premium | act_premium 
+-----------+-----------+------+------+------+---------+-------------
+ 300000.00 | t1        | p1   | p1   | p1   |  290.00 |      290.00
+(1 row)
+
+-- Variant: project a different surviving column (main_risk) from the SELECT *
+-- consumer to exercise a different pruned layout.
+explain (costs off)
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where p_id='p1')
+select m.p_id, i.main_risk, i.amnt, d.premium
+from mid m
+left join det  d on d.p_id=m.p_id
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: m.p_id, share0_ref3.main_risk, share0_ref3.amnt
+   ->  Sort
+         Sort Key: m.p_id, share0_ref3.main_risk, share0_ref3.amnt
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: policy.p_id
+                           ->  Seq Scan on policy
+               ->  Hash Left Join
+                     Hash Cond: (m.p_id = share0_ref2.p_id)
+                     ->  Hash Left Join
+                           Hash Cond: (m.p_id = share0_ref3.p_id)
+                           ->  Seq Scan on mid m
+                                 Filter: (p_id = 'p1'::text)
+                           ->  Hash
+                                 ->  Result
+                                       Filter: ((share0_ref3.p_id = 'p1'::text) AND (share0_ref3.p_id = 'p1'::text))
+                                       ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  Result
+                                 Filter: (share0_ref2.p_id = 'p1'::text)
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref2.p_id
+                                       ->  Sort
+                                             Sort Key: share0_ref2.p_id
+                                             ->  Shared Scan (share slice:id 1:0)
+ Optimizer: GPORCA
+(28 rows)
+
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where p_id='p1')
+select m.p_id, i.main_risk, i.amnt, d.premium
+from mid m
+left join det  d on d.p_id=m.p_id
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3;
+ p_id | main_risk |   amnt    | premium 
+------+-----------+-----------+---------
+ p1   | Y         | 300000.00 |  290.00
+(1 row)
+
+-- Three consumers, each needing a different subset (join key on each).
+explain (costs off)
+with agent as (select p_id, amnt, main_risk, premium from policy)
+select x.p_id, y.amnt, z.main_risk
+from agent x
+join agent y on x.p_id=y.p_id
+join agent z on x.p_id=z.p_id
+order by 1,2,3;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: share0_ref2.p_id, share0_ref4.amnt, share0_ref3.main_risk
+   ->  Sort
+         Sort Key: share0_ref2.p_id, share0_ref4.amnt, share0_ref3.main_risk
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:0)
+                     ->  Seq Scan on policy
+               ->  Hash Join
+                     Hash Cond: (share0_ref4.p_id = share0_ref2.p_id)
+                     ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Hash Join
+                                       Hash Cond: (share0_ref3.p_id = share0_ref2.p_id)
+                                       ->  Shared Scan (share slice:id 2:0)
+                                       ->  Hash
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                   ->  Result
+                                                         ->  Shared Scan (share slice:id 3:0)
+ Optimizer: GPORCA
+(20 rows)
+
+with agent as (select p_id, amnt, main_risk, premium from policy)
+select x.p_id, y.amnt, z.main_risk
+from agent x
+join agent y on x.p_id=y.p_id
+join agent z on x.p_id=z.p_id
+order by 1,2,3;
+ p_id |   amnt    | main_risk 
+------+-----------+-----------
+ p1   | 300000.00 | Y
+(1 row)
+
+-- start_ignore
+drop schema cte_mc cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table policy
+drop cascades to table mid
+-- end_ignore

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -168,7 +168,7 @@ test: gp_gin_index
 # NB: temp.sql does a reconnect which transiently uses 2 connections,
 # so keep this parallel group to at most 19 tests
 # ----------
-test: plancache limit plpgsql copy2 temp domain rangefuncs prepare conversion truncate alter_table sequence polymorphism rowtypes returning with xml cte_prune
+test: plancache limit plpgsql copy2 temp domain rangefuncs prepare conversion truncate alter_table sequence polymorphism rowtypes returning with xml cte_prune cte_prune_multi_consumer
 # large objects are not supported by GPDB
 # test: largeobject
 

--- a/src/test/regress/sql/cte_prune_multi_consumer.sql
+++ b/src/test/regress/sql/cte_prune_multi_consumer.sql
@@ -1,0 +1,92 @@
+--
+-- Multi-consumer CTE column pruning (ORCA).
+--
+-- A CTE referenced by several consumers has its shared-scan output pruned to the
+-- union of all consumers' required columns. Because ShareInputScan does not
+-- project, every consumer must expose exactly the producer's surviving columns.
+-- A consumer that projects a superset (e.g. SELECT *) and is referenced directly
+-- with a join key used to keep an identity column map and read the shared tuple
+-- by stale positions, producing wrong results (join key read from the wrong slot
+-- -> LEFT JOIN yields NULLs) and "invalid attnum N for relation shareX_refY" in
+-- EXPLAIN. See CPhysicalCTEConsumer. These queries assert correct results under
+-- both optimizers.
+--
+create schema cte_mc;
+set search_path = cte_mc;
+
+create table policy(pr_id text, pied_id text, p_id text, amnt numeric(18,2),
+                    guarantee_period text, main_risk text, premium numeric(18,2));
+create table mid(p_id text, tenant_id text, act_premium numeric(18,2));
+insert into policy values('pr1','k1','p1',300000,'1','Y',290);
+insert into mid values('p1','t1',290);
+analyze policy;
+analyze mid;
+
+-- The "info" consumer projects SELECT * but only p_id/amnt/main_risk are needed
+-- outside; the producer prunes pr_id/pied_id/guarantee_period. i.amnt and i.p_id
+-- must not come back NULL. EXPLAIN previously raised "invalid attnum".
+explain (costs off)
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where main_risk='Y' and p_id='p1'),
+     unused as (select 1 from mid)
+select i.amnt, m.tenant_id, m.p_id, i.p_id, d.p_id, d.premium, m.act_premium
+from mid m
+left join det  d on d.p_id=m.p_id and d.premium=m.act_premium
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3,4;
+
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where main_risk='Y' and p_id='p1'),
+     unused as (select 1 from mid)
+select i.amnt, m.tenant_id, m.p_id, i.p_id, d.p_id, d.premium, m.act_premium
+from mid m
+left join det  d on d.p_id=m.p_id and d.premium=m.act_premium
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3,4;
+
+-- Variant: project a different surviving column (main_risk) from the SELECT *
+-- consumer to exercise a different pruned layout.
+explain (costs off)
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where p_id='p1')
+select m.p_id, i.main_risk, i.amnt, d.premium
+from mid m
+left join det  d on d.p_id=m.p_id
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3;
+
+with agent as (select pr_id,pied_id,p_id,amnt,guarantee_period,main_risk,premium from policy),
+     det as (select p_id, sum(premium) premium from agent group by p_id),
+     info as (select * from agent where p_id='p1')
+select m.p_id, i.main_risk, i.amnt, d.premium
+from mid m
+left join det  d on d.p_id=m.p_id
+left join info i on m.p_id=i.p_id
+where m.p_id='p1'
+order by 1,2,3;
+
+-- Three consumers, each needing a different subset (join key on each).
+explain (costs off)
+with agent as (select p_id, amnt, main_risk, premium from policy)
+select x.p_id, y.amnt, z.main_risk
+from agent x
+join agent y on x.p_id=y.p_id
+join agent z on x.p_id=z.p_id
+order by 1,2,3;
+
+with agent as (select p_id, amnt, main_risk, premium from policy)
+select x.p_id, y.amnt, z.main_risk
+from agent x
+join agent y on x.p_id=y.p_id
+join agent z on x.p_id=z.p_id
+order by 1,2,3;
+
+-- start_ignore
+drop schema cte_mc cascade;
+-- end_ignore


### PR DESCRIPTION
When a CTE has multiple consumers requiring different column subsets, the producer's shared-scan output is pruned to the union of all consumers' required columns (CTranslatorDXLToExpr::PruneCTEs). But each consumer independently decided its own output columns in CPhysicalCTEConsumer from its own per-column GetUsage(). A consumer that considers all of its columns used (e.g. SELECT a.*) kept every column with an identity index map, while the producer emitted only the pruned union. The consumer then read the shared tuple by stale positions, producing wrong results (a join key read from the wrong slot -> LEFT JOIN yields NULLs) and "invalid attnum N for relation shareX_refY" during EXPLAIN.

Drive the consumer's kept columns from the producer's finalized used mask (CLogicalCTEProducer::UsedMask) -- the single source of truth -- so every consumer exposes exactly the producer's surviving columns. When the producer was not pruned the mask is NULL and behavior is unchanged.

Add a regression test (cte_prune_multi_consumer) covering multi-consumer CTEs where a SELECT * consumer is referenced directly with a join key. It asserts the EXPLAIN no longer errors and returns correct results; the ORCA path is exercised with shared scans and matches the Postgres planner.


Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [X] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
