### PR TITLE
Fix CMP0153 warnings from diskquota's pg_config probing

### DIFF
--- a/gpcontrib/diskquota/cmake/Gpdb.cmake
+++ b/gpcontrib/diskquota/cmake/Gpdb.cmake
@@ -27,17 +27,31 @@ if(PG_CONFIG)
 else()
     message(FATAL_ERROR "Unable to find 'pg_config'")
 endif()
-exec_program(${PG_CONFIG} ARGS --includedir OUTPUT_VARIABLE PG_INCLUDE_DIR)
-exec_program(${PG_CONFIG} ARGS --includedir-server OUTPUT_VARIABLE PG_INCLUDE_DIR_SERVER)
-exec_program(${PG_CONFIG} ARGS --pkglibdir OUTPUT_VARIABLE PG_PKG_LIB_DIR)
-exec_program(${PG_CONFIG} ARGS --sharedir OUTPUT_VARIABLE PG_SHARE_DIR)
-exec_program(${PG_CONFIG} ARGS --bindir OUTPUT_VARIABLE PG_BIN_DIR)
-exec_program(${PG_CONFIG} ARGS --cppflags OUTPUT_VARIABLE PG_CPP_FLAGS)
-exec_program(${PG_CONFIG} ARGS --cflags OUTPUT_VARIABLE PG_C_FLAGS)
-exec_program(${PG_CONFIG} ARGS --ldflags OUTPUT_VARIABLE PG_LD_FLAGS)
-exec_program(${PG_CONFIG} ARGS --libs OUTPUT_VARIABLE PG_LIBS)
-exec_program(${PG_CONFIG} ARGS --libdir OUTPUT_VARIABLE PG_LIB_DIR)
-exec_program(${PG_CONFIG} ARGS --pgxs OUTPUT_VARIABLE PG_PGXS)
+# Query one pg_config value into 'var'.
+#
+# exec_program() used to do this, but it is deprecated and CMake 3.30 and
+# newer warn about every call (CMP0153). execute_process() is the
+# replacement; it differs in that it keeps the trailing newline, so
+# OUTPUT_STRIP_TRAILING_WHITESPACE is required -- without it every path
+# below would carry a newline into include_directories() and friends.
+macro(pg_config_var var)
+    execute_process(
+        COMMAND ${PG_CONFIG} ${ARGN}
+        OUTPUT_VARIABLE ${var}
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endmacro()
+
+pg_config_var(PG_INCLUDE_DIR        --includedir)
+pg_config_var(PG_INCLUDE_DIR_SERVER --includedir-server)
+pg_config_var(PG_PKG_LIB_DIR        --pkglibdir)
+pg_config_var(PG_SHARE_DIR          --sharedir)
+pg_config_var(PG_BIN_DIR            --bindir)
+pg_config_var(PG_CPP_FLAGS          --cppflags)
+pg_config_var(PG_C_FLAGS            --cflags)
+pg_config_var(PG_LD_FLAGS           --ldflags)
+pg_config_var(PG_LIBS               --libs)
+pg_config_var(PG_LIB_DIR            --libdir)
+pg_config_var(PG_PGXS               --pgxs)
 get_filename_component(PG_HOME "${PG_BIN_DIR}/.." ABSOLUTE)
 
 # If PG_SRC_DIR is provided (in-tree build), use source tree paths


### PR DESCRIPTION
cmake/Gpdb.cmake queries pg_config through exec_program(), which is deprecated. CMake 3.30 added CMP0153 for it, so each of the eleven calls now prints a developer warning:

```
  CMake Warning (dev) at cmake/Gpdb.cmake:30 (exec_program):
    Policy CMP0153 is not set: The exec_program command should not be called.
    Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.

    Use execute_process() instead.
  Call Stack (most recent call first):
    CMakeLists.txt:15 (include)
  This warning is for project developers.  Use -Wno-dev to suppress it.
```

Route the queries through a pg_config_var() macro over execute_process(). The one behavioural difference that matters is that execute_process() keeps the trailing newline where exec_program() stripped it, so OUTPUT_STRIP_TRAILING_WHITESPACE is required; without it every path would carry a newline into include_directories() and the libpq link line.

Today the warning is only noise, since configure still succeeds. It stops being noise if the declared minimum ever reaches 3.30, because CMP0153's NEW behaviour turns exec_program() into a hard error.

Verified on CMake 3.30.5, where the warning appears: all eleven warnings go away, and the fourteen variables Gpdb.cmake derives, PG_INCLUDE_DIR through GP_VERSION, come out byte-identical before and after. diskquota still builds clean on Rocky 8 with CMake 3.26.5.

Assisted-by: Claude Code
Backpatch-through: REL_2_STABLE

<!-- Thank you for your contribution to Apache Cloudberry (Incubating)! -->

Fixes #ISSUE_Number

### What does this PR do?
<!-- Brief overview of the changes, including any major features or fixes -->

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes
<!-- Remove if not applicable. If yes, explain impact and migration path -->

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
