### PR TITLE
Fix ORCA GbAgg drop for nullable UNIQUE keys

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformSimplifyGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSimplifyGbAgg.cpp
@@ -101,6 +101,10 @@ CXformSimplifyGbAgg::FDropGbAgg(CMemoryPool *mp, CExpression *pexpr,
 		return false;
 	}
 
+	// A UNIQUE key permits multiple NULLs (NULL is never "equal" for uniqueness
+	// checks), but DISTINCT/GROUP BY must still collapse them into one row.
+	// Only drop the GbAgg when every key column is also provably NOT NULL.
+	CColRefSet *pcrsNotNull = pexprRelational->DeriveNotNullColumns();
 	const ULONG ulKeys = pkc->Keys();
 	BOOL fDrop = false;
 	for (ULONG ul = 0; !fDrop && ul < ulKeys; ul++)
@@ -111,7 +115,8 @@ CXformSimplifyGbAgg::FDropGbAgg(CMemoryPool *mp, CExpression *pexpr,
 
 		CColRefSet *pcrsGrpCols = GPOS_NEW(mp) CColRefSet(mp);
 		pcrsGrpCols->Include(popAgg->Pdrgpcr());
-		BOOL fGrpColsHasKey = pcrsGrpCols->ContainsAll(pcrs);
+		BOOL fGrpColsHasKey =
+			pcrsGrpCols->ContainsAll(pcrs) && pcrsNotNull->ContainsAll(pcrs);
 
 		pcrs->Release();
 		pcrsGrpCols->Release();

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -2172,6 +2172,75 @@ commit;
 ERROR:  duplicate key value violates unique constraint "t3_pkey"  (seg1 127.0.0.1:7003 pid=86457)
 DETAIL:  Key (a, b)=(1, 1) already exists.
 drop table  t1, t2, t3, t4, t5, t6;
+-- Test NULLs in a UNIQUE key column. A UNIQUE constraint allows multiple NULLs
+-- (NULL is never "equal" for uniqueness checks), but grouping columns that
+-- cover such a key must still collapse those NULLs into a single row, so
+-- dropping the GbAgg is only safe when every key column is also NOT NULL.
+drop table if exists t7, t8, t9;
+NOTICE:  table "t7" does not exist, skipping
+NOTICE:  table "t8" does not exist, skipping
+NOTICE:  table "t9" does not exist, skipping
+create table t7 (a int unique, b int);
+create table t8 (a int unique not null, b int);
+create table t9 (a int primary key, b int);
+insert into t7 values (1, 1), (2, 2), (null, 3), (null, 4), (null, 5);
+insert into t8 values (1, 1), (2, 2), (3, 3);
+insert into t9 values (1, 1), (2, 2), (3, 3);
+explain (costs off) select distinct a from t7;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a
+         ->  Seq Scan on t7
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select distinct a from t7 order by a;
+ a 
+---
+ 1
+ 2
+  
+(3 rows)
+
+explain (costs off) select distinct a from t8;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a
+         ->  Seq Scan on t8
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select distinct a from t8 order by a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+explain (costs off) select distinct a from t9;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a
+         ->  Seq Scan on t9
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select distinct a from t9 order by a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+drop table t7, t8, t9;
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -2139,9 +2139,11 @@ explain (costs off) select * from t4 group by a, b, c;
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: a, b, c
    ->  Seq Scan on t4
  Optimizer: Pivotal Optimizer (GPORCA)
-(3 rows)
+(5 rows)
 
 explain (costs off) select * from t5 group by a, b, c;
                 QUERY PLAN                
@@ -2193,6 +2195,71 @@ commit;
 ERROR:  duplicate key value violates unique constraint "t3_pkey"  (seg1 127.0.0.1:7003 pid=89310)
 DETAIL:  Key (a, b)=(1, 1) already exists.
 drop table  t1, t2, t3, t4, t5, t6;
+-- Test NULLs in a UNIQUE key column. A UNIQUE constraint allows multiple NULLs
+-- (NULL is never "equal" for uniqueness checks), but grouping columns that
+-- cover such a key must still collapse those NULLs into a single row, so
+-- dropping the GbAgg is only safe when every key column is also NOT NULL.
+drop table if exists t7, t8, t9;
+NOTICE:  table "t7" does not exist, skipping
+NOTICE:  table "t8" does not exist, skipping
+NOTICE:  table "t9" does not exist, skipping
+create table t7 (a int unique, b int);
+create table t8 (a int unique not null, b int);
+create table t9 (a int primary key, b int);
+insert into t7 values (1, 1), (2, 2), (null, 3), (null, 4), (null, 5);
+insert into t8 values (1, 1), (2, 2), (3, 3);
+insert into t9 values (1, 1), (2, 2), (3, 3);
+explain (costs off) select distinct a from t7;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: a
+         ->  Seq Scan on t7
+ Optimizer: GPORCA
+(5 rows)
+
+select distinct a from t7 order by a;
+ a 
+---
+ 1
+ 2
+  
+(3 rows)
+
+explain (costs off) select distinct a from t8;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t8
+ Optimizer: GPORCA
+(3 rows)
+
+select distinct a from t8 order by a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+explain (costs off) select distinct a from t9;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t9
+ Optimizer: GPORCA
+(3 rows)
+
+select distinct a from t9 order by a;
+ a 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+drop table t7, t8, t9;
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1555,6 +1555,31 @@ commit;
 
 drop table  t1, t2, t3, t4, t5, t6;
 
+-- Test NULLs in a UNIQUE key column. A UNIQUE constraint allows multiple NULLs
+-- (NULL is never "equal" for uniqueness checks), but grouping columns that
+-- cover such a key must still collapse those NULLs into a single row, so
+-- dropping the GbAgg is only safe when every key column is also NOT NULL.
+
+drop table if exists t7, t8, t9;
+create table t7 (a int unique, b int);
+create table t8 (a int unique not null, b int);
+create table t9 (a int primary key, b int);
+
+insert into t7 values (1, 1), (2, 2), (null, 3), (null, 4), (null, 5);
+insert into t8 values (1, 1), (2, 2), (3, 3);
+insert into t9 values (1, 1), (2, 2), (3, 3);
+
+explain (costs off) select distinct a from t7;
+select distinct a from t7 order by a;
+
+explain (costs off) select distinct a from t8;
+select distinct a from t8 order by a;
+
+explain (costs off) select distinct a from t9;
+select distinct a from t9 order by a;
+
+drop table t7, t8, t9;
+
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;


### PR DESCRIPTION
CXformSimplifyGbAgg::FDropGbAgg() drops a GROUP BY/DISTINCT's aggregate node when the grouping columns cover a key derived from a UNIQUE or PRIMARY KEY constraint, assuming the key already guarantees one row per value.

That's wrong for a plain UNIQUE column: SQL allows multiple NULLs in it (NULL is never "equal" for uniqueness checks), but dedup must still collapse those NULLs into one row.

Before:
    create table repro (c0 numeric unique);
    insert into repro values (1), (2), (null), (null), (null);
    explain (costs off) select distinct c0 from repro;
      Gather Motion 3:1  (slice1; segments: 3)
        ->  Seq Scan on repro          -- no aggregate, all 5 rows returned

After:
      Gather Motion 3:1  (slice1; segments: 3)
        ->  GroupAggregate
              Group Key: repro.c0
              ->  Seq Scan on repro    -- correctly returns 1, 2, NULL

Fix by also requiring every key column to be provably NOT NULL (CExpression::DeriveNotNullColumns()) before dropping the aggregate. PRIMARY KEY columns are always NOT NULL, so that case is unaffected.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
