### PR TITLE
Fix walreciever crash with SIGABRT

### DIFF
--- a/src/interfaces/libpq/fe-auth-scram.c
+++ b/src/interfaces/libpq/fe-auth-scram.c
@@ -26,6 +26,13 @@
 #include "common/saslprep.h"
 #include "common/scram-common.h"
 #include "fe-auth.h"
+/* Cloudberry */
+#include "common/link-canary.h"
+#ifndef FRONTEND
+#include "utils/palloc.h"
+#endif
+/* Cloudberry end */
+
 
 
 /* The exported SCRAM callback mechanism. */
@@ -146,6 +153,21 @@ scram_init(PGconn *conn,
 		}
 	}
 	state->password = prep_password;
+
+	/* Cloudberry */
+	/* After additional linkage frontend code into backend, this function
+	 * may be called on the server side. `pg_saslprep` is compiled for
+	 * backend with palloc memory allocation, but original `scram_free` releases
+	 * the memory with `free` and it leads to abort of running process.
+	 * Reallocation of password right after incorrect allocation seems less
+	 * confusing than usage `free`/`pfree` based on build macro at scram_free
+	 * only for password field.
+	 */
+#ifndef FRONTEND
+	state->password = strdup(prep_password);
+	pfree(prep_password);
+#endif
+	/* Cloudberry end */
 
 	return state;
 }
@@ -908,6 +930,14 @@ pg_fe_scram_build_secret(const char *password, int iterations, const char **errs
 	pg_saslprep_rc rc;
 	char		saltbuf[SCRAM_DEFAULT_SALT_LEN];
 	char	   *result;
+
+	/* Cloudberry */
+	/* Сallers of this function is a frontend applications.
+	 * It's unexpected to call this function at the server code,
+	 * its use will lead to incorrect free of palloc'd memory
+	 */
+	Assert(pg_link_canary_is_frontend());
+	/* Cloudberry end */
 
 	/*
 	 * Normalize the password with SASLprep.  If that doesn't work, because


### PR DESCRIPTION
Freeing of palloc'd memory leads to SIGABRT of walreciever process. The patch fixes the problem

Closes #1978

### Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Test Plan
<!-- How did you test these changes? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

### Impact
<!-- Remove sections that don't apply -->
**Performance:**
<!-- Any performance implications? -->

**User-facing changes:**
<!-- Any changes visible to users? -->

**Dependencies:**
<!-- New dependencies or version changes? -->

### Checklist
- [ ] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)

### Additional Context
<!-- Any other information that would help reviewers? Remove if none -->

### CI Skip Instructions
<!--
To skip CI builds, add the appropriate CI skip identifier to your PR title.
The identifier must:
- Be in square brackets []
- Include the word "ci" and either "skip" or "no"
- Only use for documentation-only changes or when absolutely necessary
-->

---
<!-- Join our community:
- Mailing list: [dev@cloudberry.apache.org](https://lists.apache.org/list.html?dev@cloudberry.apache.org) (subscribe: dev-subscribe@cloudberry.apache.org)
- Discussions: https://github.com/apache/cloudberry/discussions -->
