### PR TITLE
Fix duplicate --with-zstd configure declaration

### DIFF
--- a/configure
+++ b/configure
@@ -719,8 +719,8 @@ with_rt
 PROTOC
 with_gp_stats_collector
 with_diskquota
-with_libbz2
 with_zstd
+with_libbz2
 LZ4_LIBS
 LZ4_CFLAGS
 with_lz4
@@ -942,8 +942,8 @@ with_libxslt
 with_system_tzdata
 with_zlib
 with_lz4
-with_zstd
 with_libbz2
+with_zstd
 with_diskquota
 with_gp_stats_collector
 with_rt
@@ -1694,9 +1694,8 @@ Optional Packages:
                           use system time zone data in DIR
   --without-zlib          do not use Zlib
   --with-lz4              build with LZ4 support
-  --with-zstd             build with ZSTD support
   --without-libbz2        do not use bzip2
-  --with-zstd             do not build with Zstandard
+  --without-zstd          do not build with Zstandard
   --with-diskquota        build with diskquota extension
   --with-gp-stats-collector
                           build with stats collector extension
@@ -11368,146 +11367,6 @@ fi
   done
 fi
 
-# ZSTD
-#
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build with ZSTD support" >&5
-$as_echo_n "checking whether to build with ZSTD support... " >&6; }
-
-
-
-# Check whether --with-zstd was given.
-if test "${with_zstd+set}" = set; then :
-  withval=$with_zstd;
-  case $withval in
-    yes)
-
-$as_echo "#define USE_ZSTD 1" >>confdefs.h
-
-      ;;
-    no)
-      :
-      ;;
-    *)
-      as_fn_error $? "no argument expected for --with-zstd option" "$LINENO" 5
-      ;;
-  esac
-
-else
-  with_zstd=no
-
-fi
-
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_zstd" >&5
-$as_echo "$with_zstd" >&6; }
-
-
-if test "$with_zstd" = yes; then
-
-pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libzstd >= 1.4.0" >&5
-$as_echo_n "checking for libzstd >= 1.4.0... " >&6; }
-
-if test -n "$ZSTD_CFLAGS"; then
-    pkg_cv_ZSTD_CFLAGS="$ZSTD_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_ZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd >= 1.4.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-if test -n "$ZSTD_LIBS"; then
-    pkg_cv_ZSTD_LIBS="$ZSTD_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_ZSTD_LIBS=`$PKG_CONFIG --libs "libzstd >= 1.4.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd >= 1.4.0" 2>&1`
-        else
-	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd >= 1.4.0" 2>&1`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$ZSTD_PKG_ERRORS" >&5
-
-	as_fn_error $? "Package requirements (libzstd >= 1.4.0) were not met:
-
-$ZSTD_PKG_ERRORS
-
-Consider adjusting the PKG_CONFIG_PATH environment variable if you
-installed software in a non-standard prefix.
-
-Alternatively, you may set the environment variables ZSTD_CFLAGS
-and ZSTD_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details." "$LINENO" 5
-elif test $pkg_failed = untried; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-Alternatively, you may set the environment variables ZSTD_CFLAGS
-and ZSTD_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details.
-
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
-See \`config.log' for more details" "$LINENO" 5; }
-else
-	ZSTD_CFLAGS=$pkg_cv_ZSTD_CFLAGS
-	ZSTD_LIBS=$pkg_cv_ZSTD_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-fi
-  # We only care about -I, -D, and -L switches;
-  # note that -lzstd will be added by AC_CHECK_LIB below.
-  for pgac_option in $ZSTD_CFLAGS; do
-    case $pgac_option in
-      -I*|-D*) CPPFLAGS="$CPPFLAGS $pgac_option";;
-    esac
-  done
-  for pgac_option in $ZSTD_LIBS; do
-    case $pgac_option in
-      -L*) LDFLAGS="$LDFLAGS $pgac_option";;
-    esac
-  done
-fi
-
 #
 # bzip2
 #
@@ -11844,6 +11703,18 @@ else
 $as_echo "yes" >&6; }
 
 fi
+  # We only care about -I, -D, and -L switches;
+  # note that -lzstd will be added by AC_CHECK_LIB below.
+  for pgac_option in $ZSTD_CFLAGS; do
+    case $pgac_option in
+      -I*|-D*) CPPFLAGS="$CPPFLAGS $pgac_option";;
+    esac
+  done
+  for pgac_option in $ZSTD_LIBS; do
+    case $pgac_option in
+      -L*) LDFLAGS="$LDFLAGS $pgac_option";;
+    esac
+  done
 fi
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1426,30 +1426,6 @@ if test "$with_lz4" = yes; then
   done
 fi
 
-# ZSTD
-#
-AC_MSG_CHECKING([whether to build with ZSTD support])
-PGAC_ARG_BOOL(with, zstd, no, [build with ZSTD support],
-              [AC_DEFINE([USE_ZSTD], 1, [Define to 1 to build with ZSTD support. (--with-zstd)])])
-AC_MSG_RESULT([$with_zstd])
-AC_SUBST(with_zstd)
-
-if test "$with_zstd" = yes; then
-  PKG_CHECK_MODULES(ZSTD, libzstd >= 1.4.0)
-  # We only care about -I, -D, and -L switches;
-  # note that -lzstd will be added by AC_CHECK_LIB below.
-  for pgac_option in $ZSTD_CFLAGS; do
-    case $pgac_option in
-      -I*|-D*) CPPFLAGS="$CPPFLAGS $pgac_option";;
-    esac
-  done
-  for pgac_option in $ZSTD_LIBS; do
-    case $pgac_option in
-      -L*) LDFLAGS="$LDFLAGS $pgac_option";;
-    esac
-  done
-fi
-
 #
 # bzip2
 #
@@ -1494,6 +1470,18 @@ fi
 if test "$with_zstd" = yes; then
   dnl zstd_errors.h was renamed from error_public.h in v1.4.0
   PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.0])
+  # We only care about -I, -D, and -L switches;
+  # note that -lzstd will be added by AC_CHECK_LIB below.
+  for pgac_option in $ZSTD_CFLAGS; do
+    case $pgac_option in
+      -I*|-D*) CPPFLAGS="$CPPFLAGS $pgac_option";;
+    esac
+  done
+  for pgac_option in $ZSTD_LIBS; do
+    case $pgac_option in
+      -L*) LDFLAGS="$LDFLAGS $pgac_option";;
+    esac
+  done
 fi
 
 #


### PR DESCRIPTION
The REL_16 (PG16) merge added an upstream PostgreSQL --with-zstd block on top of the existing Greenplum one, leaving two PGAC_ARG_BOOL(with, zstd, ...) declarations in configure.ac.

The two AC_ARG_WITH expansions interact through ${with_zstd+set}: the first block (default "no") sets with_zstd, so the second block (default "yes") sees it already set and becomes a no-op. The effective default therefore flipped from "yes" to "no", so a plain ./configure disabled zstd and gpcontrib/zstd no longer built by default -- a regression from REL_2_STABLE.

Drop the upstream default-"no" declaration and keep the single Greenplum block (default "yes"), moving the -I/-D/-L flag injection into it so the later AC_CHECK_LIB/AC_CHECK_HEADER probes still resolve zstd in non-standard prefixes. This mirrors the parallel --with-lz4 block. The generated configure is updated to match.

Assisted-by: Claude Code

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
