### PR TITLE
Fix AO storage reloptions causing spurious TOAST wraparound vacuums

### DIFF
--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2957,6 +2957,16 @@ extract_autovac_opts(HeapTuple tup, TupleDesc pg_class_desc)
 		relam != AO_COLUMN_TABLE_AM_OID)
 		return NULL;
 
+	/*
+	 * AO reloptions use RELOPT_KIND_APPENDOPTIMIZED which does not include
+	 * autovacuum reloptions, so the embedded AutoVacOpts is zero-filled.
+	 * Returning it would make TOAST inherit freeze_max_age=0, triggering
+	 * spurious aggressive wraparound vacuums.  AO auxiliary and TOAST
+	 * relations use the heap AM, so they are unaffected by this guard.
+	 */
+	if (IsAccessMethodAO(relam))
+		return NULL;
+
 	relopts = extractRelOptions(tup, pg_class_desc, tam->amoptions);
 	if (relopts == NULL)
 		return NULL;

--- a/src/test/regress/expected/ao_relopts_autovacuum.out
+++ b/src/test/regress/expected/ao_relopts_autovacuum.out
@@ -1,0 +1,44 @@
+-- AO storage reloptions must not produce zeroed autovacuum options
+-- that get inherited by the TOAST relation.
+CREATE SCHEMA ao_relopts_av_test;
+SET search_path = ao_relopts_av_test;
+CREATE TABLE ao_row_with_storage_opts
+(
+    id integer,
+    payload text
+)
+WITH
+(
+    appendonly=true,
+    orientation=row,
+    compresstype=zlib,
+    compresslevel=1,
+    checksum=true
+)
+DISTRIBUTED RANDOMLY;
+INSERT INTO ao_row_with_storage_opts VALUES (1, repeat('x', 10000));
+-- Parent has only storage reloptions.
+SELECT option_name, option_value
+FROM pg_options_to_table(
+    (SELECT reloptions FROM pg_class
+     WHERE oid = 'ao_row_with_storage_opts'::regclass))
+ORDER BY option_name;
+  option_name  | option_value 
+---------------+--------------
+ checksum      | true
+ compresslevel | 1
+ compresstype  | zlib
+(3 rows)
+
+-- TOAST has no reloptions of its own.
+SELECT t.reloptions IS NULL AS toast_no_reloptions
+FROM pg_class c
+JOIN pg_class t ON t.oid = c.reltoastrelid
+WHERE c.oid = 'ao_row_with_storage_opts'::regclass;
+ toast_no_reloptions 
+---------------------
+ t
+(1 row)
+
+DROP SCHEMA ao_relopts_av_test CASCADE;
+NOTICE:  drop cascades to table ao_row_with_storage_opts

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -21,6 +21,7 @@
 test: autovacuum
 test: autovacuum-segment
 test: autovacuum-template0-segment
+test: ao_relopts_autovacuum
 
 # check profile feature
 test: profile

--- a/src/test/regress/sql/ao_relopts_autovacuum.sql
+++ b/src/test/regress/sql/ao_relopts_autovacuum.sql
@@ -1,0 +1,37 @@
+-- AO storage reloptions must not produce zeroed autovacuum options
+-- that get inherited by the TOAST relation.
+
+CREATE SCHEMA ao_relopts_av_test;
+SET search_path = ao_relopts_av_test;
+
+CREATE TABLE ao_row_with_storage_opts
+(
+    id integer,
+    payload text
+)
+WITH
+(
+    appendonly=true,
+    orientation=row,
+    compresstype=zlib,
+    compresslevel=1,
+    checksum=true
+)
+DISTRIBUTED RANDOMLY;
+
+INSERT INTO ao_row_with_storage_opts VALUES (1, repeat('x', 10000));
+
+-- Parent has only storage reloptions.
+SELECT option_name, option_value
+FROM pg_options_to_table(
+    (SELECT reloptions FROM pg_class
+     WHERE oid = 'ao_row_with_storage_opts'::regclass))
+ORDER BY option_name;
+
+-- TOAST has no reloptions of its own.
+SELECT t.reloptions IS NULL AS toast_no_reloptions
+FROM pg_class c
+JOIN pg_class t ON t.oid = c.reltoastrelid
+WHERE c.oid = 'ao_row_with_storage_opts'::regclass;
+
+DROP SCHEMA ao_relopts_av_test CASCADE;


### PR DESCRIPTION
AO tables with storage reloptions (compresstype, compresslevel, checksum, blocksize) had their embedded AutoVacOpts zero-filled by palloc0() because autovacuum reloptions are not registered for RELOPT_KIND_APPENDOPTIMIZED. These zero values were inherited by TOAST relations via extract_autovac_opts(), causing freeze_max_age=0 which causing problems like issue #1915

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
