### PR TITLE
fix(sandbox) Fix missing libicu-devel dependency

### DIFF
--- a/devops/sandbox/Dockerfile.main.rockylinux9
+++ b/devops/sandbox/Dockerfile.main.rockylinux9
@@ -102,6 +102,7 @@ RUN dnf makecache && \
         liburing-devel \
         libuv-devel \
         libyaml-devel \
+        libicu-devel \
         perl-IPC-Run \
         protobuf-devel && \
     dnf clean all && \


### PR DESCRIPTION
Add libicu-devel to devops/sandbox/Dockerfile.main.rockylinux9.
The sandbox build was failing because this dependency was
missing from the image.

### Type of Change
- [x] Bug fix (non-breaking change)
