### PR TITLE
feat(devops): add Rocky Linux 10 sandbox support / dynamic OS selection

### DIFF
--- a/devops/sandbox/Dockerfile.main.rockylinux10
+++ b/devops/sandbox/Dockerfile.main.rockylinux10
@@ -1,0 +1,274 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+# Multi-stage Dockerfile for Apache Cloudberry Sandbox Environment
+# --------------------------------------------------------------------
+# This Dockerfile supports two source modes:
+#   - Main branch: clone the latest main from GitHub (CODEBASE_VERSION=main)
+#   - Local source: use the repository contents from the Docker build context
+#     (CODEBASE_VERSION=local), recommended for developers working from
+#     their current checkout.
+# In both modes it compiles and installs Cloudberry, then creates a
+# runtime environment for testing and development.
+# --------------------------------------------------------------------
+
+# Build stage: Use pre-built image to compile Cloudberry
+ARG CODEBASE_VERSION=main
+FROM rockylinux/rockylinux:10.2 AS builder
+ARG CODEBASE_VERSION
+
+# Install build toolchains and development headers (avoid coreutils/curl conflicts on arm64)
+RUN dnf makecache && \
+    dnf install -y \
+        epel-release \
+        git \
+        wget && \
+    dnf config-manager --disable epel-cisco-openh264 || true && \
+    dnf makecache && \
+    dnf config-manager --disable epel
+
+RUN dnf install -y --enablerepo=epel \
+	bat \
+	htop
+
+RUN dnf install -y \
+        libicu-devel \
+        bison \
+        cmake3 \
+        ed \
+        file \
+        flex \
+        gcc \
+        gcc-c++ \
+        gdb \
+        glibc-langpack-en \
+        glibc-locale-source \
+        initscripts \
+        iproute \
+        less \
+        lsof \
+        m4 \
+        net-tools \
+        openssh-clients \
+        openssh-server \
+        perl \
+        rpm-build \
+        rpmdevtools \
+        rsync \
+        sudo \
+        tar \
+        unzip \
+        util-linux-ng \
+        wget \
+        sshpass \
+        which \
+        apr-devel \
+        bzip2-devel \
+        krb5-devel \
+        libcurl-devel \
+        libevent-devel \
+        libxml2-devel \
+        libuuid-devel \
+        libzstd-devel \
+        lz4 \
+        lz4-devel \
+        openldap-devel \
+        openssl-devel \
+        pam-devel \
+        perl-ExtUtils-Embed \
+        perl-Test-Simple \
+        perl-core \
+        readline-devel \
+        zlib-devel \
+        java-21-openjdk \
+        java-21-openjdk-devel
+
+RUN dnf install -y --enablerepo=crb \
+        liburing-devel \
+        libuv-devel \
+        libyaml-devel \
+        perl-IPC-Run \
+        protobuf-devel \
+        python3 \
+        python3-pip \
+        python3-devel \
+        python3-pytest
+
+RUN dnf clean all && rm -rf /var/cache/dnf
+
+RUN python3 -m pip install --upgrade setuptools
+
+RUN cd && XERCES_LATEST_RELEASE=3.3.0 && \
+    wget -nv "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz" && \
+    echo "$(curl -sL https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${XERCES_LATEST_RELEASE}.tar.gz.sha256)" | sha256sum -c - && \
+    tar xf "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz"; rm "xerces-c-${XERCES_LATEST_RELEASE}.tar.gz"
+
+RUN cd && XERCES_LATEST_RELEASE=3.3.0 && \
+    cd xerces-c-${XERCES_LATEST_RELEASE} && \
+    ./configure --prefix=/usr/local/xerces-c && \
+    make -j$(nproc) && \
+    make install -C ~/xerces-c-${XERCES_LATEST_RELEASE} && \
+    rm -rf ~/xerces-c*
+
+# Create gpadmin user and grant passwordless sudo in builder
+RUN groupadd -r gpadmin && \
+    useradd -m -r -g gpadmin -s /bin/bash gpadmin && \
+    echo "gpadmin ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/gpadmin && \
+    chmod 440 /etc/sudoers.d/gpadmin
+
+# Switch to gpadmin user
+USER gpadmin
+WORKDIR /home/gpadmin
+
+# Copy repository contents from build context
+# Note: This COPY always executes regardless of CODEBASE_VERSION due to Docker
+# layer caching behavior. For main branch builds, the copied content will be
+# removed and replaced by a fresh git clone in the RUN step below. This is an
+# acceptable tradeoff to keep the Dockerfile simple and maintainable.
+COPY --chown=gpadmin:gpadmin . /home/gpadmin/cloudberry
+
+# Obtain Cloudberry source code based on build mode
+RUN if [ "${CODEBASE_VERSION}" = "local" ]; then \
+        echo "Using local source from build context"; \
+    else \
+        rm -rf /home/gpadmin/cloudberry && \
+        git clone --recurse-submodules --branch main --single-branch --depth=1 https://github.com/apache/cloudberry.git; \
+    fi
+
+# Build Cloudberry using the official build scripts
+RUN cd /home/gpadmin/cloudberry && \
+    export SRC_DIR=/home/gpadmin/cloudberry && \
+    mkdir -p ${SRC_DIR}/build-logs && \
+    ./devops/build/automation/cloudberry/scripts/configure-cloudberry.sh && \
+    ./devops/build/automation/cloudberry/scripts/build-cloudberry.sh
+
+# --------------------------------------------------------------------
+# Runtime stage: Switch to a slimmer base image (Rocky Linux)
+# --------------------------------------------------------------------
+FROM rockylinux/rockylinux:10.2
+
+# Install required runtime dependencies, SSH server, sudo, and tools
+# Note: Use dnf on Rocky Linux
+RUN dnf -y update && \
+    dnf -y install \
+      openssh-server openssh-clients \
+      sudo shadow-utils \
+      bash procps-ng \
+      ca-certificates \
+      python3 \
+      apr \
+      bzip2-libs \
+      krb5-libs \
+      libevent \
+      libicu \
+      liburing \
+      libuuid \
+      libxml2 \
+      libyaml \
+      libzstd \
+      lz4 \
+      ncurses \
+      openldap \
+      openssl \
+      pam \
+      pcre2 \
+      perl \
+      protobuf \
+      readline \
+      zlib \
+      glibc-langpack-en \
+      libuv \
+      iproute \
+      net-tools \
+      which \
+      rsync \
+      keyutils \
+      libstdc++
+
+RUN dnf clean all && rm -rf /var/cache/dnf
+
+# Create gpadmin user and group, grant passwordless sudo
+RUN groupadd -r gpadmin && \
+    useradd -m -r -g gpadmin -s /bin/bash gpadmin && \
+    echo "gpadmin ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/gpadmin && \
+    chmod 440 /etc/sudoers.d/gpadmin
+
+# Prepare SSH daemon: generate host keys, ensure runtime dir, and allow gpadmin to start it
+RUN ssh-keygen -A && mkdir -p /run/sshd && chmod u+s /usr/sbin/sshd
+
+# Copy built Cloudberry from builder stage
+COPY --from=builder /usr/local/cloudberry-db /usr/local/cloudberry-db
+
+# Bring Xerces libs into Cloudberry lib dir and normalize SONAME via builder-installed versioned prefix
+COPY --from=builder /usr/local/xerces-c/lib/libxerces-c.so /usr/local/cloudberry-db/lib/
+COPY --from=builder /usr/local/xerces-c/lib/libxerces-c-3.*.so /usr/local/cloudberry-db/lib/
+
+# Copy configuration files to their final destinations
+COPY devops/sandbox/configs/90-cbdb-limits.conf /etc/security/limits.d/90-cbdb-limits.conf
+COPY devops/sandbox/configs/90-cbdb-sysctl.conf /etc/sysctl.d/90-cbdb-sysctl.conf
+COPY devops/sandbox/configs/gpinitsystem_singlenode /tmp/gpinitsystem_singlenode
+COPY devops/sandbox/configs/gpinitsystem_multinode /tmp/gpinitsystem_multinode
+COPY devops/sandbox/configs/multinode-gpinit-hosts /tmp/multinode-gpinit-hosts
+COPY devops/sandbox/configs/init_system.sh /tmp/init_system.sh
+
+# Runtime configuration
+RUN echo "cdw" > /tmp/gpdb-hosts && \
+    chmod 755 /tmp/gpinitsystem_singlenode && \
+    chmod 755 /tmp/gpinitsystem_multinode && \
+    chmod 755 /tmp/init_system.sh && \
+    mkdir -p /data0/database/coordinator /data0/database/primary /data0/database/mirror && \
+    chown -R gpadmin:gpadmin \
+      /usr/local/cloudberry-db \
+      /tmp/gpinitsystem_singlenode \
+      /tmp/gpinitsystem_multinode \
+      /tmp/gpdb-hosts \
+      /tmp/multinode-gpinit-hosts \
+      /data0 && \
+    echo "export COORDINATOR_DATA_DIRECTORY=/data0/database/coordinator/gpseg-1" >> /home/gpadmin/.bashrc && \
+    echo -e '\n# Add Cloudberry entries\nif [ -f /usr/local/cloudberry-db/cloudberry-env.sh ]; then\n  source /usr/local/cloudberry-db/cloudberry-env.sh\nfi' >> /home/gpadmin/.bashrc
+
+# ----------------------------------------------------------------------
+# Generate SSH keypair for gpadmin user at build time
+# ----------------------------------------------------------------------
+# WARNING: This embeds a fixed SSH keypair in the Docker image for
+# sandbox convenience. This is ONLY suitable for local testing and
+# development. DO NOT use this image in production or any environment
+# where security is a concern.
+# ----------------------------------------------------------------------
+RUN mkdir -p /home/gpadmin/.ssh && \
+    ssh-keygen -t rsa -b 4096 -N '' -C 'gpadmin@cloudberry-sandbox' \
+               -f /home/gpadmin/.ssh/id_rsa && \
+    cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys && \
+    chmod 700 /home/gpadmin/.ssh && \
+    chmod 600 /home/gpadmin/.ssh/id_rsa && \
+    chmod 644 /home/gpadmin/.ssh/id_rsa.pub && \
+    chmod 600 /home/gpadmin/.ssh/authorized_keys && \
+    chown -R gpadmin:gpadmin /home/gpadmin/.ssh
+
+# Set default user and working directory
+USER gpadmin
+WORKDIR /home/gpadmin
+
+EXPOSE 5432 22
+
+# cgroup mount (provided by compose/run)
+VOLUME [ "/sys/fs/cgroup" ]
+
+# Start the container by running the initialization script
+CMD ["bash","-c","/tmp/init_system.sh"]

