### PR TITLE
Materialized CTE (Shared Scan) OR predicate pushdown (#1 rebased from #1762)

### DIFF
--- a/contrib/pax_storage/src/test/regress/expected/subselect.out
+++ b/contrib/pax_storage/src/test/regress/expected/subselect.out
@@ -1904,7 +1904,7 @@ with x as materialized (select * from (select f1 from subselect_tbl) ss)
 select * from x where f1 = 1;
                      QUERY PLAN                     
 ----------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    Output: x.f1
    ->  Subquery Scan on x
          Output: x.f1
@@ -1913,9 +1913,10 @@ select * from x where f1 = 1;
                Output: share0_ref1.f1
                ->  Seq Scan on public.subselect_tbl
                      Output: subselect_tbl.f1
+                     Filter: (subselect_tbl.f1 = 1)
  Optimizer: Postgres query optimizer
  Settings: gp_cte_sharing=on
-(11 rows)
+(12 rows)
 
 -- Stable functions are safe to inline
 explain (verbose, costs off)

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -65,6 +65,8 @@
 #include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 
+#include "optimizer/optimizer.h"
+
 // TODO: these planner gucs need to be refactored into PlannerConfig.
 bool		gp_enable_sort_limit = false;
 
@@ -194,6 +196,11 @@ static void bring_to_singleQE(PlannerInfo *root, RelOptInfo *rel);
 static bool is_query_contain_limit_groupby(Query *parse);
 static void handle_gen_seggen_volatile_path(PlannerInfo *root, RelOptInfo *rel);
 
+static List *
+collect_cte_quals(PlannerInfo *root, RelOptInfo *rel,
+				   RangeTblEntry *rte, Index rti, Query *subquery);
+
+static void subquery_push_qual_1(Query *subquery, Relids relids, Node *qual);
 
 /*
  * make_one_rel
@@ -3327,6 +3334,82 @@ set_tablefunction_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rt
 	}
 }
 
+static void
+recurse_push_qual_1(Node *setOp, Query *topquery,
+				   Relids relids, Node *qual)
+{
+	if (IsA(setOp, RangeTblRef))
+	{
+		RangeTblRef *rtr = (RangeTblRef *) setOp;
+		RangeTblEntry *subrte = rt_fetch(rtr->rtindex, topquery->rtable);
+		Query	   *subquery = subrte->subquery;
+
+		Assert(subquery != NULL);
+		subquery_push_qual_1(subquery, relids, qual);
+	}
+	else if (IsA(setOp, SetOperationStmt))
+	{
+		SetOperationStmt *op = (SetOperationStmt *) setOp;
+
+		recurse_push_qual_1(op->larg, topquery, relids, qual);
+		recurse_push_qual_1(op->rarg, topquery, relids, qual);
+	}
+	else
+	{
+		elog(ERROR, "unrecognized node type: %d",
+			 (int) nodeTag(setOp));
+	}
+}
+
+/*
+ * subquery_push_qual - push down a qual that we have determined is safe
+ */
+static void
+subquery_push_qual_1(Query *subquery, Relids relids, Node *qual)
+{
+	if (subquery->setOperations != NULL)
+	{
+		/* Recurse to push it separately to each component query */
+		recurse_push_qual_1(subquery->setOperations, subquery,
+						  relids, qual);
+	}
+	else
+	{
+		/*
+		 * We need to replace Vars in the qual (which must refer to outputs of
+		 * the subquery) with copies of the subquery's targetlist expressions.
+		 * Note that at this point, any uplevel Vars in the qual should have
+		 * been replaced with Params, so they need no work.
+		 *
+		 * This step also ensures that when we are pushing into a setop tree,
+		 * each component query gets its own copy of the qual.
+		 */
+		qual = ReplaceVarsFromTargetList_1(qual, relids, 0,
+										 subquery->targetList,
+										 REPLACEVARS_REPORT_ERROR, 0,
+										 &subquery->hasSubLinks);
+
+		/*
+		 * Now attach the qual to the proper place: normally WHERE, but if the
+		 * subquery uses grouping or aggregation, put it in HAVING (since the
+		 * qual really refers to the group-result rows).
+		 */
+		if (subquery->hasAggs || subquery->groupClause || subquery->groupingSets || subquery->havingQual)
+		{
+			subquery->havingQual = (Node *) make_and_qual(subquery->havingQual, qual);
+			//subquery->havingQual = (Node *) canonicalize_qual((Expr*)subquery->havingQual, false);
+		}
+		else
+			subquery->jointree->quals = make_and_qual(subquery->jointree->quals, qual);
+
+		/*
+		 * We need not change the subquery's hasAggs or hasSubLinks flags,
+		 * since we can't be pushing down any aggregates that weren't there
+		 * before, and we don't push down subselects at all.
+		 */
+	}
+}
+
 /*
  * set_values_pathlist
  *		Build the (single) access path for a VALUES RTE
@@ -3566,6 +3649,17 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 			config->honor_order_by = false;
 
+			/*
+			 * collect all quals
+			 * make them with OR clause
+			 * push down to subquery
+			 * keep rel's baserestrictioninfo as original
+			 * reset rels->{root, paths, keys and etc.}
+			 * if one have no qual, should be XXX OR (TRUE) ?
+			 */
+
+			cteplaninfo->subquery = copyObject(subquery);
+
 			subroot = subquery_planner(cteroot->glob, subquery, cteroot, cte->cterecursive,
 									   tuple_fraction, config);
 
@@ -3582,6 +3676,112 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		}
 		else
 			subroot = cteplaninfo->subroot;
+
+
+		/* Also replace Vars with subquery's targetlist */
+		List *quals = collect_cte_quals(root, rel, rte, rel->relid, subquery);
+		cteplaninfo->rels = lappend(cteplaninfo->rels, rel);
+		cteplaninfo->relids = bms_add_member(cteplaninfo->relids, rel->relid);
+
+		// TODO: if quals is NIL, it means a cte ref need all the data from cte
+		if (quals != NIL)
+		{
+			// Expr *and_clause;
+			//and_clause = (list_length(quals) == 1) ? linitial(quals) : make_andclause(quals);
+			cteplaninfo->list_quals = lappend(cteplaninfo->list_quals, make_andclause(quals));
+		}
+
+		int num_rels = list_length(cteplaninfo->rels);
+
+		if (num_rels == cte->cterefcount)
+		{
+			/* Do a second plan for shared cte. */
+
+			PlannerConfig *config = CopyPlannerConfig(root->config);
+
+			/*
+			 * Having multiple SharedScans can lead to deadlocks. For now,
+			 * disallow sharing of ctes at lower levels.
+			 */
+			config->gp_cte_sharing = false;
+
+			config->honor_order_by = false;
+
+			Expr *new_quals = convert_expr_to_cnf_complete(make_orclause(cteplaninfo->list_quals));
+
+			List *quals = make_ands_implicit(new_quals);
+
+			ListCell   *lc;
+			foreach(lc, quals)
+			{
+				subquery_push_qual_1(cteplaninfo->subquery, cteplaninfo->relids, (Node *)lfirst(lc));
+			}
+
+			subroot = subquery_planner(cteroot->glob, cteplaninfo->subquery, cteroot, cte->cterecursive,
+										   tuple_fraction, config);
+
+			/* Select best Path and turn it into a Plan */
+			sub_final_rel = fetch_upper_rel(subroot, UPPERREL_FINAL, NULL);
+
+			/*
+			 * we cannot use different plans for different instances of this CTE
+			 * reference, so keep only the cheapest
+			 */
+			sub_final_rel->pathlist = list_make1(sub_final_rel->cheapest_total_path);
+
+			cteplaninfo->subroot = subroot;
+
+			Path *best_path = sub_final_rel->cheapest_total_path;
+			CdbPathLocus locus;
+			double		sub_total_rows;
+
+			if (!IS_DUMMY_REL(sub_final_rel))
+			{
+				double		numsegments;
+
+				if (CdbPathLocus_IsPartitioned(sub_final_rel->cheapest_total_path->locus))
+					numsegments = CdbPathLocus_NumSegments(sub_final_rel->cheapest_total_path->locus);
+				else
+					numsegments = 1;
+				sub_total_rows = sub_final_rel->cheapest_total_path->rows * numsegments;
+
+			}
+
+			foreach (lc, cteplaninfo->rels)
+			{
+				RelOptInfo *cte_rel = (RelOptInfo*) lfirst(lc);
+				Relids required_outer = cte_rel->lateral_relids;
+
+				if (IS_DUMMY_REL(sub_final_rel))
+				{
+					set_dummy_rel_pathlist(root, cte_rel);
+					continue;
+				}
+				/* Mark rel with estimated output rows, width, etc */
+				set_cte_size_estimates(root, cte_rel, sub_total_rows);
+
+				locus = cdbpathlocus_from_subquery(root, cte_rel, best_path);
+
+				/* Convert subquery pathkeys to outer representation */
+				pathkeys = convert_subquery_pathkeys(root, cte_rel, best_path->pathkeys,
+													 make_tlist_from_pathtarget(best_path->pathtarget));
+
+				cte_rel->subroot = subroot;
+
+				/* truncate preivous path */
+				cte_rel->pathlist = NIL;
+
+				/* Generate appropriate path */
+				add_path(cte_rel, create_ctescan_path(root,
+												  cte_rel,
+												  NULL /* is_shared */,
+												  locus,
+												  pathkeys,
+												  required_outer),
+						root);
+			}
+			return;
+		}
 	}
 	rel->subroot = subroot;
 
@@ -4457,6 +4657,56 @@ push_down_restrict(PlannerInfo *root, RelOptInfo *rel,
 	return subquery;
 }
 
