### PR TITLE
Fix invalid escape sequences in gpMgmt Python sources

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -717,7 +717,7 @@ def quote_unident(val):
 
 def match_notice_obj(notice):
     # match the formatting errors in notice
-    r = re.compile("^NOTICE:  found (\d+) data formatting errors.*")
+    r = re.compile(r"^NOTICE:  found (\d+) data formatting errors.*")
     m = r.match(notice)
     if m:
         return int(m.group(1))
@@ -2527,7 +2527,7 @@ WHERE relname = 'staging_gpload_reusable_%s';""" % (encoding_conditions)
         # should not explicitly specify the DISTRIBUTED BY clause.
         # Only the DISTRIBUTED BY clause can take effect if all selected fields 
         # exist in the CREATE TABLE statement.
-        dist_column_list = re.match(".*\((.*)\).*", distcols).group(1).split(",")
+        dist_column_list = re.match(r".*\((.*)\).*", distcols).group(1).split(",")
         target_column_set = set(element[0] for element in target_columns)
         if set(dist_column_list) <= target_column_set:
             quoted_dist_column = convertListToDelimited(dist_column_list)
@@ -2672,7 +2672,7 @@ WHERE relname = 'staging_gpload_reusable_%s';""" % (encoding_conditions)
             #
             update_condition = ' ' + update_condition + ' '
             for name, colType, mapto, seq in self.into_columns:
-                regexp = '(?<=[^\w])%s(?=[^\w])' % name
+                regexp = r'(?<=[^\w])%s(?=[^\w])' % name
                 self.log(self.DEBUG, 'update_condition re: ' + regexp)
                 temp_update_condition = update_condition
                 updateConditionList = splitIntoLiteralsAndNonLiterals(update_condition)
