### PR TITLE
Fix spurious global xmin > xmin error on rollback

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -3312,9 +3312,29 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 			globalxmin = DistributedLog_GetOldestXmin(globalxmin);
 	}
 
+	/*
+	 * globalxmin (the distributed oldestXmin read/advanced just above) can end
+	 * up greater than this snapshot's xmin.  xmin was computed under
+	 * ProcArrayLock, but DistributedLogShared->oldestXmin is maintained in a
+	 * different lock domain and is only read here, after ProcArrayLock has been
+	 * released.  In that window another backend can advance it past our xmin:
+	 * if the transaction whose local xid equals our xmin subsequently aborts,
+	 * its distributed-log entry keeps distribXid == 0, so
+	 * DistributedLog_AdvanceOldestXmin()'s forward scan skips over that xid
+	 * (instead of stopping at it) and bumps the shared oldestXmin beyond it.
+	 * A concurrent snapshot that took its xmin from that now-aborted xid then
+	 * reads the advanced value here.
+	 *
+	 * This is a benign, expected transient: the visibility horizon only needs
+	 * to be a valid lower bound (see src/backend/access/transam/README), and
+	 * the aborted transaction is invisible to us anyway, so a horizon at our
+	 * own xmin loses nothing.  Clamp to xmin (never error): a horizon <= our
+	 * own xmin is always safe -- it can never treat a tuple still needed by
+	 * this snapshot as removable.  This mirrors the clamp already done in
+	 * DistributedLog_GetOldestXmin().
+	 */
 	if (TransactionIdFollows(globalxmin, xmin))
-		elog(ERROR, "global xmin (%u) is higher than transaction xmin (%u)",
-			globalxmin, xmin);
+		globalxmin = xmin;
 
 
 	/*


### PR DESCRIPTION
GetSnapshotData() on a QE computes xmin under ProcArrayLock but reads/advances DistributedLogShared->oldestXmin afterwards, in a different lock domain.  In that window a concurrent backend can advance the shared oldestXmin past this snapshot's xmin: when the transaction whose local xid equals xmin aborts, its distributed-log entry keeps distribXid == 0, so DistributedLog_AdvanceOldestXmin()'s forward scan skips over it instead of stopping, bumping oldestXmin beyond xmin.  The resulting globalxmin > xmin then tripped a hard elog(ERROR) and failed the query (seen intermittently in the partition_prune regression test).

The aborted xid is invisible to this snapshot anyway, and the visibility horizon only needs to be a valid lower bound, so a horizon at our own xmin loses nothing.  Clamp globalxmin to xmin instead of erroring -- always safe, and consistent with the clamp already done in DistributedLog_GetOldestXmin().

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
