### PR TITLE
ORCA: override HashValue for CScalarSortGroupClause

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSortGroupClause.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarSortGroupClause.h
@@ -92,6 +92,9 @@ public:
 	// match function
 	BOOL Matches(COperator *op) const override;
 
+	// hash function
+	ULONG HashValue() const override;
+
 	// conversion function
 	static CScalarSortGroupClause *
 	PopConvert(COperator *pop)

--- a/src/backend/gporca/libgpopt/src/operators/CScalarIdent.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarIdent.cpp
@@ -34,7 +34,7 @@ ULONG
 CScalarIdent::HashValue() const
 {
 	return gpos::CombineHashes(COperator::HashValue(),
-							   gpos::HashPtr<CColRef>(m_pcr));
+							   CColRef::HashValue(m_pcr));
 }
 
 

--- a/src/backend/gporca/libgpopt/src/operators/CScalarSortGroupClause.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarSortGroupClause.cpp
@@ -68,6 +68,28 @@ CScalarSortGroupClause::Matches(COperator *other) const
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CScalarSortGroupClause::HashValue
+//
+//	@doc:
+//		Operator specific hash function
+//
+//---------------------------------------------------------------------------
+ULONG
+CScalarSortGroupClause::HashValue() const
+{
+	ULONG ulHash = COperator::HashValue();
+	ulHash =
+		gpos::CombineHashes(ulHash, gpos::HashValue<INT>(&m_tle_sort_group_ref));
+	ulHash = gpos::CombineHashes(ulHash, gpos::HashValue<INT>(&m_eqop));
+	ulHash = gpos::CombineHashes(ulHash, gpos::HashValue<INT>(&m_sortop));
+	ulHash = gpos::CombineHashes(ulHash, gpos::HashValue<BOOL>(&m_nulls_first));
+	ulHash = gpos::CombineHashes(ulHash, gpos::HashValue<BOOL>(&m_hashable));
+
+	return ulHash;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CScalarSortGroupClause::OsPrint
 //
 //	@doc:

--- a/src/backend/gporca/libgpopt/src/operators/CScalarSubquery.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarSubquery.cpp
@@ -76,7 +76,7 @@ ULONG
 CScalarSubquery::HashValue() const
 {
 	return gpos::CombineHashes(COperator::HashValue(),
-							   gpos::HashPtr<CColRef>(m_pcr));
+							   CColRef::HashValue(m_pcr));
 }
 
 


### PR DESCRIPTION
CScalarSortGroupClause inherited COperator::HashValue(), which hashes only the operator id. Since the operator is an arity-0 scalar leaf, the group expression hash equals the operator hash, so every SortGroupClause group expression in the memo landed in one fixed hash bucket (hash(EopScalarSortGroupClause) % GPOPT_MEMO_HT_BUCKETS), determined at compile time. That bucket accumulates all such expressions and acts as a permanent collision target for unrelated arity-0 operators whose hashes happen to be congruent modulo the bucket count.

Mix the members that Matches() already compares (tleSortGroupRef, eqop, sortop, nulls_first, hashable) into the hash, matching the convention of other scalar leaves such as CScalarConst and CScalarIdent. Equal operators still hash equally, so the hash/equality contract holds; distinct sort group clauses now spread across buckets, shortening memo hash chains during insertion and CMemo::FRehash.

Note this is a hash-quality improvement only: cross-operator bucket collisions remain possible by construction, and type safety relies on the Eopid check in CScalarSortGroupClause::Matches().


Fixes #546

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
