### PR TITLE
Fix gpexpand failing to detect tablespaces due to OID type mismatch

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1121,7 +1121,7 @@ class gpexpand:
         tblspc_info = {}
 
         for oid in tblspc_oids:
-            if oid not in tblspc_oid_names:
+            if int(oid) not in tblspc_oid_names:
                 continue
             location = os.path.dirname(os.readlink(os.path.join(coordinator_tblspc_dir,
                                                                 oid)))
@@ -1241,7 +1241,7 @@ class gpexpand:
         tblspc_oid_names = self.get_tablespace_oid_names()
         flag = False
         for oid in tblspc_oids:
-            if oid in tblspc_oid_names:
+            if int(oid) in tblspc_oid_names:
                 flag = True
         if not flag:
             return None

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py
@@ -172,5 +172,54 @@ class GpExpand(GpTestCase):
             "5|1|m|m|s|u|sdw1|sdw1|50001|/data/mirror1")
         return GpArray([self.coordinator, self.primary0, self.primary1, self.mirror0, self.mirror1])
 
+
+class GpExpandTablespaceTests(GpTestCase):
+    """Tests for tablespace detection in gpexpand (str vs int OID type mismatch)."""
+
+    def setUp(self):
+        gpexpand_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpexpand")
+        self.subject = imp.load_source('gpexpand', gpexpand_file)
+        self.subject.logger = Mock()
+        self.coordinator = Segment.initFromString("1|-1|p|p|s|u|cdw|cdw|5432|/data/coordinator")
+        self.gparray = GpArray([self.coordinator])
+        self.options = Mock()
+        self.options.filename = "/tmp/testexpand"
+        self.options.simple_progress = True
+
+    def _make_gpexpand(self):
+        gp = object.__new__(self.subject.gpexpand)
+        gp.options = self.options
+        gp.gparray = self.gparray
+        gp.logger = self.subject.logger
+        gp.conn = None
+        return gp
+
+    @patch('gpexpand.os.listdir', return_value=["17019"])
+    @patch('gpexpand.os.path.exists', return_value=False)
+    def test_read_tablespace_file_detects_tablespace_with_int_oids(self, m_exists, m_listdir):
+        gp = self._make_gpexpand()
+        gp.get_tablespace_oid_names = Mock(return_value={17019: 'mytblspace'})
+        gp.generate_tablespace_inputfile = Mock()
+
+        with self.assertRaises(SystemExit):
+            gp.read_tablespace_file()
+
+        gp.generate_tablespace_inputfile.assert_called_once_with("/tmp/testexpand.ts")
+
+    @patch('gpexpand.os.listdir', return_value=["17019"])
+    @patch('gpexpand.os.readlink', return_value="/tbspc/1")
+    @patch('builtins.open', new_callable=mock_open)
+    def test_generate_tablespace_inputfile_writes_name_and_oid(self, m_open, m_readlink, m_listdir):
+        gp = self._make_gpexpand()
+        gp.get_tablespace_oid_names = Mock(return_value={17019: 'mytblspace'})
+
+        gp.generate_tablespace_inputfile("/tmp/testexpand.ts")
+
+        handle = m_open()
+        written = "".join(call.args[0] for call in handle.write.call_args_list)
+        self.assertIn("tableSpaceNameOrders=mytblspace", written)
+        self.assertIn("tableSpaceOidOrders=17019", written)
+
+
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
### What does this PR do?
Previously, gpexpand compared tablespace OIDs returned as strings by `os.listdir()` against integer keys from the `pg_tablespace` query, so the checks always evaluated to False. This skipped tablespace template generation and left broken symlinks on new segments.

- `read_tablespace_file()` now casts the OID to int before the lookup
- `generate_tablespace_inputfile()` now casts the OID to int before the lookup
- Added unit tests covering both methods

Fixes #1885

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

Added two unit tests in `gpMgmt/bin/gppylib/test/unit/test_unit_gpexpand.py` (`GpExpandTablespaceTests`) covering `read_tablespace_file()` and `generate_tablespace_inputfile()`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
None.

**User-facing changes:**

`gpexpand` now correctly detects user-created tablespaces when re-run with `-i` against an existing tablespace input file, so new segments get valid tablespace symlinks instead of broken ones.

**Dependencies:**
None.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