+static List *
+collect_cte_quals(PlannerInfo *root, RelOptInfo *rel,
+				   RangeTblEntry *rte, Index rti, Query *subquery)
+{
+	List *quals = NIL;
+
+	pushdown_safety_info safetyInfo;
+
+	/* Nothing to do here if it doesn't have qual at all */
+	if (rel->baserestrictinfo == NIL)
+		return NIL;
+
+	memset(&safetyInfo, 0, sizeof(safetyInfo));
+	safetyInfo.unsafeFlags = (unsigned char *)
+		palloc0((list_length(subquery->targetList) + 1) * sizeof(unsigned char));
+
+	safetyInfo.unsafeLeaky = rte->security_barrier;
+
+	if (subquery_is_pushdown_safe(subquery, subquery, &safetyInfo))
+	{
+		/* OK to consider pushing down individual quals */
+		ListCell   *l;
+
+		foreach(l, rel->baserestrictinfo)
+		{
+			RestrictInfo *rinfo = (RestrictInfo *) lfirst(l);
+			Node	   *qual= (Node *) rinfo->clause;
+
+			if (!rinfo->pseudoconstant &&
+				qual_is_pushdown_safe(subquery, rti, rinfo, &safetyInfo))
+			{
+				// TODO: replace varno to the first one?
+				// Is it possible that baseresctictinfo has quals with sublink or whole row? 
+
+				qual = ReplaceVarsFromTargetList(qual, rti, 0, rte,
+												 subquery->targetList,
+												 REPLACEVARS_REPORT_ERROR, 0,
+												 &subquery->hasSubLinks);
+				/* valid quals */
+				quals = lappend(quals, qual);
+			}
+		}
+	}
+	pfree(safetyInfo.unsafeFlags);
+	quals = list_copy_deep(quals);
+
+	return quals;
+}
+
+
 /*
  * subquery_is_pushdown_safe - is a subquery safe for pushing down quals?
  *
@@ -4952,8 +5202,7 @@ subquery_push_qual(Query *subquery, RangeTblEntry *rte, Index rti, Node *qual)
 		if (subquery->hasAggs || subquery->groupClause || subquery->groupingSets || subquery->havingQual)
 			subquery->havingQual = make_and_qual(subquery->havingQual, qual);
 		else
-			subquery->jointree->quals =
-				make_and_qual(subquery->jointree->quals, qual);
+			subquery->jointree->quals = make_and_qual(subquery->jointree->quals, qual);
 
 		/*
 		 * We need not change the subquery's hasAggs or hasSubLinks flags,
@@ -5768,3 +6017,5 @@ debug_print_rel(PlannerInfo *root, RelOptInfo *rel)
 }
 
 #endif							/* OPTIMIZER_DEBUG */
+
+

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3712,6 +3712,8 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			List *quals = make_ands_implicit(new_quals);
 
 			ListCell   *lc;