--- a/devops/sandbox/README.md
+++ b/devops/sandbox/README.md
@@ -116,6 +116,20 @@ Build and deploy steps:
     ./run.sh -c main -m
     ```
 
+    - For Rocky Linux 10 on main branch running on a single container
+
+    ```shell
+    cd cloudberry/devops/sandbox
+    ./run.sh -c main -o rockylinux10
+    ```
+
+    - For Rocky Linux 10 on main branch running across multiple containers
+
+    ```shell
+    cd cloudberry/devops/sandbox
+    ./run.sh -c main -m -o rockylinux10
+    ```
+
     Once the script finishes without error, the sandbox is built and running successfully. The `docker run` and `docker compose` commands use the --detach option allowing you to ssh or access the running Apache Cloudberry instance remotely.
 
     Please review run.sh script for additional options (e.g. setting Timezone in running container, only building container). You can also execute `./run.sh -h` to see the usage.
@@ -196,12 +210,14 @@ To stop the **multi-container** deployment while _keeping the data and state_ wi
 
 ```shell
 docker compose -f docker-compose-rockylinux9.yml stop
+docker compose -f docker-compose-rockylinux10.yml stop
 ```
 
 To stop the **multi-container** deployment and also remove the network and volumes that belong to the containers, you can run the command below. Running this command means it will delete the containers as well as remove the volumes that the containers are associated with. This means any changes you've made inside of the containers or any database state will be wiped and unrecoverable.
 
 ```shell
 docker compose -f docker-compose-rockylinux9.yml down -v
