### PR TITLE
Enhancement: add gp_matviews, a schema-qualified view over gp_matview_aux

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -165,6 +165,21 @@ CREATE VIEW pg_matviews AS
          LEFT JOIN pg_tablespace T ON (T.oid = C.reltablespace)
     WHERE C.relkind = 'm';
 
+CREATE VIEW gp_matviews AS
+    SELECT
+        A.mvoid,
+        N.nspname AS mvschema,
+        C.relname AS mvname,
+        A.has_foreign,
+        A.datastatus
+    FROM gp_matview_aux A
+         JOIN pg_class C ON (C.oid = A.mvoid)
+         LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace);
+
+COMMENT ON VIEW gp_matviews IS 'Schema-qualified view of gp_matview_aux, resolving mvname live from pg_class/pg_namespace instead of a stored copy. Prefer this over gp_matview_aux.mvname, which is not schema-qualified (see https://github.com/apache/cloudberry/issues/726).';
+
+COMMENT ON COLUMN gp_matview_aux.mvname IS 'Deprecated: bare, non-schema-qualified materialized view name, retained for backward compatibility only. Two materialized views with the same name in different schemas are indistinguishable via this column. Use gp_matviews.mvname (with gp_matviews.mvschema) instead. See https://github.com/apache/cloudberry/issues/726.';
+
 CREATE VIEW pg_dynamic_tables AS
     SELECT
         N.nspname AS schemaname,

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -60,6 +60,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302606111
+#define CATALOG_VERSION_NO	302609031
 
 #endif

--- a/src/test/regress/expected/matview_data.out
+++ b/src/test/regress/expected/matview_data.out
@@ -2826,6 +2826,72 @@ select mvname, datastatus from gp_matview_aux where mvname = 'mv_par_normal_oid'
  mv_par_normal_oid | i
 (1 row)
 
