### PR TITLE
Fix diskquota build on CMake 3.16

### DIFF
--- a/gpcontrib/diskquota/CMakeLists.txt
+++ b/gpcontrib/diskquota/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
-# cmake_path requires 3.20
+cmake_minimum_required(VERSION 3.16)
 
 project(diskquota)
 
@@ -90,6 +89,9 @@ TARGET_LINK_LIBRARIES(diskquota ${PG_LIB_DIR}/libpq.so)
 # packing part, move to a separate file if this part is too large
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Distro.cmake)
 
+# NOTE: file(ARCHIVE_EXTRACT) below requires CMake 3.18. This branch is only
+# taken when DISKQUOTA_LAST_RELEASE_PATH is set explicitly, which the in-tree
+# build never does, so it does not affect the 3.16 minimum declared above.
 if(DEFINED DISKQUOTA_LAST_RELEASE_PATH)
   message(STATUS "Copy pervious installer from ${DISKQUOTA_LAST_RELEASE_PATH}")
   file(ARCHIVE_EXTRACT INPUT ${DISKQUOTA_LAST_RELEASE_PATH} PATTERNS "*.so")

--- a/gpcontrib/diskquota/cmake/Regress.cmake
+++ b/gpcontrib/diskquota/cmake/Regress.cmake
@@ -40,8 +40,11 @@
 #    SQL_DIR sql
 #    EXPECTED_DIR expected_${GP_MAJOR_VERSION})
 
-# CMAKE_CURRENT_FUNCTION_LIST_DIR - 3.17
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
+
+# Directory holding this module, captured at include() time. Used instead of
+# CMAKE_CURRENT_FUNCTION_LIST_DIR, which requires CMake 3.17.
+set(REGRESS_CMAKE_LIST_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # pg_isolation2_regress was not shipped with GPDB release. It needs to be created from source.
 function(_PGIsolation2Target_Add working_DIR)
@@ -203,7 +206,7 @@ function(RegressTarget_Add name)
         ${regress_BIN}  ${regress_opts_arg}  ${regress_arg})
     if (arg_RUN_TIMES)
         set(test_command
-            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/regress_loop.sh
+            ${REGRESS_CMAKE_LIST_DIR}/regress_loop.sh
             ${arg_RUN_TIMES}
             ${regress_command})
     else()
@@ -222,7 +225,7 @@ function(RegressTarget_Add name)
         COMMAND
         ${test_command}
         ||
-        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/regress_show_diff.sh ${working_DIR}
+        ${REGRESS_CMAKE_LIST_DIR}/regress_show_diff.sh ${working_DIR}
     )
 
     if(arg_REGRESS_TYPE STREQUAL isolation2)


### PR DESCRIPTION
### What does this PR do?

`gpcontrib/diskquota` is the only component in the tree that requires a CMake newer than 3.16, so `--with-diskquota` fails to build on distros whose default CMake is older. On Ubuntu 20.04 (CMake 3.16.3):

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.20 or higher is required.  You are running version 3.16.3
make[2]: *** [Makefile:53: build] Error 1
make[1]: *** [Makefile:52: all-diskquota-recurse] Error 2
```

Every other first-party `CMakeLists.txt` in the tree already declares 3.12 or lower (pax_storage, udp2 and interconnect at 3.11; gpfdist at 3.12), so lowering diskquota's two declarations to 3.16 brings it in line with the rest without raising the bar anywhere else.

Neither declaration needed to be as high as it was:

- **`CMakeLists.txt`: 3.20 → 3.16.** The comment claimed the minimum was driven by `cmake_path`, but `cmake_path` is not called anywhere in the diskquota tree. The comment was stale and is removed.

- **`cmake/Regress.cmake`: 3.17 → 3.16.** The 3.17 requirement came from `CMAKE_CURRENT_FUNCTION_LIST_DIR`, used in two places to locate `regress_loop.sh` and `regress_show_diff.sh`. It is replaced with `REGRESS_CMAKE_LIST_DIR`, captured from `CMAKE_CURRENT_LIST_DIR` at module-include time — same directory, available in every supported CMake.

  Worth calling out for reviewers: **lowering the version number alone would not have been enough.** On 3.16 `CMAKE_CURRENT_FUNCTION_LIST_DIR` expands to an empty string *without* raising an error, so the extension would still configure and compile while the `installcheck` and diff targets silently invoked `/regress_loop.sh` and `/regress_show_diff.sh`.

One optional code path, guarded by `if(DEFINED DISKQUOTA_LAST_RELEASE_PATH)`, calls `file(ARCHIVE_EXTRACT)` and so still needs CMake 3.18. The in-tree build never sets that variable, so it does not affect the declared minimum; a comment now records the requirement so it is not lost.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Test Plan

- Full `make -j$(nproc)` with `--with-diskquota` on **Ubuntu 20.04 / CMake 3.16.3**, which previously failed at the diskquota CMake configure step and now completes.
- `cmake/Regress.cmake` verified to parse under CMake 4.3.3, with `REGRESS_CMAKE_LIST_DIR` asserted to resolve to the directory that actually contains `regress_loop.sh` and `regress_show_diff.sh`.

Not yet run, and worth a reviewer's attention:

- [ ] Passed `make installcheck` — the `REGRESS_CMAKE_LIST_DIR` substitution changes how the diskquota regress targets are constructed, so `make -C gpcontrib/diskquota installcheck` on a supported platform (Ubuntu 22.04 / Rocky 9) is the check that matters most here.
- [ ] Passed `make -C src/test installcheck-cbdb-parallel` — unaffected by this change.

### Impact

**Performance:** none.

**User-facing changes:** none at runtime. Build-side only: `--with-diskquota` now works with CMake 3.16 and newer instead of 3.20 and newer.

**Dependencies:** lowers a build-time dependency; adds nothing. Note that Ubuntu 20.04 is not among the platforms in `devops/deploy/docker/build/` (rocky8/9/10, ubuntu22.04, ubuntu24.04), so this widens the range of hosts diskquota can be built on rather than adding a supported platform.

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [x] Reviewed code for security implications
- [x] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context

The same two files are byte-identical on `REL_2_STABLE`, so this commit cherry-picks cleanly there; that will be handled separately.

While surveying the tree I also found `src/backend/gporca/CMakeLists.txt` (`VERSION 3.1 FATAL_ERROR`) and `src/tools/make_cmakelists` (emits `VERSION 2.4`) declare minimums below 3.5, which CMake 4.x rejects outright. Neither is invoked by the normal build — GPORCA is built through the PostgreSQL makefiles — so it is latent rather than breaking, and is left out of this PR.