+docker compose -f docker-compose-rockylinux10.yml down -v
 ```
 
 **Starting A Stopped Single Container Apache Cloudberry Docker Deployment**
@@ -220,6 +236,7 @@ To start a **multi-container** deployment after it was shut down, you can run th
 
 ```shell
 docker compose -f docker-compose-rockylinux9.yml start
+docker compose -f docker-compose-rockylinux10.yml start
 ```
 
 > [!NOTE]

--- a/devops/sandbox/docker-compose-rockylinux10.yml
+++ b/devops/sandbox/docker-compose-rockylinux10.yml
@@ -1,0 +1,81 @@
+# --------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright
+# ownership. The ASF licenses this file to You under the Apache
+# License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the
+# License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# --------------------------------------------------------------------
+
+services:
+  cbdb-coordinator:
+    container_name: cbdb-cdw
+    image: cbdb-${CODEBASE_VERSION}:${OS_VERSION}
+    ports:
+    - "15432:5432"
+    hostname: cdw
+    tty: true
+    networks:
+      interconnect:
+        ipv4_address: 10.5.0.10
+    environment:
+      MULTINODE: "true"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  cbdb-standby-coordinator:
+    container_name: cbdb-scdw
+    image: cbdb-${CODEBASE_VERSION}:${OS_VERSION}
+    hostname: scdw
+    tty: true
+    networks:
+      interconnect:
+        ipv4_address: 10.5.0.11
+    environment:
+      MULTINODE: "true"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  cbdb-segment-host-1:
+    container_name: cbdb-sdw1
+    image: cbdb-${CODEBASE_VERSION}:${OS_VERSION}
+    hostname: sdw1
+    tty: true
+    networks:
+      interconnect:
+        ipv4_address: 10.5.0.12
+    environment:
+      MULTINODE: "true"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  cbdb-segment-host-2:
+    container_name: cbdb-sdw2
+    image: cbdb-${CODEBASE_VERSION}:${OS_VERSION}
+    hostname: sdw2
+    tty: true
+    networks:
+      interconnect:
+        ipv4_address: 10.5.0.13
+    environment:
+      MULTINODE: "true"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+networks:
+  interconnect:
+    name: cbdb-interconnect
+    driver: bridge
+    ipam:
+     config:
+       - subnet: 10.5.0.0/16
+         gateway: 10.5.0.1

--- a/devops/sandbox/run.sh
+++ b/devops/sandbox/run.sh
@@ -47,8 +47,11 @@ function usage() {
 }
 
 # Parse command-line options
-while getopts "c:t:p:bmh" opt; do
+while getopts "o:c:t:p:bmh" opt; do
     case "${opt}" in
+        o)
+            OS_VERSION=${OPTARG}
+            ;;
         c)
             CODEBASE_VERSION=${OPTARG}
             ;;
@@ -89,22 +92,31 @@ if [[ -z "$CODEBASE_VERSION" ]]; then
     usage
 fi
 
+# Validate CODEBASE_VERSION
+if [[ "${CODEBASE_VERSION}" != "main" && "${CODEBASE_VERSION}" != "local" && ! "${CODEBASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid codebase version: ${CODEBASE_VERSION}"
+    usage
+fi
+
 # Validate OS_VERSION and map to appropriate Docker image
 case "${OS_VERSION}" in
+    rockylinux10)
+        # Match standard version tags like '2.1.0' or '2.1.0-incubating'
+        if [[ "${CODEBASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Error: Building release (${CODEBASE_VERSION}) on ${OS_VERSION} is not supported."
+            echo "Please use 'rockylinux9' for release ${CODEBASE_VERSION} builds, or use 'main' or 'local' with rockylinux10."
+            exit 1
+        fi
+        OS_DOCKER_IMAGE=${OS_VERSION}
+        ;;
     rockylinux9)
-        OS_DOCKER_IMAGE="rockylinux9"
+        OS_DOCKER_IMAGE=${OS_VERSION}
         ;;
     *)
         echo "Invalid OS version: ${OS_VERSION}"
         usage
         ;;
 esac
-
-# Validate CODEBASE_VERSION
-if [[ "${CODEBASE_VERSION}" != "main" && "${CODEBASE_VERSION}" != "local" && ! "${CODEBASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Invalid codebase version: ${CODEBASE_VERSION}"
-    usage
-fi
 
 # Determine sandbox directory and repository root
 SANDBOX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### What does this PR do?

Introduce support for Rocky Linux 10 sandbox builds while improving the flexibility and safety of the sandbox orchestration script.

Changes include:
- Add a new `-o` option flag to `run.sh` to allow users to explicitly specify the target OS version.
- Implement a validation guard preventing users from building older release versions on Rocky Linux 10 due to modern toolchain incompatibilities.
- Move the `CODEBASE_VERSION` validation earlier in the execution path to catch errors before OS mapping occurs.
- Add missing `libicu-devel` dependency to the Rocky Linux 9 Dockerfile to fix localized build issues.

### Type of Change
- [X] New feature (non-breaking change)

### Test Plan
- [x] Passed `./run.sh -c main -m -o rockylinux10`
- [x] Passed `./run.sh -c main -m`
- [x] Passed `./run.sh -c 2.1.0 -m`

### Impact

**Dependencies:**

Optional rockylinux10

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [x] Added/updated documentation
- [x] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)
