### PR TITLE
Fix udp interconnect 2

### DIFF
--- a/contrib/interconnect/udp/ic_udpifc.c
+++ b/contrib/interconnect/udp/ic_udpifc.c
@@ -7027,8 +7027,14 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 		}
 		else if (diff < TIMER_SPAN_LOSS)
 		{
-			diff = diff < TIMER_SPAN_LOSS ? TIMER_SPAN_LOSS : diff;
+			diff = TIMER_SPAN_LOSS;
 		}
+			
+		idx = (uqr->idx + diff / TIMER_SPAN_LOSS) % UNACK_QUEUE_RING_SLOTS_NUM;
+
+#ifdef AMS_VERBOSE_LOGGING
+	write_log("PUTTW: curtime " UINT64_FORMAT " now " UINT64_FORMAT " (diff " UINT64_FORMAT ") expTime " UINT64_FORMAT " previdx %d, nowidx %d, nextidx %d", uqr->currentTime, now, diff, expTime, buf->unackQueueRingSlot, uqr->idx, idx);
+#endif
 	}
 	else
 	{
@@ -7054,12 +7060,6 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 		write_log("PUTTW: curtime " UINT64_FORMAT " now " UINT64_FORMAT " (diff " UINT64_FORMAT ") expTime " UINT64_FORMAT " previdx %d, nowidx %d, nextidx %d", uqr->currentTime, now, diff, expTime, buf->unackQueueRingSlot, uqr->idx, idx);
 #endif
 	}
-
-	idx = (uqr->idx + diff / TIMER_SPAN) % UNACK_QUEUE_RING_SLOTS_NUM;
-
-#ifdef AMS_VERBOSE_LOGGING
-	write_log("PUTTW: curtime " UINT64_FORMAT " now " UINT64_FORMAT " (diff " UINT64_FORMAT ") expTime " UINT64_FORMAT " previdx %d, nowidx %d, nextidx %d", uqr->currentTime, now, diff, expTime, buf->unackQueueRingSlot, uqr->idx, idx);
-#endif
 
 	buf->unackQueueRingSlot = idx;
 	icBufferListAppend(&unack_queue_ring.slots[idx], buf);

--- a/contrib/udp2/ic_common/udp2/ic_udp2.cpp
+++ b/contrib/udp2/ic_common/udp2/ic_udp2.cpp
@@ -3049,8 +3049,14 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 		}
 		else if (diff < TIMER_SPAN_LOSS)
 		{
-			diff = diff < TIMER_SPAN_LOSS ? TIMER_SPAN_LOSS : diff;
+			diff = TIMER_SPAN_LOSS;
 		}
+
+		idx = (uqr->idx + diff / TIMER_SPAN_LOSS) % UNACK_QUEUE_RING_SLOTS_NUM;
+
+#ifdef AMS_VERBOSE_LOGGING
+		LOG(INFO, "PUTTW: curtime %lu now %lu (diff %lu) expTime %lu previdx %d, nowidx %d, nextidx %d", uqr->currentTime, now, diff, expTime, buf->unackQueueRingSlot, uqr->idx, idx);
+#endif
 	}
 	else
 	{
@@ -3076,12 +3082,6 @@ putIntoUnackQueueRing(UnackQueueRing *uqr, ICBuffer *buf, uint64 expTime, uint64
 		LOG(INFO, "PUTTW: curtime " UINT64_FORMAT " now " UINT64_FORMAT " (diff " UINT64_FORMAT ") expTime " UINT64_FORMAT " previdx %d, nowidx %d, nextidx %d", uqr->currentTime, now, diff, expTime, buf->unackQueueRingSlot, uqr->idx, idx);
 #endif
 	}
-
-	idx = (uqr->idx + diff / TIMER_SPAN) % UNACK_QUEUE_RING_SLOTS_NUM;
-
-#ifdef AMS_VERBOSE_LOGGING
-	LOG(INFO, "PUTTW: curtime %lu now %lu (diff %lu) expTime %lu previdx %d, nowidx %d, nextidx %d", uqr->currentTime, now, diff, expTime, buf->unackQueueRingSlot, uqr->idx, idx);
-#endif
 
 	buf->unackQueueRingSlot = idx;
 	unack_queue_ring.slots[idx].append(buf);


### PR DESCRIPTION
What does this PR do?
Fix putIntoUnackQueueRing function logic for Intercontect interfaces

what
There are several logic issues in the putIntoUnackQueueRing function.
Defect : Misuse of TIMER_SPAN_LOSS (Severity: Medium)

why
For Defect  (TIMER_SPAN_LOSS misuse):

Time alignment bias: Expected 5ms boundary alignment, actual 2.5ms alignment
Imprecise retransmission timing: May cause packets to trigger retransmission too early or too late
Degraded flow control performance: Affects accuracy of timeout-based mechanisms
Subtle bug: Not immediately obvious during testing but impacts long-term stability

Overall justification:
These are not just cosmetic issues—they affect correctness (Defect 2) and code quality (all three)
Low risk fix with high confidence: changes are localized and don't alter external behavior
Follows best practices: clean code, eliminate redundancy, use correct constants

How
Perform logical fixes on the premise that existing code functionality remains intact.

Type of Change
 Bug fix (non-breaking change)
 New feature (non-breaking change)
 Breaking change (fix or feature with breaking changes)
 Documentation update
Breaking Changes
Test Plan
 Unit tests added/updated
 Integration tests added/updated
 Passed make installcheck
 Passed make -C src/test installcheck-cbdb-parallel
Impact
Performance:

User-facing changes:

Dependencies:

Checklist
 Followed [contribution guide](https://cloudberry.apache.org/contribute/code)
 Added/updated documentation
 Reviewed code for security implications
 This PR contains AI-assisted code generation
 Requested review from [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers)
Additional Context
CI Skip Instructions