+			// hack to make varno = 1 in bms
+			cteplaninfo->relids = bms_add_member(cteplaninfo->relids, 1);
 			foreach(lc, quals)
 			{
 				subquery_push_qual_1(cteplaninfo->subquery, cteplaninfo->relids, (Node *)lfirst(lc));
@@ -4688,10 +4690,10 @@ collect_cte_quals(PlannerInfo *root, RelOptInfo *rel,
 			if (!rinfo->pseudoconstant &&
 				qual_is_pushdown_safe(subquery, rti, rinfo, &safetyInfo))
 			{
-				// TODO: replace varno to the first one?
+				// TODO: replace varno to the subquery itself.
 				// Is it possible that baseresctictinfo has quals with sublink or whole row? 
 
-				qual = ReplaceVarsFromTargetList(qual, rti, 0, rte,
+				qual = ReplaceVarnoFromSubquery(qual, rti, 0, rte,
 												 subquery->targetList,
 												 REPLACEVARS_REPORT_ERROR, 0,
 												 &subquery->hasSubLinks);

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3744,29 +3744,26 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			Path *best_path = sub_final_rel->cheapest_total_path;
 			CdbPathLocus locus;
 			double		sub_total_rows;
+			double		numsegments;
 
-			if (!IS_DUMMY_REL(sub_final_rel))
+			if (IS_DUMMY_REL(sub_final_rel))
 			{
-				double		numsegments;
-
-				if (CdbPathLocus_IsPartitioned(sub_final_rel->cheapest_total_path->locus))
-					numsegments = CdbPathLocus_NumSegments(sub_final_rel->cheapest_total_path->locus);
-				else
-					numsegments = 1;
-				sub_total_rows = sub_final_rel->cheapest_total_path->rows * numsegments;
-
+				foreach (lc, cteplaninfo->rels)
+					set_dummy_rel_pathlist(root, (RelOptInfo *) lfirst(lc));
+				return;
 			}
+
+			if (CdbPathLocus_IsPartitioned(best_path->locus))
+				numsegments = CdbPathLocus_NumSegments(best_path->locus);
+			else
+				numsegments = 1;
+			sub_total_rows = best_path->rows * numsegments;
 
 			foreach (lc, cteplaninfo->rels)
 			{
 				RelOptInfo *cte_rel = (RelOptInfo*) lfirst(lc);
 				Relids required_outer = cte_rel->lateral_relids;
 
-				if (IS_DUMMY_REL(sub_final_rel))
-				{
-					set_dummy_rel_pathlist(root, cte_rel);
-					continue;
-				}
 				/* Mark rel with estimated output rows, width, etc */
 				set_cte_size_estimates(root, cte_rel, sub_total_rows);
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3673,7 +3673,14 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			sub_final_rel->pathlist = list_make1(sub_final_rel->cheapest_total_path);
 
 			cteplaninfo->subroot = subroot;
-			cteplaninfo->push_quals_possible = true;
+
+			/*
+			 * Pushing quals into the producer changes how many times the
+			 * subquery's volatile expressions are evaluated, so leave a CTE
+			 * containing volatile functions alone.  This is the same rule the
+			 * non-shared path above applies before calling push_down_restrict().
+			 */
+			cteplaninfo->push_quals_possible = !contain_volatile_function;
 		}
 		else
 			subroot = cteplaninfo->subroot;

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3673,27 +3673,35 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			sub_final_rel->pathlist = list_make1(sub_final_rel->cheapest_total_path);
 
 			cteplaninfo->subroot = subroot;
+			cteplaninfo->push_quals_possible = true;
 		}
 		else
 			subroot = cteplaninfo->subroot;
 
-
-		/* Also replace Vars with subquery's targetlist */
-		List *quals = collect_cte_quals(root, rel, rte, rel->relid, subquery);
-		cteplaninfo->rels = lappend(cteplaninfo->rels, rel);
-		cteplaninfo->relids = bms_add_member(cteplaninfo->relids, rel->relid);
-
-		// TODO: if quals is NIL, it means a cte ref need all the data from cte
-		if (quals != NIL)
+		if (cteplaninfo->push_quals_possible)
 		{
-			// Expr *and_clause;
-			//and_clause = (list_length(quals) == 1) ? linitial(quals) : make_andclause(quals);
-			cteplaninfo->list_quals = lappend(cteplaninfo->list_quals, make_andclause(quals));
+			/* Also replace Vars with subquery's targetlist */
+			List *quals = collect_cte_quals(root, rel, rte, rel->relid, subquery);
+			cteplaninfo->rels = lappend(cteplaninfo->rels, rel);
+			cteplaninfo->relids = bms_add_member(cteplaninfo->relids, rel->relid);
+
+			if (quals != NIL)
+				cteplaninfo->list_quals = lappend(cteplaninfo->list_quals, make_andclause(quals));
+			else
+			{
+				/*
+				 * This reference has no qual that can be pushed down, i.e. it
+				 * needs every row of the CTE.  Pushing the other references'
+				 * quals into the producer would drop rows this one still
+				 * needs, so give up on the pushdown for this CTE entirely.
+				 */
+				cteplaninfo->push_quals_possible = false;
+				cteplaninfo->list_quals = NIL;
+			}
 		}
 
-		int num_rels = list_length(cteplaninfo->rels);
-
-		if (num_rels == cte->cterefcount)
+		if (cteplaninfo->push_quals_possible &&
+			list_length(cteplaninfo->rels) == cte->cterefcount)
 		{
 			/* Do a second plan for shared cte. */
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -200,7 +200,7 @@ static List *
 collect_cte_quals(PlannerInfo *root, RelOptInfo *rel,
 				   RangeTblEntry *rte, Index rti, Query *subquery);
 
-static void subquery_push_qual_1(Query *subquery, Relids relids, Node *qual);
+static void subquery_push_qual_cte(Query *subquery, Relids relids, Node *qual);
 
 /*
  * make_one_rel
@@ -3335,7 +3335,7 @@ set_tablefunction_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rt
 }
 
 static void
-recurse_push_qual_1(Node *setOp, Query *topquery,
+recurse_push_qual_cte(Node *setOp, Query *topquery,
 				   Relids relids, Node *qual)
 {
 	if (IsA(setOp, RangeTblRef))
@@ -3345,14 +3345,14 @@ recurse_push_qual_1(Node *setOp, Query *topquery,
 		Query	   *subquery = subrte->subquery;
 
 		Assert(subquery != NULL);
-		subquery_push_qual_1(subquery, relids, qual);
+		subquery_push_qual_cte(subquery, relids, qual);
 	}
 	else if (IsA(setOp, SetOperationStmt))
 	{
 		SetOperationStmt *op = (SetOperationStmt *) setOp;
 
-		recurse_push_qual_1(op->larg, topquery, relids, qual);
-		recurse_push_qual_1(op->rarg, topquery, relids, qual);
+		recurse_push_qual_cte(op->larg, topquery, relids, qual);
+		recurse_push_qual_cte(op->rarg, topquery, relids, qual);
 	}
 	else
 	{
@@ -3365,12 +3365,12 @@ recurse_push_qual_1(Node *setOp, Query *topquery,
  * subquery_push_qual - push down a qual that we have determined is safe
  */
 static void
-subquery_push_qual_1(Query *subquery, Relids relids, Node *qual)
+subquery_push_qual_cte(Query *subquery, Relids relids, Node *qual)
 {
 	if (subquery->setOperations != NULL)
 	{
 		/* Recurse to push it separately to each component query */
-		recurse_push_qual_1(subquery->setOperations, subquery,
+		recurse_push_qual_cte(subquery->setOperations, subquery,
 						  relids, qual);
 	}
 	else
@@ -3384,7 +3384,7 @@ subquery_push_qual_1(Query *subquery, Relids relids, Node *qual)
 		 * This step also ensures that when we are pushing into a setop tree,
 		 * each component query gets its own copy of the qual.
 		 */
-		qual = ReplaceVarsFromTargetList_1(qual, relids, 0,
+		qual = ReplaceVarsFromTargetList_CTE(qual, relids, 0,
 										 subquery->targetList,
 										 REPLACEVARS_REPORT_ERROR, 0,
 										 &subquery->hasSubLinks);
@@ -3716,7 +3716,7 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			cteplaninfo->relids = bms_add_member(cteplaninfo->relids, 1);
 			foreach(lc, quals)
 			{
-				subquery_push_qual_1(cteplaninfo->subquery, cteplaninfo->relids, (Node *)lfirst(lc));
+				subquery_push_qual_cte(cteplaninfo->subquery, cteplaninfo->relids, (Node *)lfirst(lc));
 			}
 
 			subroot = subquery_planner(cteroot->glob, cteplaninfo->subquery, cteroot, cte->cterecursive,

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -2527,7 +2527,12 @@ distribute_qual_to_rels(PlannerInfo *root, Node *clause,
 	{
 		JoinTreeItem *pitem;
 
-		Assert(root->hasLateralRTEs);	/* shouldn't happen otherwise */
+		/*
+		 * GPDB: quals collected from CTE references and pushed down into the
+		 * shared CTE subquery may end up outside their syntactic scope without
+		 * any LATERAL RTE being involved, so this assertion no longer holds.
+		 */
+		/* Assert(root->hasLateralRTEs); */	/* shouldn't happen otherwise */
 		Assert(sjinfo == NULL); /* mustn't postpone past outer join */
 		for (pitem = jtitem->jti_parent; pitem; pitem = pitem->jti_parent)
 		{

--- a/src/backend/optimizer/prep/prepqual.c
+++ b/src/backend/optimizer/prep/prepqual.c
@@ -675,3 +675,438 @@ process_duplicate_ors(List *orlist)
 	else
 		return make_andclause(pull_ands(winners));
 }
+
+static Expr *
+convert_or_to_cnf_complete(Expr *expr);
+
+static Expr *
+convert_and_to_cnf_complete(Expr *expr);
+static Expr *
+distribute_or_over_ands_complete(List *non_ands, List *and_clauses);
+static List *
+flatten_or_args_complete(List *args);
+static List *
+flatten_and_args_complete(List *args);
+static Expr *
+combine_cnf_clauses_complete(List *clauses);
+static List *
+remove_duplicates_in_list(List *clauses);
+static List *
+remove_duplicate_and_subsumed_clauses(List *clauses);
+static bool
+or_clause_subsumes(Expr *or_clause1, Expr *or_clause2);
+static Expr *
+deduplicate_cnf_result(Expr *expr);
+
+/*
+ * convert_expr_to_cnf_complete
+ *    Complete CNF conversion with built-in deduplication
+ *    Handles: (s='s' AND year=2001) OR (s='s' AND year=2002) OR
+ *             (s='c' AND year=2001 AND sum>0) OR (s='c' AND year=2002 AND sum>0)
+ *    Should produce: (year=2001 OR year=2002) AND (s='s' OR s='c') AND (s='s' OR sum>0)
+ */
+Expr *
+convert_expr_to_cnf_complete(Expr *expr)
+{
+	if (expr == NULL)
+		return NULL;
+
+	/* Base case: non-Boolean expressions */
+	if (!is_orclause(expr) && !is_andclause(expr))
+		return expr;
+
+	if (is_orclause(expr))
+	{
+		return convert_or_to_cnf_complete(expr);
+	}
+	else if (is_andclause(expr))
+	{
+		return convert_and_to_cnf_complete(expr);
+	}
+
+	return expr;
+}
+
+/*
+ * convert_or_to_cnf_complete
+ *    Complete OR to CNF conversion with deduplication
+ */
+static Expr *
+convert_or_to_cnf_complete(Expr *expr)
+{
+	List *or_args = NIL;
+	ListCell *lc;
+
+	/* Step 1: Recursively convert all arguments */
+	foreach (lc, ((BoolExpr *)expr)->args)
+	{
+		Expr *arg = convert_expr_to_cnf_complete((Expr *)lfirst(lc));
+		or_args = lappend(or_args, arg);
+	}
+
+	/* Step 2: Flatten nested ORs */
+	or_args = flatten_or_args_complete(or_args);
+
+	/* Step 3: Remove duplicate arguments within this OR */
+	or_args = remove_duplicates_in_list(or_args);
+
+	/* Step 4: Check for AND clauses that need distribution */
+	List *and_clauses = NIL;
+	List *non_and_clauses = NIL;
+	bool has_and = false;
+
+	foreach (lc, or_args)
+	{
+		Expr *arg = (Expr *)lfirst(lc);
+		if (is_andclause(arg))
+		{
+			and_clauses = lappend(and_clauses, arg);
+			has_and = true;
+		}
+		else
+		{
+			non_and_clauses = lappend(non_and_clauses, arg);
+		}
+	}
+
+	/* Step 5: If no AND clauses, return simplified OR */
+	if (!has_and)
+	{
+		if (list_length(or_args) == 0)
+			return (Expr *)makeBoolConst(true, false);
+		else if (list_length(or_args) == 1)
+			return (Expr *)linitial(or_args);
+		else
+			return make_orclause(or_args);
+	}
+
+	/* Step 6: Apply distributive law */
+	Expr *result = distribute_or_over_ands_complete(non_and_clauses, and_clauses);
+
+	/* Step 7: Final deduplication of the resulting CNF */
+	return deduplicate_cnf_result(result);
+}
+
+/*
+ * convert_and_to_cnf_complete
+ *    Complete AND to CNF conversion with deduplication
+ */
+static Expr *
+convert_and_to_cnf_complete(Expr *expr)
+{
+	List *and_args = NIL;
+	ListCell *lc;
+
+	/* Step 1: Recursively convert all arguments */
+	foreach (lc, ((BoolExpr *)expr)->args)
+	{
+		Expr *arg = convert_expr_to_cnf_complete((Expr *)lfirst(lc));
+		and_args = lappend(and_args, arg);
+	}
+
+	/* Step 2: Flatten nested ANDs */
+	and_args = flatten_and_args_complete(and_args);
+
+	/* Step 3: Remove duplicates */
+	and_args = remove_duplicates_in_list(and_args);
+
+	/* Step 4: Return simplified AND */
+	if (list_length(and_args) == 0)
+		return (Expr *)makeBoolConst(true, false);
+	else if (list_length(and_args) == 1)
+		return (Expr *)linitial(and_args);
+	else
+		return make_andclause(and_args);
+}
+
+/*
+ * distribute_or_over_ands_complete
+ *    Enhanced distribution that handles multiple AND clauses properly
+ */
+static Expr *
+distribute_or_over_ands_complete(List *non_ands, List *and_clauses)
+{
+	/* Use the first AND clause for initial distribution */
+	Expr *first_and = (Expr *)linitial(and_clauses);
+	List *first_and_args = ((BoolExpr *)first_and)->args;
+
+	/* Remove duplicates from first AND arguments */
+	first_and_args = remove_duplicates_in_list(first_and_args);
+
+	/* Remaining AND clauses */
+	List *remaining_ands = list_delete_first(list_copy(and_clauses));
+
+	/* Base arguments for distribution: non-ANDs + remaining ANDs */
+	List *base_args = list_concat(remove_duplicates_in_list(non_ands),
+								  remaining_ands);
+
+	/* Apply distribution */
+	List *distributed_clauses = NIL;
+	ListCell *lc;
+
+	foreach (lc, first_and_args)
+	{
+		Expr *subclause = (Expr *)lfirst(lc);
+
+		/* Create new OR: (base_args OR subclause) */
+		List *new_or_args = list_copy(base_args);
+		new_or_args = lappend(new_or_args, subclause);
+
+		/* Remove duplicates in the new OR arguments */
+		new_or_args = remove_duplicates_in_list(new_or_args);
+
+		/* Convert recursively to CNF */
+		Expr *new_or = make_orclause(new_or_args);
+		Expr *cnf_or = convert_expr_to_cnf_complete(new_or);
+
+		distributed_clauses = lappend(distributed_clauses, cnf_or);
+	}
+
+	/* Combine all distributed clauses */
+	return combine_cnf_clauses_complete(distributed_clauses);
+}
+
+/*
+ * flatten_or_args_complete
+ *    Flatten nested OR clauses with deduplication
+ */
+static List *
+flatten_or_args_complete(List *args)
+{
+	List *result = NIL;
+	ListCell *lc;
+
+	foreach (lc, args)
+	{
+		Expr *arg = (Expr *)lfirst(lc);
+
+		if (is_orclause(arg))
+		{
+			List *sub_args = flatten_or_args_complete(((BoolExpr *)arg)->args);
+			result = list_concat(result, sub_args);
+		}
+		else
+		{
+			result = lappend(result, arg);
+		}
+	}
+
+	/* Remove duplicates after flattening */
+	return remove_duplicates_in_list(result);
+}
+
+/*
+ * flatten_and_args_complete
+ *    Flatten nested AND clauses with deduplication
+ */
+static List *
+flatten_and_args_complete(List *args)
+{
+	List *result = NIL;
+	ListCell *lc;
+
+	foreach (lc, args)
+	{
+		Expr *arg = (Expr *)lfirst(lc);
+
+		if (is_andclause(arg))
+		{
+			List *sub_args = flatten_and_args_complete(((BoolExpr *)arg)->args);
+			result = list_concat(result, sub_args);
+		}
+		else
+		{
+			result = lappend(result, arg);
+		}
+	}
+
+	/* Remove duplicates after flattening */
+	return remove_duplicates_in_list(result);
+}
+
+/*
+ * combine_cnf_clauses_complete
+ *    Combine CNF clauses with advanced deduplication
+ */
+static Expr *
+combine_cnf_clauses_complete(List *clauses)
+{
+	if (list_length(clauses) == 0)
+		return (Expr *)makeBoolConst(true, false);
+
+	if (list_length(clauses) == 1)
+		return (Expr *)linitial(clauses);
+
+	/* Extract all subclauses, handling nested ANDs */
+	List *all_clauses = NIL;
+	ListCell *lc;
+
+	foreach (lc, clauses)
+	{
+		Expr *clause = (Expr *)lfirst(lc);
+
+		if (is_andclause(clause))
+		{
+			all_clauses = list_concat(all_clauses,
+									  list_copy(((BoolExpr *)clause)->args));
+		}
+		else
+		{
+			all_clauses = lappend(all_clauses, clause);
+		}
+	}
+
+	/* Remove duplicates and subsumed clauses */
+	all_clauses = remove_duplicate_and_subsumed_clauses(all_clauses);
+
+	if (list_length(all_clauses) == 0)
+		return (Expr *)makeBoolConst(true, false);
+	else if (list_length(all_clauses) == 1)
+		return (Expr *)linitial(all_clauses);
+	else
+		return make_andclause(all_clauses);
+}
+
+/*
+ * remove_duplicates_in_list
+ *    Remove duplicate expressions from a list
+ */
+static List *
+remove_duplicates_in_list(List *clauses)
+{
+	List *result = NIL;
+	ListCell *lc;
+
+	foreach (lc, clauses)
+	{
+		Expr *clause = (Expr *)lfirst(lc);
+		bool found = false;
+		ListCell *lc2;
+
+		foreach (lc2, result)
+		{
+			if (equal(clause, (Expr *)lfirst(lc2)))
+			{
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+			result = lappend(result, clause);
+	}
+
+	return result;
+}
+
+/*
+ * remove_duplicate_and_subsumed_clauses
+ *    Remove duplicates and subsumed OR clauses
+ */
+static List *
+remove_duplicate_and_subsumed_clauses(List *clauses)
+{
+	List *result = NIL;
+	ListCell *lc;
+
+	foreach (lc, clauses)
+	{
+		Expr *clause = (Expr *)lfirst(lc);
+		bool keep = true;
+
+		/* Check against all existing clauses */
+		ListCell *lc_exist;
+		foreach (lc_exist, result)
+		{
+			Expr *existing = (Expr *)lfirst(lc_exist);
+
+			/* Exact duplicate */
+			if (equal(clause, existing))
+			{
+				keep = false;
+				break;
+			}
+
+			/* Check for OR clause subsumption */
+			if (is_orclause(clause) && is_orclause(existing))
+			{
+				if (or_clause_subsumes(existing, clause))
+				{
+					/* Existing subsumes current, skip current */
+					keep = false;
+					break;
+				}
+				else if (or_clause_subsumes(clause, existing))
+				{
+					/* Current subsumes existing, remove existing */
+					result = list_delete_cell(result, lc_exist);
+					break;
+				}
+			}
+		}
+
+		if (keep)
+			result = lappend(result, clause);
+	}
+
+	return result;
+}
+
+/*
+ * or_clause_subsumes
+ *    Check if or_clause1 subsumes or_clause2
+ *    (A OR B) subsumes (A OR B OR C) means we can remove (A OR B OR C)
+ */
+static bool
+or_clause_subsumes(Expr *or_clause1, Expr *or_clause2)
+{
+	if (!is_orclause(or_clause1) || !is_orclause(or_clause2))
+		return false;
+
+	List *args1 = ((BoolExpr *)or_clause1)->args;
+	List *args2 = ((BoolExpr *)or_clause2)->args;
+
+	/* If all elements of clause1 are in clause2, clause1 subsumes clause2 */
+	ListCell *lc1;
+	foreach (lc1, args1)
+	{
+		Expr *arg1 = (Expr *)lfirst(lc1);
+		bool found = false;
+		ListCell *lc2;
+
+		foreach (lc2, args2)
+		{
+			if (equal(arg1, (Expr *)lfirst(lc2)))
+			{
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * deduplicate_cnf_result
+ *    Final deduplication pass for the CNF result
+ */
+static Expr *
+deduplicate_cnf_result(Expr *expr)
+{
+	if (!is_andclause(expr))
+		return expr;
+
+	List *and_args = ((BoolExpr *)expr)->args;
+	List *unique_clauses = remove_duplicate_and_subsumed_clauses(and_args);
+
+	if (list_length(unique_clauses) == 0)
+		return (Expr *)makeBoolConst(true, false);
+	else if (list_length(unique_clauses) == 1)
+		return (Expr *)linitial(unique_clauses);
+	else
+		return make_andclause(unique_clauses);
+}

--- a/src/backend/optimizer/prep/prepqual.c
+++ b/src/backend/optimizer/prep/prepqual.c
@@ -699,11 +699,85 @@ static Expr *
 deduplicate_cnf_result(Expr *expr);
 
 /*
- * convert_expr_to_cnf_complete
- *    Complete CNF conversion with built-in deduplication
- *    Handles: (s='s' AND year=2001) OR (s='s' AND year=2002) OR
- *             (s='c' AND year=2001 AND sum>0) OR (s='c' AND year=2002 AND sum>0)
- *    Should produce: (year=2001 OR year=2002) AND (s='s' OR s='c') AND (s='s' OR sum>0)
+ * CNF Conversion for CTE Predicate Pushdown
+ *
+ * MOTIVATION:
+ * When a CTE is referenced multiple times with different filter predicates,
+ * we want to push down the combined predicates to reduce materialization.
+ * For example:
+ *
+ *   WITH cte AS (SELECT ... FROM large_table)
+ *   SELECT * FROM cte WHERE store_id = 10
+ *   UNION ALL
+ *   SELECT * FROM cte WHERE store_id = 20
+ *
+ * We collect predicates from all consumers and combine them:
+ *   (store_id = 10) OR (store_id = 20)
+ *
+ * For more complex cases with AND predicates:
+ *   WHERE (store_id = 10 AND year = 2001)
+ *   WHERE (store_id = 20 AND year = 2001)
+ *
+ * Combined: (store_id = 10 AND year = 2001) OR (store_id = 20 AND year = 2001)
+ *
+ * WHY CNF CONVERSION:
+ * CNF (Conjunctive Normal Form) is required because:
+ * 1. The planner expects filter predicates in AND-of-ORs form
+ * 2. CNF enables individual clauses to be pushed down independently
+ * 3. After CNF conversion, (year = 2001) can be extracted as a separate
+ *    conjunct and pushed down even if other parts cannot be
+ *
+ * ALGORITHM:
+ * We use the distributive law to convert OR-of-ANDs to AND-of-ORs:
+ *
+ *   (A AND B) OR (A AND C)
+ *   = (A OR A) AND (A OR C) AND (B OR A) AND (B OR C)  [distribute]
+ *   = A AND (A OR C) AND (B OR A) AND (B OR C)         [simplify A OR A = A]
+ *   = A AND (A OR C) AND (A OR B) AND (B OR C)         [reorder]
+ *
+ * With subsumption detection, we can further simplify:
+ *   - (A OR C) subsumes any clause containing all its terms plus more
+ *   - So A AND (A OR C) simplifies to A (since A subsumes A OR C? No...)
+ *   
+ * Actually: In CNF context, (A) subsumes (A OR B) because:
+ *   - If A is true, both A and (A OR B) are true
+ *   - (A) is more restrictive, so (A OR B) is redundant
+ *
+ * EXAMPLE WALKTHROUGH:
+ * Input: (s='s' AND year=2001) OR (s='s' AND year=2002)
+ *
+ * Step 1: Identify AND clauses to distribute
+ *   - First AND: (s='s' AND year=2001)
+ *   - Remaining: (s='s' AND year=2002)
+ *
+ * Step 2: Distribute first AND over remaining
+ *   - (s='s' OR (s='s' AND year=2002))  → recurse
+ *   - (year=2001 OR (s='s' AND year=2002))  → recurse
+ *
+ * Step 3: Recursively convert each:
+ *   - (s='s' OR (s='s' AND year=2002))
+ *     = (s='s' OR s='s') AND (s='s' OR year=2002)
+ *     = s='s' AND (s='s' OR year=2002)
+ *   
+ *   - (year=2001 OR (s='s' AND year=2002))
+ *     = (year=2001 OR s='s') AND (year=2001 OR year=2002)
+ *
+ * Step 4: Combine with AND:
+ *   = s='s' AND (s='s' OR year=2002) AND (year=2001 OR s='s') AND (year=2001 OR year=2002)
+ *
+ * Step 5: Deduplicate and remove subsumed clauses:
+ *   - s='s' subsumes (s='s' OR year=2002) and (year=2001 OR s='s')
+ *   - Final: s='s' AND (year=2001 OR year=2002)
+ *
+ * DEDUPLICATION STRATEGY:
+ * 1. Exact duplicate removal: (A OR B) appears twice → keep one
+ * 2. Subsumption removal: (A OR B) AND (A OR B OR C) → keep only (A OR B)
+ *    because (A OR B) being true implies (A OR B OR C) is true
+ *
+ * COMPLEXITY NOTE:
+ * CNF conversion can cause exponential blowup in the worst case.
+ * For n AND-clauses each with m terms: O(m^n) output clauses.
+ * The deduplication helps mitigate this for practical queries.
  */
 Expr *
 convert_expr_to_cnf_complete(Expr *expr)
@@ -773,7 +847,7 @@ convert_or_to_cnf_complete(Expr *expr)
 	if (!has_and)
 	{
 		if (list_length(or_args) == 0)
-			return (Expr *)makeBoolConst(true, false);
+			return (Expr *)makeBoolConst(false, false);
 		else if (list_length(or_args) == 1)
 			return (Expr *)linitial(or_args);
 		else
@@ -1013,6 +1087,7 @@ remove_duplicate_and_subsumed_clauses(List *clauses)
 	{
 		Expr *clause = (Expr *)lfirst(lc);
 		bool keep = true;
+		List *to_remove = NIL;
 
 		/* Check against all existing clauses */
 		ListCell *lc_exist;
@@ -1038,11 +1113,25 @@ remove_duplicate_and_subsumed_clauses(List *clauses)
 				}
 				else if (or_clause_subsumes(clause, existing))
 				{
-					/* Current subsumes existing, remove existing */
-					result = list_delete_cell(result, lc_exist);
-					break;
+					/*
+					 * Current subsumes existing, mark for removal.
+					 * Continue checking other clauses since the current
+					 * clause may subsume multiple existing clauses.
+					 */
+					to_remove = lappend(to_remove, existing);
 				}
 			}
+		}
+
+		/* Remove all clauses that current clause subsumes */
+		if (to_remove != NIL)
+		{
+			ListCell *lc_rm;
+			foreach (lc_rm, to_remove)
+			{
+				result = list_delete_ptr(result, lfirst(lc_rm));
+			}
+			list_free(to_remove);
 		}
 
 		if (keep)

--- a/src/backend/optimizer/prep/prepqual.c
+++ b/src/backend/optimizer/prep/prepqual.c
@@ -1075,7 +1075,21 @@ remove_duplicates_in_list(List *clauses)
 
 /*
  * remove_duplicate_and_subsumed_clauses
- *    Remove duplicates and subsumed OR clauses
+ *    Remove duplicates and logically redundant clauses from a CNF conjunction.
+ *
+ * In a CNF conjunction (AND of clauses), a clause is redundant if it is
+ * logically implied by another clause already in the list. We detect three
+ * cases of redundancy:
+ *
+ * 1. Exact duplicates: (A OR B) AND (A OR B) → keep one
+ *
+ * 2. OR-vs-OR subsumption: (A OR B) AND (A OR B OR C) → keep (A OR B)
+ *    A shorter OR-clause with all its terms present in a longer one
+ *    makes the longer one always-true when the shorter one is true.
+ *
+ * 3. Literal-vs-OR subsumption: A AND (A OR B) → keep A
+ *    A bare literal makes any OR-clause containing it redundant,
+ *    because if the literal is true, the OR-clause is trivially true.
  */
 static List *
 remove_duplicate_and_subsumed_clauses(List *clauses)
@@ -1121,6 +1135,22 @@ remove_duplicate_and_subsumed_clauses(List *clauses)
 					to_remove = lappend(to_remove, existing);
 				}
 			}
+			else if (!is_orclause(clause) && is_orclause(existing))
+			{
+				/* A AND (A OR B) could be simplied to A */
+				if (list_member(((BoolExpr *)existing)->args, clause))
+				{
+					to_remove = lappend(to_remove, existing);
+				}
+			}
+			else if (is_orclause(clause) && !is_orclause(existing))
+			{
+				if (list_member(((BoolExpr *)clause)->args, existing))
+				{
+					keep = false;
+					break;
+				}
+			}
 		}
 
 		/* Remove all clauses that current clause subsumes */
@@ -1144,7 +1174,7 @@ remove_duplicate_and_subsumed_clauses(List *clauses)
 /*
  * or_clause_subsumes
  *    Check if or_clause1 subsumes or_clause2
- *    (A OR B) subsumes (A OR B OR C) means we can remove (A OR B OR C)
+ *    (A OR B) subsumes (B OR C OR A) means we can remove (B OR C OR A)
  */
 static bool
 or_clause_subsumes(Expr *or_clause1, Expr *or_clause2)

--- a/src/backend/rewrite/rewriteManip.c
+++ b/src/backend/rewrite/rewriteManip.c
@@ -1885,7 +1885,7 @@ replace_rte_variables_1(Node *node, Bitmapset *target_varno_bms, int sublevels_u
 
 
 Node *
-ReplaceVarsFromTargetList_1(Node *node,
+ReplaceVarsFromTargetList_CTE(Node *node,
 						  Bitmapset *target_varno_bms, int sublevels_up,
 						  List *targetlist,
 						  ReplaceVarsNoMatchOption nomatch_option,

--- a/src/backend/rewrite/rewriteManip.c
+++ b/src/backend/rewrite/rewriteManip.c
@@ -1396,6 +1396,7 @@ replace_rte_variables(Node *node, int target_varno, int sublevels_up,
 	context.callback_arg = callback_arg;
 	context.target_varno = target_varno;
 	context.sublevels_up = sublevels_up;
+	context.target_varno_bms = NULL;
 
 	/*
 	 * We try to initialize inserted_sublink to true if there is no need to
@@ -1440,7 +1441,8 @@ replace_rte_variables_mutator(Node *node,
 	{
 		Var		   *var = (Var *) node;
 
-		if (var->varno == context->target_varno &&
+		if ((var->varno == context->target_varno ||
+			bms_is_member(var->varno, context->target_varno_bms)) &&
 			var->varlevelsup == context->sublevels_up)
 		{
 			/* Found a matching variable, make the substitution */
@@ -1828,6 +1830,76 @@ ReplaceVarsFromTargetList(Node *node,
 	context.nomatch_varno = nomatch_varno;
 
 	return replace_rte_variables(node, target_varno, sublevels_up,
+								 ReplaceVarsFromTargetList_callback,
+								 (void *) &context,
+								 outer_hasSubLinks);
+}
+
+static Node *
+replace_rte_variables_1(Node *node, Bitmapset *target_varno_bms, int sublevels_up,
+					  replace_rte_variables_callback callback,
+					  void *callback_arg,
+					  bool *outer_hasSubLinks)
+{
+	Node	   *result;
+	replace_rte_variables_context context;
+
+	context.callback = callback;
+	context.callback_arg = callback_arg;
+	context.target_varno = 0;
+	context.target_varno_bms = target_varno_bms;
+	context.sublevels_up = sublevels_up;
+
+	/*
+	 * We try to initialize inserted_sublink to true if there is no need to
+	 * detect new sublinks because the query already has some.
+	 */
+	if (node && IsA(node, Query))
+		context.inserted_sublink = ((Query *) node)->hasSubLinks;
+	else if (outer_hasSubLinks)
+		context.inserted_sublink = *outer_hasSubLinks;
+	else
+		context.inserted_sublink = false;
+
+	/*
+	 * Must be prepared to start with a Query or a bare expression tree; if
+	 * it's a Query, we don't want to increment sublevels_up.
+	 */
+	result = query_or_expression_tree_mutator(node,
+											  replace_rte_variables_mutator,
+											  (void *) &context,
+											  0);
+
+	if (context.inserted_sublink)
+	{
+		if (result && IsA(result, Query))
+			((Query *) result)->hasSubLinks = true;
+		else if (outer_hasSubLinks)
+			*outer_hasSubLinks = true;
+		else
+			elog(ERROR, "replace_rte_variables inserted a SubLink, but has noplace to record it");
+	}
+
+	return result;
+}
+
+
+Node *
+ReplaceVarsFromTargetList_1(Node *node,
+						  Bitmapset *target_varno_bms, int sublevels_up,
+						  List *targetlist,
+						  ReplaceVarsNoMatchOption nomatch_option,
+						  int nomatch_varno,
+						  bool *outer_hasSubLinks)
+{
+	ReplaceVarsFromTargetList_context context;
+
+	context.target_rte = NULL;
+	context.targetlist = targetlist;
+	context.nomatch_option = nomatch_option;
+	context.nomatch_varno = nomatch_varno;
+
+	return replace_rte_variables_1(node, target_varno_bms, sublevels_up,
 								 ReplaceVarsFromTargetList_callback,
 								 (void *) &context,
 								 outer_hasSubLinks);

--- a/src/backend/rewrite/rewriteManip.c
+++ b/src/backend/rewrite/rewriteManip.c
@@ -1904,3 +1904,68 @@ ReplaceVarsFromTargetList_1(Node *node,
 								 (void *) &context,
 								 outer_hasSubLinks);
 }
+
+static Node *
+ReplaceVarnoFromSubquery_callback(Var *var,
+								   replace_rte_variables_context *context)
+{
+	ReplaceVarsFromTargetList_context *rcon = (ReplaceVarsFromTargetList_context *) context->callback_arg;
+
+	if (var->varattno == InvalidAttrNumber)
+	{
+		/* Must expand whole-tuple reference into RowExpr */
+		RowExpr    *rowexpr;
+		List	   *colnames;
+		List	   *fields;
+
+		/*
+		 * If generating an expansion for a var of a named rowtype (ie, this
+		 * is a plain relation RTE), then we must include dummy items for
+		 * dropped columns.  If the var is RECORD (ie, this is a JOIN), then
+		 * omit dropped columns.  Either way, attach column names to the
+		 * RowExpr for use of ruleutils.c.
+		 */
+		expandRTE(rcon->target_rte,
+				  var->varno, var->varlevelsup, var->location,
+				  (var->vartype != RECORDOID),
+				  &colnames, &fields);
+		/* Adjust the generated per-field Vars... */
+		fields = (List *) replace_rte_variables_mutator((Node *) fields,
+														context);
+		rowexpr = makeNode(RowExpr);
+		rowexpr->args = fields;
+		rowexpr->row_typeid = var->vartype;
+		rowexpr->row_format = COERCE_IMPLICIT_CAST;
+		rowexpr->colnames = colnames;
+		rowexpr->location = var->location;
+
+		return (Node *) rowexpr;
+	}
+
+	Var *newnode = (Var *)copyObject(var);
+	/* Make var to the subquery itself. */
+	((Var *) newnode)->varno = 1;
+	return (Node *) newnode;
+}
+
+Node *
+ReplaceVarnoFromSubquery(Node *node,
+						  int target_varno, int sublevels_up,
+						  RangeTblEntry *target_rte,
+						  List *targetlist,
+						  ReplaceVarsNoMatchOption nomatch_option,
+						  int nomatch_varno,
+						  bool *outer_hasSubLinks)
+{
+	ReplaceVarsFromTargetList_context context;
+
+	context.target_rte = target_rte;
+	context.targetlist = targetlist;
+	context.nomatch_option = nomatch_option;
+	context.nomatch_varno = nomatch_varno;
+
+	return replace_rte_variables(node, target_varno, sublevels_up,
+								 ReplaceVarnoFromSubquery_callback,
+								 (void *)&context,
+								 outer_hasSubLinks);
+}

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -694,6 +694,13 @@ typedef struct CtePlanInfo
 
 	/* the relations refered to shared cte. */
 	List *rels;
+
+	/*
+	 * True while it is still possible to push the OR of the consumers'
+	 * quals down into the shared CTE subquery.  Reset as soon as one
+	 * consumer turns out to need all the rows of the CTE.
+	 */
+	bool push_quals_possible;
 	
 	List *list_quals;
 

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -691,6 +691,15 @@ typedef struct CtePlanInfo
 	 * The subroot corresponding to the subplan.
 	 */
 	PlannerInfo *subroot;
+
+	/* the relations refered to shared cte. */
+	List *rels;
+	
+	List *list_quals;
+
+	Relids relids;
+	
+	Query *subquery;
 } CtePlanInfo;
 
 /*

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -138,6 +138,7 @@ extern void extract_query_dependencies(Node *query,
 
 extern Node *negate_clause(Node *node);
 extern Expr *canonicalize_qual(Expr *qual, bool is_check);
+extern Expr *convert_expr_to_cnf_complete(Expr *expr);
 
 /* in util/clauses.c: */
 

--- a/src/include/rewrite/rewriteManip.h
+++ b/src/include/rewrite/rewriteManip.h
@@ -102,5 +102,13 @@ extern Node *ReplaceVarsFromTargetList_1(Node *node,
 									   ReplaceVarsNoMatchOption nomatch_option,
 									   int nomatch_varno,
 									   bool *outer_hasSubLinks);
+extern Node *
+ReplaceVarnoFromSubquery(Node *node,
+						  int target_varno, int sublevels_up,
+						  RangeTblEntry *target_rte,
+						  List *targetlist,
+						  ReplaceVarsNoMatchOption nomatch_option,
+						  int nomatch_varno,
+						  bool *outer_hasSubLinks);
 
 #endif							/* REWRITEMANIP_H */

--- a/src/include/rewrite/rewriteManip.h
+++ b/src/include/rewrite/rewriteManip.h
@@ -96,7 +96,7 @@ extern Node *ReplaceVarsFromTargetList(Node *node,
 									   int nomatch_varno,
 									   bool *outer_hasSubLinks);
 
-extern Node *ReplaceVarsFromTargetList_1(Node *node,
+extern Node *ReplaceVarsFromTargetList_CTE(Node *node,
 									   Bitmapset *target_varno_bms, int sublevels_up,
 									   List *targetlist,
 									   ReplaceVarsNoMatchOption nomatch_option,

--- a/src/include/rewrite/rewriteManip.h
+++ b/src/include/rewrite/rewriteManip.h
@@ -29,6 +29,7 @@ struct replace_rte_variables_context
 	replace_rte_variables_callback callback;	/* callback function */
 	void	   *callback_arg;	/* context data for callback function */
 	int			target_varno;	/* RTE index to search for */
+	Bitmapset 	*target_varno_bms;	/* RTE indexes to search for */
 	int			sublevels_up;	/* (current) nesting depth */
 	bool		inserted_sublink;	/* have we inserted a SubLink? */
 };
@@ -90,6 +91,13 @@ extern Node *map_variable_attnos(Node *node,
 extern Node *ReplaceVarsFromTargetList(Node *node,
 									   int target_varno, int sublevels_up,
 									   RangeTblEntry *target_rte,
+									   List *targetlist,
+									   ReplaceVarsNoMatchOption nomatch_option,
+									   int nomatch_varno,
+									   bool *outer_hasSubLinks);
+
+extern Node *ReplaceVarsFromTargetList_1(Node *node,
+									   Bitmapset *target_varno_bms, int sublevels_up,
 									   List *targetlist,
 									   ReplaceVarsNoMatchOption nomatch_option,
 									   int nomatch_varno,

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1947,7 +1947,7 @@ with x as (select * from (select f1, random() from subselect_tbl) ss)
 select * from x where f1 = 1;
                         QUERY PLAN                        
 ----------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: x.f1, x.random
    ->  Subquery Scan on x
          Output: x.f1, x.random
@@ -1956,10 +1956,8 @@ select * from x where f1 = 1;
                Output: share0_ref1.f1, share0_ref1.random
                ->  Seq Scan on public.subselect_tbl
                      Output: subselect_tbl.f1, random()
-                     Filter: (subselect_tbl.f1 = 1)
- Settings: optimizer = 'off'
  Optimizer: Postgres query optimizer
-(12 rows)
+(10 rows)
 
 create temporary sequence ts;
 create table vol_test(a int, b int);
@@ -1970,7 +1968,7 @@ with x as (select * from (select a, nextval('ts') from vol_test) ss)
 select * from x where a = 1;
                            QUERY PLAN                            
 -----------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: x.a, x.nextval
    ->  Subquery Scan on x
          Output: x.a, x.nextval
@@ -1979,10 +1977,8 @@ select * from x where a = 1;
                Output: share0_ref1.a, share0_ref1.nextval
                ->  Seq Scan on public.vol_test
                      Output: vol_test.a, nextval('ts'::regclass)
-                     Filter: (vol_test.a = 1)
- Settings: optimizer = 'off'
  Optimizer: Postgres query optimizer
-(12 rows)
+(10 rows)
 
 drop sequence ts;
 drop table vol_test;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1910,7 +1910,7 @@ with x as materialized (select * from (select f1 from subselect_tbl) ss)
 select * from x where f1 = 1;
                      QUERY PLAN                     
 ----------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    Output: x.f1
    ->  Subquery Scan on x
          Output: x.f1
@@ -1919,9 +1919,10 @@ select * from x where f1 = 1;
                Output: share0_ref1.f1
                ->  Seq Scan on public.subselect_tbl
                      Output: subselect_tbl.f1
+                     Filter: (subselect_tbl.f1 = 1)
+ Settings: optimizer = 'off'
  Optimizer: Postgres query optimizer
- Settings: gp_cte_sharing=on
-(11 rows)
+(12 rows)
 
 -- Stable functions are safe to inline
 explain (verbose, costs off)
@@ -1946,7 +1947,7 @@ with x as (select * from (select f1, random() from subselect_tbl) ss)
 select * from x where f1 = 1;
                         QUERY PLAN                        
 ----------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    Output: x.f1, x.random
    ->  Subquery Scan on x
          Output: x.f1, x.random
@@ -1955,8 +1956,10 @@ select * from x where f1 = 1;
                Output: share0_ref1.f1, share0_ref1.random
                ->  Seq Scan on public.subselect_tbl
                      Output: subselect_tbl.f1, random()
+                     Filter: (subselect_tbl.f1 = 1)
+ Settings: optimizer = 'off'
  Optimizer: Postgres query optimizer
-(10 rows)
+(12 rows)
 
 create temporary sequence ts;
 create table vol_test(a int, b int);
@@ -1967,7 +1970,7 @@ with x as (select * from (select a, nextval('ts') from vol_test) ss)
 select * from x where a = 1;
                            QUERY PLAN                            
 -----------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    Output: x.a, x.nextval
    ->  Subquery Scan on x
          Output: x.a, x.nextval
@@ -1976,8 +1979,10 @@ select * from x where a = 1;
                Output: share0_ref1.a, share0_ref1.nextval
                ->  Seq Scan on public.vol_test
                      Output: vol_test.a, nextval('ts'::regclass)
+                     Filter: (vol_test.a = 1)
+ Settings: optimizer = 'off'
  Optimizer: Postgres query optimizer
-(10 rows)
+(12 rows)
 
 drop sequence ts;
 drop table vol_test;

--- a/src/test/regress/expected/tpcds_q04.out
+++ b/src/test/regress/expected/tpcds_q04.out
@@ -5426,8 +5426,8 @@ INSERT INTO pg_statistic VALUES (
           ,t_s_secyear.customer_last_name
           ,t_s_secyear.customer_login
  limit 100;
-                                                                                                                                                        QUERY PLAN                                                                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                           QUERY PLAN                                                                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Gather Motion 3:1  (slice1; segments: 3)
          Merge Key: t_s_secyear.customer_id, t_s_secyear.customer_first_name, t_s_secyear.customer_last_name, t_s_secyear.customer_login
@@ -5435,97 +5435,100 @@ INSERT INTO pg_statistic VALUES (
                ->  Sort
                      Sort Key: t_s_secyear.customer_id, t_s_secyear.customer_first_name, t_s_secyear.customer_last_name, t_s_secyear.customer_login
                      ->  Hash Join
-                           Hash Cond: ((t_s_secyear.customer_id)::text = (t_w_firstyear.customer_id)::text)
+                           Hash Cond: ((t_s_secyear.customer_id)::text = (t_w_secyear.customer_id)::text)
                            Join Filter: (CASE WHEN (t_c_firstyear.year_total > '0'::numeric) THEN (t_c_secyear.year_total / t_c_firstyear.year_total) ELSE NULL::numeric END > CASE WHEN (t_w_firstyear.year_total > '0'::numeric) THEN (t_w_secyear.year_total / t_w_firstyear.year_total) ELSE NULL::numeric END)
-                           ->  Hash Join
-                                 Hash Cond: ((t_s_secyear.customer_id)::text = (t_c_secyear.customer_id)::text)
-                                 Join Filter: (CASE WHEN (t_c_firstyear.year_total > '0'::numeric) THEN (t_c_secyear.year_total / t_c_firstyear.year_total) ELSE NULL::numeric END > CASE WHEN (t_s_firstyear.year_total > '0'::numeric) THEN (t_s_secyear.year_total / t_s_firstyear.year_total) ELSE NULL::numeric END)
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: t_s_secyear.customer_id
-                                       ->  Hash Join
-                                             Hash Cond: ((t_s_firstyear.customer_id)::text = (t_s_secyear.customer_id)::text)
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                   ->  Subquery Scan on t_s_firstyear
-                                                         Filter: ((t_s_firstyear.year_total > '0'::numeric) AND (t_s_firstyear.sale_type = 's'::text) AND (t_s_firstyear.dyear = 2001))
-                                                         ->  Shared Scan (share slice:id 3:0)
-                                             ->  Hash
-                                                   ->  Subquery Scan on t_s_secyear
-                                                         Filter: ((t_s_secyear.sale_type = 's'::text) AND (t_s_secyear.dyear = 2002))
-                                                         ->  Shared Scan (share slice:id 2:0)
-                                 ->  Hash
-                                       ->  Hash Join
-                                             Hash Cond: ((t_c_firstyear.customer_id)::text = (t_c_secyear.customer_id)::text)
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: t_c_firstyear.customer_id
-                                                   ->  Subquery Scan on t_c_firstyear
-                                                         Filter: ((t_c_firstyear.year_total > '0'::numeric) AND (t_c_firstyear.sale_type = 'c'::text) AND (t_c_firstyear.dyear = 2001))
-                                                         ->  Shared Scan (share slice:id 4:0)
-                                             ->  Hash
-                                                   ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                                         Hash Key: t_c_secyear.customer_id
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Hash Join
+                                       Hash Cond: ((t_s_secyear.customer_id)::text = (t_c_firstyear.customer_id)::text)
+                                       Join Filter: (CASE WHEN (t_c_firstyear.year_total > '0'::numeric) THEN (t_c_secyear.year_total / t_c_firstyear.year_total) ELSE NULL::numeric END > CASE WHEN (t_s_firstyear.year_total > '0'::numeric) THEN (t_s_secyear.year_total / t_s_firstyear.year_total) ELSE NULL::numeric END)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                             ->  Hash Join
+                                                   Hash Cond: ((t_s_secyear.customer_id)::text = (t_c_secyear.customer_id)::text)
+                                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                         ->  Hash Join
+                                                               Hash Cond: ((t_s_secyear.customer_id)::text = (t_w_firstyear.customer_id)::text)
+                                                               ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                                     ->  Hash Join
+                                                                           Hash Cond: ((t_s_firstyear.customer_id)::text = (t_s_secyear.customer_id)::text)
+                                                                           ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                                                                                 ->  Subquery Scan on t_s_firstyear
+                                                                                       Filter: ((t_s_firstyear.year_total > '0'::numeric) AND (t_s_firstyear.sale_type = 's'::text) AND (t_s_firstyear.dyear = 2001))
+                                                                                       ->  Shared Scan (share slice:id 6:0)
+                                                                           ->  Hash
+                                                                                 ->  Subquery Scan on t_s_secyear
+                                                                                       Filter: ((t_s_secyear.sale_type = 's'::text) AND (t_s_secyear.dyear = 2002))
+                                                                                       ->  Shared Scan (share slice:id 5:0)
+                                                               ->  Hash
+                                                                     ->  Subquery Scan on t_w_firstyear
+                                                                           Filter: ((t_w_firstyear.year_total > '0'::numeric) AND (t_w_firstyear.sale_type = 'w'::text) AND (t_w_firstyear.dyear = 2001))
+                                                                           ->  Shared Scan (share slice:id 4:0)
+                                                   ->  Hash
                                                          ->  Subquery Scan on t_c_secyear
                                                                Filter: ((t_c_secyear.sale_type = 'c'::text) AND (t_c_secyear.dyear = 2002))
-                                                               ->  Shared Scan (share slice:id 5:0)
-                           ->  Hash
-                                 ->  Hash Join
-                                       Hash Cond: ((t_w_firstyear.customer_id)::text = (t_w_secyear.customer_id)::text)
-                                       ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                             Hash Key: t_w_firstyear.customer_id
-                                             ->  Subquery Scan on t_w_firstyear
-                                                   Filter: ((t_w_firstyear.year_total > '0'::numeric) AND (t_w_firstyear.sale_type = 'w'::text) AND (t_w_firstyear.dyear = 2001))
-                                                   ->  Shared Scan (share slice:id 6:0)
+                                                               ->  Shared Scan (share slice:id 3:0)
                                        ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice7; segments: 3)
-                                                   Hash Key: t_w_secyear.customer_id
-                                                   ->  Subquery Scan on t_w_secyear
-                                                         Filter: ((t_w_secyear.sale_type = 'w'::text) AND (t_w_secyear.dyear = 2002))
-                                                         ->  Shared Scan (share slice:id 7:0)
-                                                               ->  Append
-                                                                     ->  HashAggregate
-                                                                           Group Key: customer.c_customer_id, customer.c_first_name, customer.c_last_name, customer.c_preferred_cust_flag, customer.c_birth_country, customer.c_login, customer.c_email_address, date_dim.d_year
-                                                                           ->  Redistribute Motion 3:3  (slice8; segments: 3)
-                                                                                 Hash Key: customer.c_customer_id, customer.c_first_name, customer.c_last_name, customer.c_preferred_cust_flag, customer.c_birth_country, customer.c_login, customer.c_email_address, date_dim.d_year
-                                                                                 ->  Hash Join
-                                                                                       Hash Cond: (store_sales.ss_customer_sk = customer.c_customer_sk)
-                                                                                       ->  Hash Join
-                                                                                             Hash Cond: (store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-                                                                                             ->  Seq Scan on store_sales
-                                                                                             ->  Hash
-                                                                                                   ->  Broadcast Motion 3:3  (slice9; segments: 3)
-                                                                                                         ->  Seq Scan on date_dim
-                                                                                       ->  Hash
-                                                                                             ->  Broadcast Motion 3:3  (slice10; segments: 3)
-                                                                                                   ->  Seq Scan on customer
-                                                                     ->  HashAggregate
-                                                                           Group Key: customer_1.c_customer_id, customer_1.c_first_name, customer_1.c_last_name, customer_1.c_preferred_cust_flag, customer_1.c_birth_country, customer_1.c_login, customer_1.c_email_address, date_dim_1.d_year
-                                                                           ->  Redistribute Motion 3:3  (slice11; segments: 3)
-                                                                                 Hash Key: customer_1.c_customer_id, customer_1.c_first_name, customer_1.c_last_name, customer_1.c_preferred_cust_flag, customer_1.c_birth_country, customer_1.c_login, customer_1.c_email_address, date_dim_1.d_year
-                                                                                 ->  Hash Join
-                                                                                       Hash Cond: (catalog_sales.cs_bill_customer_sk = customer_1.c_customer_sk)
-                                                                                       ->  Hash Join
-                                                                                             Hash Cond: (catalog_sales.cs_sold_date_sk = date_dim_1.d_date_sk)
-                                                                                             ->  Seq Scan on catalog_sales
-                                                                                             ->  Hash
-                                                                                                   ->  Broadcast Motion 3:3  (slice12; segments: 3)
-                                                                                                         ->  Seq Scan on date_dim date_dim_1
-                                                                                       ->  Hash
-                                                                                             ->  Broadcast Motion 3:3  (slice13; segments: 3)
-                                                                                                   ->  Seq Scan on customer customer_1
-                                                                     ->  HashAggregate
-                                                                           Group Key: customer_2.c_customer_id, customer_2.c_first_name, customer_2.c_last_name, customer_2.c_preferred_cust_flag, customer_2.c_birth_country, customer_2.c_login, customer_2.c_email_address, date_dim_2.d_year
-                                                                           ->  Redistribute Motion 3:3  (slice14; segments: 3)
-                                                                                 Hash Key: customer_2.c_customer_id, customer_2.c_first_name, customer_2.c_last_name, customer_2.c_preferred_cust_flag, customer_2.c_birth_country, customer_2.c_login, customer_2.c_email_address, date_dim_2.d_year
-                                                                                 ->  Hash Join
-                                                                                       Hash Cond: (web_sales.ws_sold_date_sk = date_dim_2.d_date_sk)
-                                                                                       ->  Hash Join
-                                                                                             Hash Cond: (web_sales.ws_bill_customer_sk = customer_2.c_customer_sk)
-                                                                                             ->  Seq Scan on web_sales
-                                                                                             ->  Hash
-                                                                                                   ->  Broadcast Motion 3:3  (slice15; segments: 3)
-                                                                                                         ->  Seq Scan on customer customer_2
-                                                                                       ->  Hash
-                                                                                             ->  Broadcast Motion 3:3  (slice16; segments: 3)
-                                                                                                   ->  Seq Scan on date_dim date_dim_2
+                                             ->  Subquery Scan on t_c_firstyear
+                                                   Filter: ((t_c_firstyear.year_total > '0'::numeric) AND (t_c_firstyear.sale_type = 'c'::text) AND (t_c_firstyear.dyear = 2001))
+                                                   ->  Shared Scan (share slice:id 2:0)
+                           ->  Hash
+                                 ->  Subquery Scan on t_w_secyear
+                                       Filter: ((t_w_secyear.sale_type = 'w'::text) AND (t_w_secyear.dyear = 2002))
+                                       ->  Shared Scan (share slice:id 1:0)
+                                             ->  Append
+                                                   ->  HashAggregate
+                                                         Group Key: customer.c_customer_id, customer.c_first_name, customer.c_last_name, customer.c_preferred_cust_flag, customer.c_birth_country, customer.c_login, customer.c_email_address, date_dim.d_year
+                                                         Filter: ((sum(((((store_sales.ss_ext_list_price - store_sales.ss_ext_wholesale_cost) - store_sales.ss_ext_discount_amt) + store_sales.ss_ext_sales_price) / '2'::numeric)) > '0'::numeric) OR (date_dim.d_year = 2002))
+                                                         ->  Redistribute Motion 3:3  (slice7; segments: 3)
+                                                               Hash Key: customer.c_customer_id, customer.c_first_name, customer.c_last_name, customer.c_preferred_cust_flag, customer.c_birth_country, customer.c_login, customer.c_email_address, date_dim.d_year
+                                                               ->  Hash Join
+                                                                     Hash Cond: (store_sales.ss_customer_sk = customer.c_customer_sk)
+                                                                     ->  Redistribute Motion 3:3  (slice8; segments: 3)
+                                                                           Hash Key: store_sales.ss_customer_sk
+                                                                           ->  Hash Join
+                                                                                 Hash Cond: (store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+                                                                                 ->  Seq Scan on store_sales
+                                                                                 ->  Hash
+                                                                                       ->  Broadcast Motion 3:3  (slice9; segments: 3)
+                                                                                             ->  Seq Scan on date_dim
+                                                                                                   Filter: ((d_year = 2001) OR (d_year = 2002))
+                                                                     ->  Hash
+                                                                           ->  Seq Scan on customer
+                                                   ->  HashAggregate
+                                                         Group Key: customer_1.c_customer_id, customer_1.c_first_name, customer_1.c_last_name, customer_1.c_preferred_cust_flag, customer_1.c_birth_country, customer_1.c_login, customer_1.c_email_address, date_dim_1.d_year
+                                                         Filter: ((sum(((((catalog_sales.cs_ext_list_price - catalog_sales.cs_ext_wholesale_cost) - catalog_sales.cs_ext_discount_amt) + catalog_sales.cs_ext_sales_price) / '2'::numeric)) > '0'::numeric) OR (date_dim_1.d_year = 2002))
+                                                         ->  Redistribute Motion 3:3  (slice10; segments: 3)
+                                                               Hash Key: customer_1.c_customer_id, customer_1.c_first_name, customer_1.c_last_name, customer_1.c_preferred_cust_flag, customer_1.c_birth_country, customer_1.c_login, customer_1.c_email_address, date_dim_1.d_year
+                                                               ->  Hash Join
+                                                                     Hash Cond: (catalog_sales.cs_bill_customer_sk = customer_1.c_customer_sk)
+                                                                     ->  Redistribute Motion 3:3  (slice11; segments: 3)
+                                                                           Hash Key: catalog_sales.cs_bill_customer_sk
+                                                                           ->  Hash Join
+                                                                                 Hash Cond: (catalog_sales.cs_sold_date_sk = date_dim_1.d_date_sk)
+                                                                                 ->  Seq Scan on catalog_sales
+                                                                                 ->  Hash
+                                                                                       ->  Broadcast Motion 3:3  (slice12; segments: 3)
+                                                                                             ->  Seq Scan on date_dim date_dim_1
+                                                                                                   Filter: ((d_year = 2001) OR (d_year = 2002))
+                                                                     ->  Hash
+                                                                           ->  Seq Scan on customer customer_1
+                                                   ->  HashAggregate
+                                                         Group Key: customer_2.c_customer_id, customer_2.c_first_name, customer_2.c_last_name, customer_2.c_preferred_cust_flag, customer_2.c_birth_country, customer_2.c_login, customer_2.c_email_address, date_dim_2.d_year
+                                                         Filter: ((sum(((((web_sales.ws_ext_list_price - web_sales.ws_ext_wholesale_cost) - web_sales.ws_ext_discount_amt) + web_sales.ws_ext_sales_price) / '2'::numeric)) > '0'::numeric) OR (date_dim_2.d_year = 2002))
+                                                         ->  Redistribute Motion 3:3  (slice13; segments: 3)
+                                                               Hash Key: customer_2.c_customer_id, customer_2.c_first_name, customer_2.c_last_name, customer_2.c_preferred_cust_flag, customer_2.c_birth_country, customer_2.c_login, customer_2.c_email_address, date_dim_2.d_year
+                                                               ->  Hash Join
+                                                                     Hash Cond: (web_sales.ws_bill_customer_sk = customer_2.c_customer_sk)
+                                                                     ->  Redistribute Motion 3:3  (slice14; segments: 3)
+                                                                           Hash Key: web_sales.ws_bill_customer_sk
+                                                                           ->  Hash Join
+                                                                                 Hash Cond: (web_sales.ws_sold_date_sk = date_dim_2.d_date_sk)
+                                                                                 ->  Seq Scan on web_sales
+                                                                                 ->  Hash
+                                                                                       ->  Broadcast Motion 3:3  (slice15; segments: 3)
+                                                                                             ->  Seq Scan on date_dim date_dim_2
+                                                                                                   Filter: ((d_year = 2001) OR (d_year = 2002))
+                                                                     ->  Hash
+                                                                           ->  Seq Scan on customer customer_2
  Optimizer: Postgres query optimizer
-(99 rows)
+(102 rows)
 

--- a/src/test/singlenode_regress/expected/subselect.out
+++ b/src/test/singlenode_regress/expected/subselect.out
@@ -1687,8 +1687,9 @@ select * from x where f1 = 1;
          Output: share0_ref1.f1
          ->  Seq Scan on public.subselect_tbl
                Output: subselect_tbl.f1
+               Filter: (subselect_tbl.f1 = 1)
  Optimizer: Postgres query optimizer
-(8 rows)
+(10 rows)
 
 -- Stable functions are safe to inline
 explain (verbose, costs off)


### PR DESCRIPTION
# Materialized CTE (Shared Scan) OR predicate pushdown

This is optimization only **#1** optimization from #1762 — *CTE Predicate Pushdown via OR Collection and CNF
Conversion* — split out on its own and rebased onto current `main` (PG16 kernel).

Original work by @avamingli; reviewed in #1762 by @leborchuk and @yjhjstz.

## What it does

When a CTE is materialized as a Shared Scan, consumer predicates cannot be pushed into the
producer, so the producer materializes every row any consumer might need. Following the ORCA
paper §6.1, this collects the quals of all CTE references, ORs them together, converts the
result to CNF and pushes it into the producer. The original predicates stay on each consumer,
so results are unchanged.

```sql
WITH v AS (SELECT i_brand, i_color FROM item WHERE i_current_price < 50)
SELECT * FROM v v1, v v2
WHERE v1.i_brand = v2.i_brand AND v1.i_color = 'red' AND v2.i_color = 'blue';
```

The producer now also carries `(i_color = 'red' OR i_color = 'blue')`.

CNF conversion is `convert_expr_to_cnf_complete()` in `prepqual.c`; it removes duplicate and
subsumed clauses so the expression does not blow up:

```
(s = 's' AND year = 2001) OR (s = 's' AND year = 2002)
  =>  s = 's' AND (year = 2001 OR year = 2002)
```

## Commits

Commits 1–6 are every commit in #1762 that touches this optimization, kept separate rather
than squashed; 7–11 are new here:

| | upstream commit | subject |
|---|---|---|
| 1 | `7f13fc4fa53` | Materialized CTE (Shared Scan) OR predicate pushdown |
| 2 | `4f341ff07ee` | Fix conflicts from main branch |
| 3 | `b9ae0e452cb` | Fix logical errors in OR-clause simplification |
| 4 | `544e67029cd` | Fix literal-vs-OR subsumption in CNF deduplication |
| 5 | `5e4635efda0` | Rename vague pushdown functions for clarity |
| 6 | `d2bd38d2e82` | Positive side effect (Direct Dispatch) of push down Shared Scan quals |
| 7 | new | Do not push CTE quals down when a consumer needs all rows |
| 8 | new | Compute `sub_total_rows` unconditionally in `set_cte_pathlist()` |
| 9 | new | Do not push CTE quals down into a CTE with volatile functions |
| 10 | new | Update the pax and singlenode copies of `subselect.out` |
| 11 | new | Update `tpcds_q04` expected plan for the CTE qual pushdown |

Rebase to PG16 needed two adjustments: `pushdown_safety_info.unsafeColumns` is now
`unsafeFlags` (bitmask), and `distribute_qual_to_rels()` was rewritten upstream — the
original commit's disabling of `Assert(root->hasLateralRTEs)` is preserved on top of the new
code, since pushed-down CTE quals can land outside their syntactic scope with no LATERAL RTE.

**Commit 7** fixes a wrong-results bug: if one CTE reference has no pushdown-safe qual (it
needs every row), its branch is missing from the disjunction and the producer gets filtered by
the other references' quals. #1762 fixes this in `54930251e4c`, which otherwise belongs to
optimization #2; commit 7 ports just the guard. Before it, a two-reference query where one
reference is unfiltered returned 1000 rows instead of 2666; three references with one
unfiltered returned 0 instead of 334.

**Commit 8** silences a GCC 13 `may be used uninitialized` warning on `sub_total_rows`: the
dummy-rel case is now handled before the loop instead of being skipped inside it. No
behaviour change.

**Commit 9** applies to the shared path the rule the inlined path already had: do not push
quals into a CTE containing volatile functions. Without it,

```sql
WITH x AS (SELECT a, nextval('ts') FROM vol_test) SELECT * FROM x WHERE a = 3
```

evaluated `nextval()` only for the matching row instead of once per row of `vol_test`, so the
value of the CTE's `nextval` column changed.

### Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