+-- Test https://github.com/apache/cloudberry/issues/726: gp_matview_aux.mvname
+-- is not schema-qualified, so two materialized views with the same bare name
+-- in different schemas are indistinguishable through it. gp_matviews (added
+-- above) resolves the name live from pg_class/pg_namespace instead, so it
+-- distinguishes them correctly; mvname itself is unchanged (kept, deprecated,
+-- for backward compatibility -- see the COMMENT ON in system_views.sql).
+--
+create schema mv_schema_test_s1;
+create schema mv_schema_test_s2;
+create table mv_schema_test_s1.t0(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table mv_schema_test_s2.t0(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mv_schema_test_s1.t0 values (1), (2);
+insert into mv_schema_test_s2.t0 values (10), (20), (30);
+create materialized view mv_schema_test_s1.mv0 as select * from mv_schema_test_s1.t0;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view mv_schema_test_s2.mv0 as select * from mv_schema_test_s2.t0;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Apache Cloudberry data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- gp_matview_aux.mvname alone cannot tell these two mv0's apart (both rows
+-- show mvname = 'mv0' with no schema information) -- this is the deprecated,
+-- pre-existing behavior, kept for backward compatibility, not the fix.
+select mvname, datastatus from gp_matview_aux where mvname = 'mv0' order by mvoid;
+ mvname | datastatus 
+--------+------------
+ mv0    | u
+ mv0    | u
+(2 rows)
+
+-- gp_matviews distinguishes them via mvschema.
+select mvschema, mvname, has_foreign, datastatus from gp_matviews
+  where mvschema in ('mv_schema_test_s1', 'mv_schema_test_s2') and mvname = 'mv0'
+  order by mvschema;
+     mvschema      | mvname | has_foreign | datastatus 
+-------------------+--------+-------------+------------
+ mv_schema_test_s1 | mv0    | f           | u
+ mv_schema_test_s2 | mv0    | f           | u
+(2 rows)
+
+-- rename in one schema; the other schema's mv0 must be unaffected and
+-- gp_matviews must reflect the new name immediately (it's resolved live,
+-- not synced).
+alter materialized view mv_schema_test_s1.mv0 rename to mv0_renamed;
+select mvschema, mvname, has_foreign, datastatus from gp_matviews
+  where mvschema in ('mv_schema_test_s1', 'mv_schema_test_s2')
+    and mvname in ('mv0', 'mv0_renamed')
+  order by mvschema;
+     mvschema      |   mvname    | has_foreign | datastatus 
+-------------------+-------------+-------------+------------
+ mv_schema_test_s1 | mv0_renamed | f           | u
+ mv_schema_test_s2 | mv0         | f           | u
+(2 rows)
+
+drop schema mv_schema_test_s1 cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table mv_schema_test_s1.t0
+drop cascades to materialized view mv_schema_test_s1.mv0_renamed
+drop schema mv_schema_test_s2 cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table mv_schema_test_s2.t0
+drop cascades to materialized view mv_schema_test_s2.mv0
+
 --start_ignore
 drop schema matview_data_schema cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/matview_data.out
+++ b/src/test/regress/expected/matview_data.out
@@ -2826,6 +2826,7 @@ select mvname, datastatus from gp_matview_aux where mvname = 'mv_par_normal_oid'
  mv_par_normal_oid | i
 (1 row)
 
+--
 -- Test https://github.com/apache/cloudberry/issues/726: gp_matview_aux.mvname
 -- is not schema-qualified, so two materialized views with the same bare name
 -- in different schemas are indistinguishable through it. gp_matviews (added
@@ -2891,7 +2892,6 @@ drop schema mv_schema_test_s2 cascade;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table mv_schema_test_s2.t0
 drop cascades to materialized view mv_schema_test_s2.mv0
-
 --start_ignore
 drop schema matview_data_schema cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/sql/matview_data.sql
+++ b/src/test/regress/sql/matview_data.sql
@@ -1177,6 +1177,41 @@ select mvname, datastatus from gp_matview_aux where mvname = 'mv_par_normal_oid'
 insert into par_normal_oid values(1, 2);
 select mvname, datastatus from gp_matview_aux where mvname = 'mv_par_normal_oid';
 
+--
+-- Test https://github.com/apache/cloudberry/issues/726: gp_matview_aux.mvname
+-- is not schema-qualified, so two materialized views with the same bare name
+-- in different schemas are indistinguishable through it. gp_matviews (added
+-- above) resolves the name live from pg_class/pg_namespace instead, so it
+-- distinguishes them correctly; mvname itself is unchanged (kept, deprecated,
+-- for backward compatibility -- see the COMMENT ON in system_views.sql).
+--
+create schema mv_schema_test_s1;
+create schema mv_schema_test_s2;
+create table mv_schema_test_s1.t0(a int);
+create table mv_schema_test_s2.t0(a int);
+insert into mv_schema_test_s1.t0 values (1), (2);
+insert into mv_schema_test_s2.t0 values (10), (20), (30);
+create materialized view mv_schema_test_s1.mv0 as select * from mv_schema_test_s1.t0;
+create materialized view mv_schema_test_s2.mv0 as select * from mv_schema_test_s2.t0;
+-- gp_matview_aux.mvname alone cannot tell these two mv0's apart (both rows
+-- show mvname = 'mv0' with no schema information) -- this is the deprecated,
+-- pre-existing behavior, kept for backward compatibility, not the fix.
+select mvname, datastatus from gp_matview_aux where mvname = 'mv0' order by mvoid;
+-- gp_matviews distinguishes them via mvschema.
+select mvschema, mvname, has_foreign, datastatus from gp_matviews
+  where mvschema in ('mv_schema_test_s1', 'mv_schema_test_s2') and mvname = 'mv0'
+  order by mvschema;
+-- rename in one schema; the other schema's mv0 must be unaffected and
+-- gp_matviews must reflect the new name immediately (it's resolved live,
+-- not synced).
+alter materialized view mv_schema_test_s1.mv0 rename to mv0_renamed;
+select mvschema, mvname, has_foreign, datastatus from gp_matviews
+  where mvschema in ('mv_schema_test_s1', 'mv_schema_test_s2')
+    and mvname in ('mv0', 'mv0_renamed')
+  order by mvschema;
+drop schema mv_schema_test_s1 cascade;
+drop schema mv_schema_test_s2 cascade;
+
 --start_ignore
 drop schema matview_data_schema cascade;
 --end_ignore


### PR DESCRIPTION
Fixes #726

### What does this PR do?
`gp_matview_aux.mvname` is populated from a bare, non-schema-qualified
relation name (`InsertMatviewAuxEntry()`, `gp_matview_aux.c`), so two
materialized views sharing a name in different schemas produce identical,
indistinguishable `mvname` values.

This PR adds `gp_matviews`, modeled on `pg_matviews`, which live-joins
`gp_matview_aux` → `pg_class` → `pg_namespace` for an always-correct
schema-qualified name (`mvschema`/`mvname`). `gp_matview_aux.mvname` is
left completely unchanged — still populated, still synced on rename via
the existing `mvaux_rename()` — and marked deprecated via `COMMENT ON
COLUMN`, pointing callers at the new view. This is purely additive: no
column removed, no existing behavior changed.

I considered (and rejected) two alternatives:
- **Prefix schema into the existing `mvname` column** (the maintainer's
  literal suggestion on the introducing PR, #720) — `mvname` is
  `NameData` (63 usable bytes); a schema prefix could silently truncate
  or re-collide for long identifiers.
- **Add a new stored, synced `mvschema` column** instead of a view — I
  verified (`grep`) that no code anywhere syncs a matview's schema on
  `ALTER ... SET SCHEMA` today, since `mvname` never tracked schema. A
  new synced column would need that sync code added from scratch, and if
  ever missed, would reproduce the exact staleness bug this issue is
  about. A live-resolved view can't go stale by construction.

Root cause: `namestrcpy(&mvname, get_rel_name(mvoid))` at
`gp_matview_aux.c:253` never schema-qualifies. Introduced in #720
(merged 2024-12-02); flagged same-day in that PR's own review by
@yjhnupt, with @yjhjstz suggesting the schema-prefix approach above —
the follow-up sat unactioned for ~20 months.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Test Plan
- [x] Unit tests added/updated — new self-contained schema-collision
      test in `matview_data.sql` (create `mv0` in two schemas, confirm
      `gp_matview_aux.mvname` can't distinguish them but
      `gp_matviews.mvschema` can; confirm `ALTER ... RENAME` resolves
      live)
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

Neither `make installcheck` command was run as literally stated — see
Additional Context for what was actually run and why.

### Impact
**Performance:** None — purely additive, no existing code path changed.

**User-facing changes:** New `gp_matviews` view available;
`gp_matview_aux.mvname` now documented (via `COMMENT ON COLUMN`) as
deprecated, but unchanged in behavior.

**Dependencies:** None.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [x] Reviewed code for security implications
- [x] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context

**AI disclosure:** this change was drafted end-to-end by Claude Code
under my direction — design (including a design pivot from an initial
breaking-change approach after I asked about it), implementation, and
this PR description. I reviewed the diff and the live-cluster evidence
below before submitting; I'm accountable for what's in this PR.

**What was actually run, honestly:**
- `mvn apache-rat:check` — passed clean (0 unapproved).
- Built from source and validated against a real, live 6-segment
  `gpdemo` cluster via a Docker-based local toolchain, not the official
  CI matrix. Confirmed live: the #726 scenario (`gp_matview_aux.mvname`
  can't distinguish two same-named matviews in different schemas;
  `gp_matviews.mvschema` can), `ALTER ... RENAME` resolves live, the new
  `COMMENT ON` deprecation notices are queryable
  (`col_description()`/`obj_description()`), catalog version bootstraps
  cleanly, `-Werror` compiles clean.
- `matview_data.sql` was piped through `psql` directly against the live
  cluster (not `pg_regress`/`make installcheck` — not wired up for this
  ad hoc cluster) and the new test's expected output spliced into
  `matview_data.out` at its exact insertion point — confirmed via diff
  against the pristine upstream file that this is a pure addition (0
  deletions).
- `misc_sanity.sql` diffed byte-identical against its checked-in
  expected output.
- This design doesn't touch `aqumv.sql`, `pax_storage`, or
  `singlenode_regress` at all (only the now-superseded removal design
  needed to) — nothing to test there.