@@ -2686,7 +2686,7 @@ WHERE relname = 'staging_gpload_reusable_%s';""" % (encoding_conditions)
                 if update_condition == temp_update_condition:
                    # see if column can be undelimited, and try again.
                    if len(name) > 2 and name[1:-1] == name[1:-1].lower():
-                      regexp = '(?<=[^\w])%s(?=[^\w])' % name[1:-1]
+                      regexp = r'(?<=[^\w])%s(?=[^\w])' % name[1:-1]
                       self.log(self.DEBUG, 'update_condition undelimited re: ' + regexp)
                       update_condition = re.sub( regexp
                                                , self.fix_update_cond

--- a/gpMgmt/bin/gpload_test/gpload/TEST.py
+++ b/gpMgmt/bin/gpload_test/gpload/TEST.py
@@ -319,20 +319,20 @@ def modify_sql_file(num):
     if os.path.isfile(file):
         for line in fileinput.FileInput(file,inplace=1):
             if platform.system() in ['Windows', 'Microsoft']:
-                line = line.replace("\!gpload ","\!gpload.py")
+                line = line.replace(r"\!gpload ",r"\!gpload.py")
                 line = line.replace("gpload ","gpload.py ")
             else:
                 line = line.replace("gpload.py ","gpload ")
             # using absolute path
             line = re.sub('-h WinnBook.local', '-h '+get_hostname(), line)
             line = line.replace("-h localhost",'-h '+get_hostname())
-            line = re.sub('-p \d+', '-p '+get_port(), line)
+            line = re.sub(r'-p \d+', '-p '+get_port(), line)
             line = re.sub('-p$', '-p '+get_port(), line)
-            line = re.sub('-h (\d+)\.(\d+)\.(\d+)\.(\d+)', '-h '+get_hostname(), line)
+            line = re.sub(r'-h (\d+)\.(\d+)\.(\d+)\.(\d+)', '-h '+get_hostname(), line)
             if num == 12 or num == 13 or num == 14 or num == 15 or num == 176:
-                line = re.sub('-U \w+', '-U fake_user', line)
+                line = re.sub(r'-U \w+', '-U fake_user', line)
             else:
-                line = re.sub('-U \w+', '-U '+user, line)
+                line = re.sub(r'-U \w+', '-U '+user, line)
             print((str(re.sub('\n','',line))))
 
 def windows_path(command):
@@ -350,9 +350,9 @@ def get_port():
     if os.path.isfile(file):
         f = open(file)
         for line in f:
-            match = re.search('port=\d+',line)
+            match = re.search(r'port=\d+',line)
             if match:
-                match1 = re.search('\d+', match.group())
+                match1 = re.search(r'\d+', match.group())
                 if match1:
                     return match1.group()
         f.close()
@@ -407,7 +407,7 @@ class GPLoad_Env_TestCase(unittest.TestCase):
         "0  gpload setup"
         for num in range(1,6):
            f = open(mkpath('query%d.sql' % num),'w')
-           f.write("\! gpload -f "+mkpath('config/config_file')+ " -d gptest")
+           f.write(r"\! gpload -f "+mkpath('config/config_file')+ " -d gptest")
            f.close()
 
     def testQuery01(self):

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -294,14 +294,14 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "gparray": self.three_failedover_segs_gparray_str,
                 "new_hosts": ['new_1', 'new_2'],
                 "unreachable_hosts": ['new_1', 'new_2'],
-                "expected": "Cannot recover. The following recovery target hosts are unreachable: \['new_1', 'new_2'\]"
+                "expected": r"Cannot recover. The following recovery target hosts are unreachable: \['new_1', 'new_2'\]"
             },
             {
                 "name": "some_hosts_unreachable",
                 "gparray": self.three_failedover_segs_gparray_str,
                 "new_hosts": ['new_1', 'new_2'],
                 "unreachable_hosts": ['new_2'],
-                "expected": "Cannot recover. The following recovery target hosts are unreachable: \['new_2'\]"
+                "expected": r"Cannot recover. The following recovery target hosts are unreachable: \['new_2'\]"
             },
             {
                 "name": "no_peer_for_failed_seg",
@@ -329,7 +329,7 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "gparray": self.three_failedover_segs_gparray_str,
                 "new_hosts": ['new_1','new_2'],
                 "unreachable_existing_hosts": ['sdw2'],
-                "expected": "The recovery source segment sdw2 \(content 0\) is unreachable"
+                "expected": r"The recovery source segment sdw2 \(content 0\) is unreachable"
             },
             {
             "name": "failed_and_live_same_dbid",

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_database_segment_guc.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_database_segment_guc.py
@@ -23,6 +23,6 @@ class DatabaseSegmentGucTest(GpTestCase):
 
     def test_init_with_insufficient_database_values_raises(self):
         row = ['contentid', 'guc_name']
-        with self.assertRaisesRegex(Exception, "must provide \['context', 'guc name', 'value'\]"):
+        with self.assertRaisesRegex(Exception, r"must provide \['context', 'guc name', 'value'\]"):
             DatabaseSegmentGuc(row)
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_file_segment_guc.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_file_segment_guc.py
@@ -28,7 +28,7 @@ class FileSegmentGucTest(GpTestCase):
 
     def test_init_with_insufficient_file_values_raises(self):
         row = ['contentid', 'guc_name', 'value_from_file']
-        with self.assertRaisesRegex(Exception, "must provide \['context', 'guc name', 'value', 'dbid'\]"):
+        with self.assertRaisesRegex(Exception, r"must provide \['context', 'guc name', 'value', 'dbid'\]"):
             FileSegmentGuc(row)
 
     def test_when_coordinator_when_integer_dbid_report_success_format_file(self):

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gppkg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gppkg.py
@@ -69,7 +69,7 @@ class GpPkgProgramTestCase(GpTestCase):
         options, args = parser.parse_args()
         self.subject = GpPkgProgram(options, args)
         with self.assertRaisesRegex(Exception, "Remove request 'sampl' too broad. "
-                                                "Multiple packages match remove request: \( sample.gppkg, sample2.gppkg \)."):
+                                                r"Multiple packages match remove request: \( sample.gppkg, sample2.gppkg \)."):
             self.subject.run()
 
         self.assertFalse(self.mock_uninstall_package.run.called)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -301,7 +301,7 @@ class SegRecoveryTestCase(GpTestCase):
         self.assertEqual(1, mock_pgrewind_init.call_count)
         self.assertEqual(1, mock_pgbasebackup_run.call_count)
         self.assertEqual(1, mock_pgbasebackup_init.call_count)
-        self.assertRegex(gplog.get_logfile(), '/gpsegrecovery.py_\d+\.log')
+        self.assertRegex(gplog.get_logfile(), r'/gpsegrecovery.py_\d+\.log')
 
     @patch('gppylib.commands.pg.PgRewind.__init__', return_value=None)
     @patch('gppylib.commands.pg.PgRewind.run')
@@ -330,7 +330,7 @@ class SegRecoveryTestCase(GpTestCase):
         self.assertEqual(1, mock_pgrewind_init.call_count)
         self.assertEqual(2, mock_pgbasebackup_run.call_count)
         self.assertEqual(2, mock_pgbasebackup_init.call_count)
-        self.assertRegex(gplog.get_logfile(), '/gpsegrecovery.py_\d+\.log')
+        self.assertRegex(gplog.get_logfile(), r'/gpsegrecovery.py_\d+\.log')
 
     @patch('recovery_base.gplog.setup_tool_logging')
     @patch('recovery_base.RecoveryBase.main')

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
@@ -259,7 +259,7 @@ class SegSetupRecoveryTestCase(GpTestCase):
         mock_connect.assert_called_once()
         mock_execsql.assert_called_once()
         #TODO use regex pattern
-        self.assertRegex(gplog.get_logfile(), '/gpsegsetuprecovery.py_\d+\.log')
+        self.assertRegex(gplog.get_logfile(), r'/gpsegsetuprecovery.py_\d+\.log')
 
     @patch('gpsegsetuprecovery.ValidationForFullRecovery.validate_failover_data_directory')
     @patch('gpsegsetuprecovery.dbconn.connect')
@@ -284,7 +284,7 @@ class SegSetupRecoveryTestCase(GpTestCase):
         mock_validate_datadir.assert_called_once()
         mock_dburl.assert_called_once()
         mock_connect.assert_called_once()
-        self.assertRegex(gplog.get_logfile(), '/gpsegsetuprecovery.py_\d+\.log')
+        self.assertRegex(gplog.get_logfile(), r'/gpsegsetuprecovery.py_\d+\.log')
 
 
     @patch('recovery_base.gplog.setup_tool_logging')

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_package.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_package.py
@@ -119,7 +119,7 @@ class MigratePackagesTestCase(GpTestCase):
         self.args['to_gphome'] = '/wrong/gphome'
         subject = MigratePackages(**self.args)
 
-        expected_raise = "The target GPHOME, %s, must match the current \$GPHOME used to launch gppkg." % self.args['to_gphome']
+        expected_raise = r"The target GPHOME, %s, must match the current \$GPHOME used to launch gppkg." % self.args['to_gphome']
         with self.assertRaisesRegex(ExceptionNoStackTraceNeeded, expected_raise):
             subject.execute()
 

--- a/gpMgmt/bin/gppylib/util/ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/ssh_utils.py
@@ -265,7 +265,7 @@ class Session(cmd.Cmd):
         pass
 
     def escapeLine(self, line):
-        '''Escape occurrences of \ and $ as needed and package the line as an "eval" shell command'''
+        r'''Escape occurrences of \ and $ as needed and package the line as an "eval" shell command'''
         line = line.strip()
         if line == 'EOF' or line == 'exit' or line == 'quit':
             raise self.SessionCmdExit()

--- a/gpMgmt/bin/lib/pexpect/pxssh.py
+++ b/gpMgmt/bin/lib/pexpect/pxssh.py
@@ -102,12 +102,12 @@ class pxssh (spawn):
         #prompt command different than the regex.
 
         # used to match the command-line prompt
-        self.UNIQUE_PROMPT = "\[PEXPECT\][\$\#] "
+        self.UNIQUE_PROMPT = r"\[PEXPECT\][\$\#] "
         self.PROMPT = self.UNIQUE_PROMPT
 
         # used to set shell command-line prompt to UNIQUE_PROMPT.
-        self.PROMPT_SET_SH = "PS1='[PEXPECT]\$ '"
-        self.PROMPT_SET_CSH = "set prompt='[PEXPECT]\$ '"
+        self.PROMPT_SET_SH = r"PS1='[PEXPECT]\$ '"
+        self.PROMPT_SET_CSH = r"set prompt='[PEXPECT]\$ '"
         self.SSH_OPTS = ("-o'RSAAuthentication=no'"
                 + " -o 'PubkeyAuthentication=no'")
 # Disabling host key checking, makes you vulnerable to MITM attacks.

--- a/gpMgmt/sbin/seg_update_pg_hba.py
+++ b/gpMgmt/sbin/seg_update_pg_hba.py
@@ -38,7 +38,7 @@ def validate_args(options):
 
 def lineToCanonical(s):
     s = s.strip()
-    s = re.sub("\s+", " ", s) # reduce whitespace runs to single space
+    s = re.sub(r"\s+", " ", s) # reduce whitespace runs to single space
     return s
 
 def read_from_hba_file_and_get_empty_tempfile(hba_filename):

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -76,7 +76,7 @@ def impl(context, recovery_types, contents):
     for index, seg_to_display in enumerate(segments_to_display):
         hostname = seg_to_display.getSegmentHostName()
         port = seg_to_display.getSegmentPort()
-        expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\%".format(hostname, port,
+        expected_msg = "{}[ \t]+{}[ \t]+{}[ \t]+[0-9]+[ \t]+[0-9]+[ \t]+[0-9]+\\%".format(hostname, port,
                                                                                          recovery_types[index])
         check_stdout_msg(context, expected_msg)
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -680,7 +680,7 @@ def impl(context, process_name):
 def impl(context):
     # We keep trying to find the gpcreateseg process using ps,grep
     # and when we find it, we want to kill it only after the trap for ERROR_EXIT is setup (hence the sleep 1)
-    command = """timeout 10m
+    command = r"""timeout 10m
     bash -c "while sleep 0.1;
     do if ps ux | grep [g]pcreateseg ;
     then sleep 1 && ps ux | grep [g]pcreateseg |awk '{print \$2}' | xargs kill ;
@@ -905,7 +905,7 @@ def impl(context, command, num):
     matches = lines_matching_both(context.stdout_message, workerPool_out, command)
 
     for matched_line in matches:
-        iw_re = re.search('initialized with (\d+) workers', matched_line)
+        iw_re = re.search(r'initialized with (\d+) workers', matched_line)
         init_workers = int(iw_re.group(1))
         if init_workers > int(num):
             raise Exception("Expected Workerpool for %s to be initialized with %d workers. Found %d. \n %s"
@@ -2004,7 +2004,7 @@ def impl(context, filename, some, output):
         valuesShouldExist = False
     else:
         raise Exception("only 'some' and 'no' are valid inputs")
-    regexStr = "%s%s" % ("^[\s]*", output)
+    regexStr = "%s%s" % (r"^[\s]*", output)
     pat = re.compile(regexStr)
     file_path = os.path.join(coordinator_data_dir, filename)
     with open(file_path) as fr:
@@ -2220,7 +2220,7 @@ def imp(context):
 
 @then('validate and run gpcheckcat repair')
 def impl(context):
-    context.execute_steps('''
+    context.execute_steps(r'''
         Then gpcheckcat should print "repair script\(s\) generated in dir gpcheckcat.repair.*" to stdout
         Then the path "gpcheckcat.repair.*" is found in cwd "1" times
         Then run all the repair scripts in the dir "gpcheckcat.repair.*"
@@ -3343,12 +3343,12 @@ def step_impl(context, options):
     elif '-Q' in options:
         for stdout_line in context.stdout_message.split('\n'):
             if 'up segments, from configuration table' in stdout_line:
-                segments_up = int(re.match(".*of up segments, from configuration table\s+=\s+([0-9]+)", stdout_line).group(1))
+                segments_up = int(re.match(r".*of up segments, from configuration table\s+=\s+([0-9]+)", stdout_line).group(1))
                 if segments_up <= 1:
                     raise Exception("gpstate -Q output does not match expectations of more than one segment up")
 
             if 'down segments, from configuration table' in stdout_line:
-                segments_down = int(re.match(".*of down segments, from configuration table\s+=\s+([0-9]+)", stdout_line).group(1))
+                segments_down = int(re.match(r".*of down segments, from configuration table\s+=\s+([0-9]+)", stdout_line).group(1))
                 if segments_down != 0:
                     raise Exception("gpstate -Q output does not match expectations of all segments up")
                 break ## down segments comes after up segments, so we can break here
@@ -3846,7 +3846,7 @@ def check_locales(database_locales, locale_names, expected):
             raise Exception("Expected %s to be %s, but it was %s" % (name, expected, locale))
 
 def get_en_utf_locale():
-    cmd = Command(name='Get installed US UTF locale', cmdStr='locale -a | grep -i "en[_-]..\.utf.*8" | head -1')
+    cmd = Command(name='Get installed US UTF locale', cmdStr=r'locale -a | grep -i "en[_-]..\.utf.*8" | head -1')
     cmd.run(validateAfter=True)
     locale = cmd.get_stdout()
     if locale == "":
@@ -3977,7 +3977,7 @@ def impl(context):
 
      # Update hostfile location
      cmd = Command(name='update master hostname in config file',
-                   cmdStr= "sed 's/MACHINE_LIST_FILE=.*/MACHINE_LIST_FILE=\/tmp\/hostfile--1/g' -i /tmp/clusterConfigFile-1")
+                   cmdStr= r"sed 's/MACHINE_LIST_FILE=.*/MACHINE_LIST_FILE=\/tmp\/hostfile--1/g' -i /tmp/clusterConfigFile-1")
      cmd.run(validateAfter=True)
 
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/replication_slots_utils.py
@@ -28,7 +28,7 @@ def create_cluster(context, with_mirrors=True):
     cd ../gpAux/gpdemo; \
         export DEMO_PORT_BASE={port_base} && \
         export NUM_PRIMARY_MIRROR_PAIRS={num_primary_mirror_pairs} && \
-        export WITH_MIRRORS={with_mirrors} && \A
+        export WITH_MIRRORS={with_mirrors} && \\A
         ./demo_cluster.sh -d && ./demo_cluster.sh -c && \
         ./demo_cluster.sh
     """.format(port_base=os.getenv('PORT_BASE', 15432),
@@ -87,7 +87,7 @@ def step_impl(context):
 
     # NOTE that these commands are manually escaped; beware when adding dollar
     # signs or double-quotes!
-    cmd = "ps aux | grep '[p]ostgres .* %s' | awk '{print \$2}' | xargs kill -9" % datadir
+    cmd = r"ps aux | grep '[p]ostgres .* %s' | awk '{print \$2}' | xargs kill -9" % datadir
     cmd = 'ssh %s "%s"' % (host, cmd)
     run_command(context, cmd)
 

--- a/gpMgmt/test/behave_utils/utils.py
+++ b/gpMgmt/test/behave_utils/utils.py
@@ -679,7 +679,7 @@ def modify_sql_file(file, hostport):
     if os.path.isfile(file):
         for line in fileinput.FileInput(file, inplace=1):
             if line.find("gpfdist") >= 0:
-                line = re.sub('(\d+)\.(\d+)\.(\d+)\.(\d+)\:(\d+)', hostport, line)
+                line = re.sub(r'(\d+)\.(\d+)\.(\d+)\.(\d+)\:(\d+)', hostport, line)
             print(str(re.sub('\n', '', line)))
 
 


### PR DESCRIPTION
Python 3.12 promoted "invalid escape sequence" from a DeprecationWarning (hidden by default) to a SyntaxWarning that is printed whenever the module is compiled. On distributions shipping Python 3.12 or newer -- Rocky Linux 10, Fedora 40+, Ubuntu 24.10+ -- the management utilities therefore print warnings before doing any work:

  /usr/local/cloudberry-db/lib/python/gppylib/util/ssh_utils.py:268:
    SyntaxWarning: invalid escape sequence '\ '
  /usr/local/cloudberry-db/bin/lib/pexpect/pxssh.py:105:
    SyntaxWarning: invalid escape sequence '\['
  /usr/local/cloudberry-db/bin/lib/pexpect/pxssh.py:109:
    SyntaxWarning: invalid escape sequence '\$'
  /usr/local/cloudberry-db/bin/lib/pexpect/pxssh.py:110:
    SyntaxWarning: invalid escape sequence '\$'

The four above come from gpsync/gpssh/gpssh-exkeys and are the ones users see; compiling everything under gpMgmt/ turns up 41 such literals in 16 files.  Nothing misbehaves today -- CPython leaves an unrecognised escape in the string as-is, which happens to be what a regex or a shell snippet wants -- but the warnings are noise on stderr, and the Python docs say these sequences will become a SyntaxError in a future release.

Fix the literals rather than silencing the warning:

  * a literal whose every backslash escape is invalid gets an r prefix
  * a literal that mixes valid and invalid escapes has the invalid backslash doubled instead, since r would also change the meaning of the valid ones

Both transformations leave the literal's runtime value byte-for-byte identical, which was verified mechanically: for each touched file the ordered list of str/bytes constants in the AST is unchanged against the parent commit, and compiling the file under -W error::SyntaxWarning is now clean.

Two of the rewrites are worth a reviewer's eye:

  * gpstate_utils.py:79 and replication_slots_utils.py:31 are the mixed-escape case, so they read '\\%' and '\\A' now.
  * the '\A' in replication_slots_utils.py looks like a stray keystroke in a run of shell line continuations -- the shell it is handed sees "&& A ./demo_cluster.sh" and tries to run A.  That is pre-existing behaviour, so this commit preserves it exactly rather than quietly changing what the behave step does; it wants a separate fix.

gpMgmt/bin/lib/pexpect is a vendored copy of pexpect 3.3; upstream pexpect made these same literals raw long ago.

27 more files under src/ and contrib/ (mostly gporca and try_convert developer scripts) have the same problem and are left for a follow-up.

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
