### PR TITLE
Fix PAX protobuf array bounds warnings

### DIFF
--- a/contrib/pax_storage/src/cpp/storage/proto/proto_wrappers.h
+++ b/contrib/pax_storage/src/cpp/storage/proto/proto_wrappers.h
@@ -35,9 +35,19 @@
 #undef Min
 #undef Max
 #undef IsPowerOf2
+
+// GCC 14 emits false -Warray-bounds warnings in protobuf 3.19 headers.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 #include "storage/proto/micro_partition_stats.pb.h"
 #include "storage/proto/orc_proto.pb.h"
 #include "storage/proto/pax.pb.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #define FATAL 22
 #define Min(x, y) ((x) < (y) ? (x) : (y))
 #define Max(x, y) ((x) > (y) ? (x) : (y))


### PR DESCRIPTION
Fixes #1677

### What does this PR do?
GCC 14 emits false `-Warray-bounds` warnings in protobuf 3.19 headers when compiling PAX.

Wrap the protobuf includes in `proto_wrappers.h` with GCC diagnostic push/pop directives. This suppresses the warnings within those headers and restores diagnostics afterwards.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Test Plan
Validated on Ubuntu 22.04 ARM64:

- GCC 14.3 with protobuf 3.19.6 and `-O3`: the three warnings in `micro_partition_stats.cc` and `orc_format_reader.cc` disappear, including with `-Werror=array-bounds`.
- An intentional out-of-bounds access after the includes still triggers a compiler error.
- PAX builds successfully; all 21 existing tests selected by `MicroPartitionStatsTest.*:OrcTest.*` pass.
- Header compilation passes with GCC 11 and Clang 14 under strict warnings.

Rocky Linux 10 was not tested directly

### Checklist
- [x] Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
- [ ] Added/updated documentation
- [ ] Reviewed code for security implications
- [ ] This PR contains AI-assisted code generation
- [ ] Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)
