### PR TITLE
Fix two crashes/wrong-answer bugs in the gp_percentile_* transition functions (in REL_2_STABLE)

### DIFF
--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -1516,6 +1516,17 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 	int64        first_row;
 	int64        second_row;
 
+	/*
+	 * Note: 'proargtypes' for this function in pg_proc.dat has 4 arguments.
+	 * There are actually 5 arguments coming in here - the result of the
+	 * previous call and 4 main arguments.
+	 */
+	if (PG_NARGS() != 5)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("wrong number of arguments to gp_percentile_cont_transition()"),
+				 errhint("expected 5, got %d", PG_NARGS())));
+
 	/* Return state for NULL inputs of val*/
 	if (PG_ARGISNULL(1) && !PG_ARGISNULL(0))
 		PG_RETURN_DATUM(PG_GETARG_DATUM(0));
@@ -1618,6 +1629,17 @@ Datum
 gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 {
 	int64        rownum;
+
+	/*
+	 * Note: 'proargtypes' for this function in pg_proc.dat has 4 arguments.
+	 * There are actually 5 arguments coming in here - the result of the
+	 * previous call and 4 main arguments.
+	 */
+	if (PG_NARGS() != 5)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("wrong number of arguments to gp_percentile_disc_transition()"),
+				 errhint("expected 5, got %d", PG_NARGS())));
 
 	/* Return state for NULL inputs of val*/
 	if (PG_ARGISNULL(1) && !PG_ARGISNULL(0))

--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -1573,6 +1573,17 @@ gp_percentile_cont_transition(FunctionCallInfo fcinfo,
 	{
 		return_state = lerpfunc(prev_state, val, proportion);
 	}
+	else if (PG_ARGISNULL(0))
+	{
+		/*
+		 * Neither of the rows we are after landed in this peer group, so we
+		 * hand the previous state back unchanged.  When that state is NULL
+		 * the isnull flag has to travel with it: returning a bare Datum(0)
+		 * as non-NULL gives wrong answers for by-value types and a NULL
+		 * pointer dereference for by-reference ones.
+		 */
+		fcinfo->isnull = true;
+	}
 	*cnt = *cnt + peer_count;
 
 	if(*cnt > total_rows)
@@ -1656,7 +1667,6 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 				 errmsg("percentile value %g is not between 0 and 1",
 						percentile)));
 	Datum prev_state = PG_GETARG_DATUM(0);
-	bool prev_state_isnull = PG_ARGISNULL(0);
 	Datum val = PG_GETARG_DATUM(1);
 	Datum return_state = prev_state;
 	int64 total_rows = PG_GETARG_INT64(3);
@@ -1681,6 +1691,11 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 	{
 		return_state = val;
 	}
+	else if (PG_ARGISNULL(0))
+	{
+		/* see gp_percentile_cont_transition() */
+		fcinfo->isnull = true;
+	}
 
 	*cnt = *cnt + peer_count;
 
@@ -1689,10 +1704,6 @@ gp_percentile_disc_transition(PG_FUNCTION_ARGS)
 		/* Clean up, so the next group can see NULL for fn_extra */
 		pfree(cnt);
 		fcinfo->flinfo->fn_extra = NULL;
-	}
-
-	if (return_state == prev_state) {
-		fcinfo->isnull = prev_state_isnull;
 	}
 
 	PG_RETURN_DATUM(return_state);

--- a/src/test/regress/expected/percentile.out
+++ b/src/test/regress/expected/percentile.out
@@ -876,6 +876,30 @@ group by d1, d2;
      55 |     1
 (1 row)
 
+--
+-- gp_percentile_cont()/gp_percentile_disc() are the split ordered-set
+-- aggregates that ORCA rewrites percentile_cont()/percentile_disc()/median()
+-- into.  Their transition functions carry the running state on top of the
+-- four aggregate arguments, so they read five arguments, while pg_proc.dat
+-- describes four.  That is left alone here so as not to force an initdb on a
+-- stable branch; instead a direct call, which would read past the end of the
+-- argument array, is rejected.
+--
+select gp_percentile_cont_float8_transition(NULL::float8, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
+select gp_percentile_cont_interval_transition(NULL::interval, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
+select gp_percentile_cont_timestamp_transition(NULL::timestamp, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
+select gp_percentile_cont_timestamptz_transition(NULL::timestamptz, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_cont_transition()
+HINT:  expected 5, got 4
+select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
+ERROR:  wrong number of arguments to gp_percentile_disc_transition()
+HINT:  expected 5, got 4
 drop view percv2;
 drop view percv;
 drop table perct;

--- a/src/test/regress/expected/percentile.out
+++ b/src/test/regress/expected/percentile.out
@@ -900,6 +900,76 @@ HINT:  expected 5, got 4
 select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
 ERROR:  wrong number of arguments to gp_percentile_disc_transition()
 HINT:  expected 5, got 4
+-- On an empty input set the transition state stays NULL.  The transition
+-- functions hand that state back untouched and have to keep its isnull flag
+-- with it: a bare Datum(0) escaping here reads as a bogus value for by-value
+-- types and dereferences a NULL pointer for by-reference ones.
+select gp_percentile_cont(0::float8, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+                   
+(1 row)
+
+select gp_percentile_cont('0 hour'::interval, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+ 
+(1 row)
+
+select gp_percentile_cont('2006-01-01 13:10:13'::timestamp, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+ 
+(1 row)
+
+select gp_percentile_cont('2006-01-01 13:10:13+00'::timestamptz, 0, 0, 0);
+ gp_percentile_cont 
+--------------------
+ 
+(1 row)
+
+select gp_percentile_disc(0::numeric, 0, 0, 0);
+ gp_percentile_disc 
+--------------------
+                   
+(1 row)
+
+-- A value that really was picked has to come back, even when its Datum
+-- representation happens to be 0.
+select gp_percentile_disc(0::float8, 0, 1, 1);
+ gp_percentile_disc 
+--------------------
+                  0
+(1 row)
+
+select gp_percentile_disc(0::int, 0, 1, 1);
+ gp_percentile_disc 
+--------------------
+                  0
+(1 row)
+
+select gp_percentile_cont(0::float8, 0, 1, 1);
+ gp_percentile_cont 
+--------------------
+                  0
+(1 row)
+
+-- The same, end to end: the smallest value of b is 0.
+create table perczero (a int, b float8) distributed by (a);
+insert into perczero select i, (i - 1)::float8 from generate_series(1, 10) i;
+select percentile_disc(0) within group (order by b) from perczero;
+ percentile_disc 
+-----------------
+               0
+(1 row)
+
+select percentile_cont(0) within group (order by b) from perczero;
+ percentile_cont 
+-----------------
+               0
+(1 row)
+
+drop table perczero;
 drop view percv2;
 drop view percv;
 drop table perct;

--- a/src/test/regress/sql/percentile.sql
+++ b/src/test/regress/sql/percentile.sql
@@ -216,6 +216,20 @@ from  mpp_22413
 where d2 ='55'
 group by d1, d2;
 
+--
+-- gp_percentile_cont()/gp_percentile_disc() are the split ordered-set
+-- aggregates that ORCA rewrites percentile_cont()/percentile_disc()/median()
+-- into.  Their transition functions carry the running state on top of the
+-- four aggregate arguments, so they read five arguments, while pg_proc.dat
+-- describes four.  That is left alone here so as not to force an initdb on a
+-- stable branch; instead a direct call, which would read past the end of the
+-- argument array, is rejected.
+--
+select gp_percentile_cont_float8_transition(NULL::float8, 1, 1, 1);
+select gp_percentile_cont_interval_transition(NULL::interval, 1, 1, 1);
+select gp_percentile_cont_timestamp_transition(NULL::timestamp, 1, 1, 1);
+select gp_percentile_cont_timestamptz_transition(NULL::timestamptz, 1, 1, 1);
+select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
 drop view percv2;
 drop view percv;
 drop table perct;

--- a/src/test/regress/sql/percentile.sql
+++ b/src/test/regress/sql/percentile.sql
@@ -230,6 +230,26 @@ select gp_percentile_cont_interval_transition(NULL::interval, 1, 1, 1);
 select gp_percentile_cont_timestamp_transition(NULL::timestamp, 1, 1, 1);
 select gp_percentile_cont_timestamptz_transition(NULL::timestamptz, 1, 1, 1);
 select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
+-- On an empty input set the transition state stays NULL.  The transition
+-- functions hand that state back untouched and have to keep its isnull flag
+-- with it: a bare Datum(0) escaping here reads as a bogus value for by-value
+-- types and dereferences a NULL pointer for by-reference ones.
+select gp_percentile_cont(0::float8, 0, 0, 0);
+select gp_percentile_cont('0 hour'::interval, 0, 0, 0);
+select gp_percentile_cont('2006-01-01 13:10:13'::timestamp, 0, 0, 0);
+select gp_percentile_cont('2006-01-01 13:10:13+00'::timestamptz, 0, 0, 0);
+select gp_percentile_disc(0::numeric, 0, 0, 0);
+-- A value that really was picked has to come back, even when its Datum
+-- representation happens to be 0.
+select gp_percentile_disc(0::float8, 0, 1, 1);
+select gp_percentile_disc(0::int, 0, 1, 1);
+select gp_percentile_cont(0::float8, 0, 1, 1);
+-- The same, end to end: the smallest value of b is 0.
+create table perczero (a int, b float8) distributed by (a);
+insert into perczero select i, (i - 1)::float8 from generate_series(1, 10) i;
+select percentile_disc(0) within group (order by b) from perczero;
+select percentile_cont(0) within group (order by b) from perczero;
+drop table perczero;
 drop view percv2;
 drop view percv;
 drop table perct;


### PR DESCRIPTION
gp_percentile_cont() / gp_percentile_disc() are the split ordered-set
aggregates ORCA rewrites percentile_cont(), percentile_disc() and median()
into. Two bugs in their transition functions. Only the ORCA path reaches
these aggregates on its own, so percentile_* WITHIN GROUP on the Postgres
planner is unaffected.

1. Direct SQL calls read past the end of the argument array (2f409c8)

The transition functions read five arguments in C (state + the four
aggregate arguments), but pg_proc.dat declares four. As transition
functions they are called correctly; a direct SQL call makes
PG_GETARG_INT64(4) pick up garbage — wrong results, an assertion on
pfree(NULL), or a segfault.

Fixing the declaration would force an initdb, which is not acceptable on a
stable branch, so the argument count is checked and a plain error is
raised. Direct calls were never useful.

2. The isnull flag is lost when the previous state is returned (8251c47)

When the current row isn't one the percentile is computed from, the
previous state is handed back untouched. On the first call that state is
NULL, and returning a bare Datum(0) with isnull false drops the flag: 0
instead of NULL for by-value types, a NULL pointer dereference for
by-reference ones — an empty input set crashed the backend for interval,
timestamp and timestamptz.

Both ported from Greengage [477b04a](https://github.com/GreengageDB/greengage/commit/477b04a) (ADBDEV-7770)

The bug reproduction:

```
-- Bug 1: pg_proc.dat declares four arguments, the code reads five
select gp_percentile_disc_transition(NULL::numeric, 1, 1, 1);
-- before: server closed the connection unexpectedly
-- after:  ERROR:  wrong number of arguments to gp_percentile_disc_transition()
--         HINT:  expected 5, got 4

-- Bug 2, by-value: silently wrong answer
select gp_percentile_cont(0::float8, 0, 0, 0);             -- 0, expecting NULL
-- Bug 2, by-reference: backend crash
select gp_percentile_cont('0 hour'::interval, 0, 0, 0);    -- server closed the connection
-- Bug 2, the 6c289ad regression: a selected value whose Datum is 0 turns into NULL
select gp_percentile_disc(0::float8, 0, 1, 1);             -- NULL, expecting 0
select gp_percentile_disc(0::int,    0, 1, 1);             -- NULL, expecting 0

-- The same, end to end: ORCA and the Postgres planner disagree
create table perczero (a int, b float8) distributed by (a);
insert into perczero select i, (i - 1)::float8 from generate_series(1, 10) i;
select percentile_disc(0) within group (order by b) from perczero;  -- NULL
set optimizer = off;
select percentile_disc(0) within group (order by b) from perczero;  -- 0
```

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [x] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
